### PR TITLE
Disable JDK11 to speed up builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ scala_212: &scala_212
 scala_213: &scala_213
   SCALA_VERSION: 2.13.1
 
-scala_dotty: &scala_dotty
-  SCALA_VERSION: 0.20.0-RC1
+# scala_dotty: &scala_dotty
+#   SCALA_VERSION: 0.20.0-RC1
 
 jdk_8: &jdk_8
   JDK_VERSION: 8
 
-jdk_11: &jdk_11
-  JDK_VERSION: 11
+# jdk_11: &jdk_11
+#   JDK_VERSION: 11
 
 machine_ubuntu: &machine_ubuntu
   machine:
@@ -196,12 +196,12 @@ jobs:
       - <<: *scala_212
       - <<: *jdk_8
 
-  compile_dotty:
-    <<: *compile
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_dotty
-      - <<: *jdk_8
+  # compile_dotty:
+  #   <<: *compile
+  #   <<: *machine_ubuntu
+  #   environment:
+  #     - <<: *scala_dotty
+  #     - <<: *jdk_8
 
   mdoc:
     <<: *mdoc
@@ -224,33 +224,33 @@ jobs:
       - <<: *scala_213
       - <<: *jdk_8
 
-  test_dotty_jdk8_jvm:
-    <<: *test
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_dotty
-      - <<: *jdk_8
+  # test_dotty_jdk8_jvm:
+  #   <<: *test
+  #   <<: *machine_ubuntu
+  #   environment:
+  #     - <<: *scala_dotty
+  #     - <<: *jdk_8
 
-  test_212_jdk11_jvm:
-    <<: *test
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_212
-      - <<: *jdk_11
+  # test_212_jdk11_jvm:
+  #   <<: *test
+  #   <<: *machine_ubuntu
+  #   environment:
+  #     - <<: *scala_212
+  #     - <<: *jdk_11
 
-  test_213_jdk11_jvm:
-    <<: *test
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_213
-      - <<: *jdk_11
+  # test_213_jdk11_jvm:
+  #   <<: *test
+  #   <<: *machine_ubuntu
+  #   environment:
+  #     - <<: *scala_213
+  #     - <<: *jdk_11
 
-  test_dotty_jdk11_jvm:
-    <<: *test
-    <<: *machine_ubuntu
-    environment:
-      - <<: *scala_dotty
-      - <<: *jdk_11
+  # test_dotty_jdk11_jvm:
+  #   <<: *test
+  #   <<: *machine_ubuntu
+  #   environment:
+  #     - <<: *scala_dotty
+  #     - <<: *jdk_11
 
   # release:
   #   <<: *release
@@ -288,16 +288,16 @@ workflows:
             - lint
           filters:
             <<: *filter_tags
-      - test_212_jdk11_jvm:
-          requires:
-            - lint
-          filters:
-            <<: *filter_tags
-      - test_213_jdk11_jvm:
-          requires:
-            - lint
-          filters:
-            <<: *filter_tags
+      # - test_212_jdk11_jvm:
+      #     requires:
+      #       - lint
+      #     filters:
+      #       <<: *filter_tags
+      # - test_213_jdk11_jvm:
+      #     requires:
+      #       - lint
+      #     filters:
+      #       <<: *filter_tags
       # - release:
       #     context: Sonatype2
       #     requires:


### PR DESCRIPTION
Besides disabling JDK11, I've commented out dotty-related steps as they aren't used at the moment.