### PR TITLE
Further Work on Coherency

### DIFF
--- a/src/main/scala/zio/prelude/Associative.scala
+++ b/src/main/scala/zio/prelude/Associative.scala
@@ -1,6 +1,6 @@
 package zio.prelude
 
-import zio.prelude.coherent.AssociativeEqual
+import zio.prelude.coherent.AssociativeCoherent
 import zio.prelude.newtypes.{ And, First, Last, Max, Min, Or, Prod, Sum }
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
@@ -12,7 +12,7 @@ import zio.test.laws.{ Lawful, Laws }
  */
 trait Associative[A] extends Closure[A]
 
-object Associative extends Lawful[Associative with Equal] with AssociativeEqual {
+object Associative extends Lawful[Associative with Equal] with AssociativeCoherent {
 
   /**
    * The associativity law states that for some binary operator `*`, for all

--- a/src/main/scala/zio/prelude/Closure.scala
+++ b/src/main/scala/zio/prelude/Closure.scala
@@ -1,6 +1,6 @@
 package zio.prelude
 
-import zio.prelude.coherent.ClosureEqual
+import zio.prelude.coherent.ClosureCoherent
 import zio.prelude.newtypes.{ And, Or, Prod, Sum }
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
@@ -9,7 +9,7 @@ trait Closure[A] {
   def combine(l: => A, r: => A): A
 }
 
-object Closure extends Lawful[Closure] with ClosureEqual {
+object Closure extends Lawful[Closure] with ClosureCoherent {
 
   final val closureLaw = new Laws.Law2[Closure]("closureLaw") {
     def apply[A: Closure](a1: A, a2: A): TestResult =

--- a/src/main/scala/zio/prelude/Commutative.scala
+++ b/src/main/scala/zio/prelude/Commutative.scala
@@ -1,6 +1,6 @@
 package zio.prelude
 
-import zio.prelude.coherent.CommutativeEqual
+import zio.prelude.coherent.CommutativeCoherent
 import zio.prelude.newtypes.{ And, Or, Prod, Sum }
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
@@ -10,7 +10,7 @@ trait Commutative[A] extends Closure[A] {
   final def commute: Commutative[A] = Commutative((l, r) => self.combine(r, l))
 }
 
-object Commutative extends Lawful[Commutative with Equal] with CommutativeEqual {
+object Commutative extends Lawful[Commutative with Equal] with CommutativeCoherent {
 
   final val commutativeLaw = new Laws.Law2[Commutative with Equal]("commutativeLaw") {
     def apply[A](a1: A, a2: A)(implicit c: Commutative[A] with Equal[A]): TestResult =

--- a/src/main/scala/zio/prelude/Hash.scala
+++ b/src/main/scala/zio/prelude/Hash.scala
@@ -2,7 +2,7 @@ package zio.prelude
 
 import scala.annotation.implicitNotFound
 
-import zio.prelude.coherent.HashOrd
+import zio.prelude.coherent.HashCoherent
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
 
@@ -83,7 +83,7 @@ trait Hash[-A] extends Equal[A] { self =>
     )
 }
 
-object Hash extends Lawful[Hash] with HashOrd {
+object Hash extends Lawful[Hash] with HashCoherent {
 
   /**
    * For all values `a1` and `a2`, if `a1` is equal to `a2` then the hash of

--- a/src/main/scala/zio/prelude/Identity.scala
+++ b/src/main/scala/zio/prelude/Identity.scala
@@ -1,6 +1,6 @@
 package zio.prelude
 
-import zio.prelude.coherent.IdentityEqual
+import zio.prelude.coherent.IdentityCoherent
 import zio.prelude.newtypes.{ And, Or, Prod, Sum }
 import zio.test.laws.Lawful
 
@@ -12,7 +12,7 @@ trait Identity[A] extends LeftIdentity[A] with RightIdentity[A] {
   override final def rightIdentity: A = identity
 }
 
-object Identity extends Lawful[Identity with Equal] with IdentityEqual {
+object Identity extends Lawful[Identity with Equal] with IdentityCoherent {
 
   final val laws = LeftIdentity.laws + RightIdentity.laws
 

--- a/src/main/scala/zio/prelude/coherent/AssociativeCoherent.scala
+++ b/src/main/scala/zio/prelude/coherent/AssociativeCoherent.scala
@@ -2,7 +2,7 @@ package zio.prelude.coherent
 
 import zio.prelude._
 
-trait AssociativeEqual {
+trait AssociativeCoherent {
 
   /**
    * Derives a `Associative[A] with Equal[A]` given a Associative[A]` and an `Equal[A]`.

--- a/src/main/scala/zio/prelude/coherent/ClosureCoherent.scala
+++ b/src/main/scala/zio/prelude/coherent/ClosureCoherent.scala
@@ -2,7 +2,7 @@ package zio.prelude.coherent
 
 import zio.prelude._
 
-trait ClosureEqual {
+trait ClosureCoherent {
 
   /**
    * Derives a `Closure[A] with Equal[A]` given a closure[A]` and an `Equal[A]`.

--- a/src/main/scala/zio/prelude/coherent/CommutativeEqual.scala
+++ b/src/main/scala/zio/prelude/coherent/CommutativeEqual.scala
@@ -2,7 +2,27 @@ package zio.prelude.coherent
 
 import zio.prelude._
 
-trait CommutativeEqual {
+trait CommutativeCoherent extends CommutativeCoherentLowPriority {
+
+  /**
+   * Derives a `Commutative[A] with Equal[A]` given a `Commutative[A]` and an `Equal[A]`.
+   */
+  implicit def associativeCommutativeEqual[A](
+    implicit associative0: Associative[A],
+    commutative0: Commutative[A],
+    equal0: Equal[A]
+  ): Associative[A] with Commutative[A] with Equal[A] =
+    new Associative[A] with Commutative[A] with Equal[A] {
+
+      val _ = associative0
+
+      override def combine(l: => A, r: => A): A = commutative0.combine(l, r)
+
+      override protected def checkEqual(l: A, r: A): Boolean = equal0.equal(l, r)
+    }
+}
+
+trait CommutativeCoherentLowPriority {
 
   /**
    * Derives a `Commutative[A] with Equal[A]` given a `Commutative[A]` and an `Equal[A]`.

--- a/src/main/scala/zio/prelude/coherent/HashCoherent.scala
+++ b/src/main/scala/zio/prelude/coherent/HashCoherent.scala
@@ -2,7 +2,7 @@ package zio.prelude.coherent
 
 import zio.prelude._
 
-trait HashOrd {
+trait HashCoherent {
 
   /**
    * Derive a `Hash[A] with Ord[A]` given a `Hash[A]` and an `Ord[A]`.

--- a/src/main/scala/zio/prelude/coherent/IdentityCoherent.scala
+++ b/src/main/scala/zio/prelude/coherent/IdentityCoherent.scala
@@ -2,7 +2,7 @@ package zio.prelude.coherent
 
 import zio.prelude._
 
-trait IdentityEqual {
+trait IdentityCoherent {
 
   /**
    * Derives a `Identity[A] with Equal[A]` given a `Identity[A]` and an `Equal[A]`.

--- a/src/test/scala/zio/prelude/coherent/CoherentSpec.scala
+++ b/src/test/scala/zio/prelude/coherent/CoherentSpec.scala
@@ -37,6 +37,12 @@ object CoherentSpec extends DefaultRunnableSpec {
 
       assert(instance.combine(Sum(1), Sum(5)))(equalTo(Sum(6))) &&
       assert(instance.equal(Sum(5), Sum(5)))(isTrue)
+    },
+    test("AssociativeCommutativeEqual") {
+      val instance = implicitly[Associative[Sum[Int]] with Commutative[Sum[Int]] with Equal[Sum[Int]]]
+
+      assert(instance.combine(Sum(1), Sum(5)))(equalTo(Sum(6))) &&
+      assert(instance.equal(Sum(5), Sum(5)))(isTrue)
     }
   )
 }


### PR DESCRIPTION
Further work on coherent type classes. Moves to a structure where each companion object extends a respective `Coherent` trait that contains coherent instances for that type class. Extending low priority traits is used to prioritize more powerful instances over less powerful ones. This is still just a start but shows how we can have everything working with the existing second two element intersections and an overlapping three element intersection. The actual changes are not large but impact a bunch of files so would suggest we merge and then can build on it.