### PR TITLE
Add Documentation for Newtypes

### DIFF
--- a/src/main/scala/zio/prelude/Newtype.scala
+++ b/src/main/scala/zio/prelude/Newtype.scala
@@ -2,7 +2,114 @@ package zio.prelude
 
 import zio.test.Assertion
 
-sealed trait NewtypeModule {
+/**
+ * The `Newtype` module provides functionality for creating zero overhead
+ * newtypes. Newtypes wrap an existing type and have the same representation as
+ * the underlying type at runtime but are treated as distinct types by the
+ * Scala compiler. Newtypes can be used to increase type safety in modeling a
+ * domain, for example by creating separate types for `Meter` and `Foot`. They
+ * can also be used to provide coherent instances for types that can support
+ * more than one version of a typeclass. For example, the `And` and `Or`
+ * types can be used to distinguish boolean conjunction and disjunction.
+ *
+ * To create a newtype, simply implement an object which extends `Newtype[A]`,
+ * where `A` is the underlying type you are wrapping. Then implement a type
+ * alias for `Type` in the object you create.
+ *
+ * {{{
+ * object Meter extends Newtype[Double]
+ * type Meter = Meter.Type
+ * }}}
+ *
+ * This creates a newtype `Meter` that wraps an underlying `Double` value.
+ *
+ * We can convert the underlying type to the newtype using the `wrap` method on
+ * the object we created, or convert a collection of values of the underlying
+ * type using `wrapAll`. Similarly we can convert a newtype back to the
+ * underlying value using `unwrap` and `unwrapAll`. We can also wrap a value in
+ * a newtype using the `apply` method of the object we created or pattern match
+ * to recover the underlying value using its `unapply` method. None of these
+ * methods incur any runtime overhead in doing these conversions.
+ *
+ * {{{
+ * implicit class MeterSyntax(private val self: Meter) extends AnyVal {
+ *   def +(that: Meter): Meter =
+ *     Meter.wrap(Meter.unwrap(self) + Meter.unwrap(that))
+ * }
+ *
+ * val x = Meter(3.4)
+ * val y = Meter(4.3)
+ * val z = x + y
+ * }}}
+ *
+ * In the example above, `Meter` is completely indepnedent of `Double`. Outside
+ * of the methods we create to convert between them, the two types are
+ * completely unrelated from the perspective of the Scala compiler. This can be
+ * valuable because it fully hides the underlying type. For example, we cannot
+ * accidentally add a `Meter` and a `Foot`. On the other hand `Meter` also does
+ * not have any of the methods defined on it that are defined for `Double`
+ * values so we have to reimplement them ourselves or wrap and unwrap each
+ * time.
+ *
+ * It is also possible to create newtypes that are subtypes of existing types.
+ * To do this, just implement your newtype the same we as described above but
+ * extends `Subtype[A]`, where `A` is the underlying value you are wrapping.
+ *
+ * {{{
+ * object And extends Subtype[Boolean]
+ * type And = And.Type
+ *
+ * object Or extends Subtype[Boolean]
+ * type Or = Or.Type
+ *
+ * implicit object AndInstance extends Associative[And] with Identity[And] {
+ *   def combine(l: => And, r: => And): And =
+ *     And(l && r)
+ *   val identity: And =
+ *     And(true)
+ * }
+ *
+ * implicit object OrInstance extends Associative[Or] with Identity[Or] {
+ *   def combine(l: => Or, r: => Or): Or =
+ *     Or(l || r)
+ *   val identity: Or =
+ *     Or(false)
+ * }
+ *
+ * def foldMap[A, B](as: List[A])(f: A => B)(implicit B: Associative[B] with Identity[B]) =
+ *   as.foldLeft(B.identity)((b, a) => B.combine(b, f(a)))
+ *
+ * def exists[A](as: List[A])(f: A => Boolean): Boolean =
+ *   Or.unwrap(foldMap(as)(a => Or(f(a))))
+ *
+ * def forall[A](as: List[A])(f: A => Boolean): Boolean =
+ *   And.unwrap(foldMap(as)(a => And(f(a))))
+ * }}}
+ *
+ * Notice how `And` and `Or` are distinct types that each can have their own
+ * coherent typeclass instances, but operations on `Boolean` such as `&&` and
+ * `||` are still available on them. These methods can still return the
+ * underlying type, so this technique is most useful for creating coherent
+ * typeclasses instances rather than type safe domain specific languages.
+ *
+ * Finally, it is possible to create newtypes that require smart constructors
+ * by extending `NewTypeSmart` or `SubtypeSmart`. In this case we must provide
+ * an additional argument to the class we are extending indicating how to
+ * validate an instance of the underlying type. For example, let's create a
+ * newtype for natural numbers, which must be equal to or greater than zero.
+ *
+ * {{{
+ * object Natural extends NewtypeSmart[Int](isGreaterThanEqualTo(0))
+ * type Natural = Natural.Type
+ * }}}
+ *
+ * In this case, attempting to convert an integer to a natural number will
+ * return a `Validation[String, Natural]` that will either contain a`Natural`
+ * if the integer was equal to or greater than zero or a string with a
+ * descriptive error message if the condition was not satisfied.
+ */
+private[prelude] sealed trait NewtypeModule {
+
   def newtype[A]: Newtype[A]
 
   def newtypeSmart[A](assertion: Assertion[A]): NewtypeSmart[A]
@@ -16,32 +123,92 @@ sealed trait NewtypeModule {
   sealed trait Newtype[A] {
     type Type
 
+    /**
+     * Converts an instance of the underlying type to an instance of the
+     * newtype.
+     */
     def apply(value: A): Type = wrap(value)
 
+    /**
+     * Allows pattern matching on newtype instances to convert them back to
+     * instances of the underlying type.
+     */
     def unapply(value: Type): Some[A] = Some(unwrap(value))
 
+    /**
+     * Converts an instance of the underlying type to an instance of the
+     * newtype.
+     */
     def wrap(value: A): Type = wrapAll[Id](value)
 
+    /**
+     * Converts an instance of the newtype back to an instance of the
+     * underlying type.
+     */
     def unwrap(value: Type): A = unwrapAll[Id](value)
 
+    /**
+     * Converts an instance of a type parameterized on the underlying type
+     * to an instance of a type parameterized on the newtype. For example,
+     * this could be used to convert a list of instances of the underlying
+     * type to a list of instances of the newtype.
+     */
     def wrapAll[F[_]](value: F[A]): F[Type]
 
+    /**
+     * Converts an instance of a type parameterized on the newtype back to an
+     * instance of a type parameterized on the underlying type. For example,
+     * this could be used to convert a list of instances of the newtype back
+     * to a list of instances of the underlying type.
+     */
     def unwrapAll[F[_]](value: F[Type]): F[A]
   }
 
   sealed trait NewtypeSmart[A] {
     type Type
 
+    /**
+     * Attempts to convert an instance of the underlying type to an instance
+     * of the newtype, returning a `Validation` containing either a valid
+     * instance of the newtype or a string message describing why the instance
+     * was invalid.
+     */
     def make(value: A): Validation[String, Type] = wrap(value)
 
+    /**
+     * Allows pattern matching on newtype instances to convert them back to
+     * instances of the underlying type.
+     */
     def unapply(value: Type): Some[A] = Some(unwrap(value))
 
+    /**
+     * Attempts to convert an instance of the underlying type to an instance
+     * of the newtype, returning a `Validation` containing either a valid
+     * instance of the newtype or a string message describing why the instance
+     * was invalid.
+     */
     def wrap(value: A): Validation[String, Type]
 
+    /**
+     * Converts an instance of the newtype back to an instance of the
+     * underlying type.
+     */
     def unwrap(value: Type): A = unwrapAll[Id](value)
 
+    /**
+     * Attempts to convert a collection of instances of the underlying type to
+     * a collection of instances of the newtype, returning a `Validation`
+     * containing either a collection of valid instances of the newtype or an
+     * accumulation of validation errors.
+     */
     def wrapAll(value: List[A]): Validation[String, List[Type]]
 
+    /**
+     * Converts an instance of a type parameterized on the newtype back to an
+     * instance of a type parameterized on the underlying type. For example,
+     * this could be used to convert a list of instances of the newtype back
+     * to a list of instances of the underlying type.
+     */
     def unwrapAll[F[_]](value: F[Type]): F[A]
   }
 
@@ -53,6 +220,7 @@ sealed trait NewtypeModule {
     type Type <: A
   }
 }
+
 private[prelude] object NewtypeModule {
   val instance: NewtypeModule =
     new NewtypeModule {
@@ -101,9 +269,20 @@ private[prelude] object NewtypeModule {
         }
     }
 }
+
 trait NewtypeExports {
   import NewtypeModule._
 
+  /**
+   * The class of objects corresponding to newtypes. Users should implement an
+   * object that extends this class to create their own newtypes, specifying
+   * `A` as the underlying type to wrap.
+   *
+   * {{{
+   * object Meter extends Newtype[Double]
+   * type Meter = Meter.Type
+   * }}}
+   */
   abstract class Newtype[A] extends instance.Newtype[A] {
     val newtype: instance.Newtype[A] = instance.newtype[A]
 
@@ -114,6 +293,19 @@ trait NewtypeExports {
     def unwrapAll[F[_]](value: F[Type]): F[A] = newtype.unwrapAll(value)
   }
 
+  /**
+   * The class of objects corresponding to newtypes with smart constructors
+   * where not all instances of the underlying type are valid instances of the
+   * newtype. Users should implement an object that extends this class to
+   * create their own newtypes, specifying `A` as the underlying type to wrap
+   * and an assertion that valid instances of the underlying type should
+   * satisfy.
+   *
+   * {{{
+   * object Natural extends NewtypeSmart[Int](isGreaterThanEqualTo(0))
+   * type Natural = Natural.Type
+   * }}}
+   */
   abstract class NewtypeSmart[A](assertion: Assertion[A]) extends instance.NewtypeSmart[A] {
     val newtype: instance.NewtypeSmart[A] = instance.newtypeSmart[A](assertion)
 
@@ -126,6 +318,16 @@ trait NewtypeExports {
     def unwrapAll[F[_]](value: F[Type]): F[A] = newtype.unwrapAll(value)
   }
 
+  /**
+   * The class of objects corresponding to subtypes. Users should implement an
+   * object that extends this class to create their own subtypes, specifying
+   * `A` as the underlying type to wrap.
+   *
+   * {{{
+   * object And extends Subtype[Boolean]
+   * type And = And.Type
+   * }}}
+   */
   abstract class Subtype[A] extends instance.Subtype[A] {
     val subtype: instance.Subtype[A] = instance.subtype[A]
 
@@ -136,6 +338,19 @@ trait NewtypeExports {
     def unwrapAll[F[_]](value: F[Type]): F[A] = subtype.unwrapAll(value)
   }
 
+  /**
+   * The class of objects corresponding to subtypes with smart constructors
+   * where not all instances of the underlying type are valid instances of the
+   * subtype. Users should implement an object that extends this class to
+   * create their own subtypes, specifying `A` as the underlying type to wrap
+   * and an assertion that valid instances of the underlying type should
+   * satisfy.
+   *
+   * {{{
+   * object Natural extends SubtypeSmart[Int](isGreaterThanEqualTo(0))
+   * type Natural = Natural.Type
+   * }}}
+   */
   abstract class SubtypeSmart[A](assertion: Assertion[A]) extends instance.SubtypeSmart[A] {
     val subtype: instance.SubtypeSmart[A] = instance.subtypeSmart[A](assertion)
 

--- a/src/main/scala/zio/prelude/NewtypeF.scala
+++ b/src/main/scala/zio/prelude/NewtypeF.scala
@@ -1,6 +1,63 @@
 package zio.prelude
 
-sealed trait NewtypeModuleF {
+/**
+ * The `NewtypeF` module provides functionality for creating newtypes that are
+ * parameterized on some type `A`. See the documentation on `Newtype` for a
+ * more general discussion of newtypes, their use cases, and creating and
+ * working with newtypes. Unlike the newtypes in that module, the newtypes
+ * created by this module are parameterized on some type `A`. For example, we
+ * could try to use unparameterized newtypes to distinguish integer addition
+ * from multiplication:
+ *
+ * {{{
+ * object IntSum extends Newtype[Int]
+ * type IntSum = IntSum.Type
+ *
+ * object IntMult extends Newtype[Int]
+ * type IntMult = IntMult.Type
+ * }}}
+ *
+ * However, what happens if we want to similarly distinguish addition and
+ * multiplication for longs and other numeric values? We could implement
+ * separate newtypes for each of them (e.g. `LongSum`, `LongMult`) but this
+ * involves significant boilerplate and removes our ability to abstract over
+ * addition in general, separate from the specific type of numeric values we
+ * are adding.
+ *
+ * We can improve this by using the `NewtypeF` module. We define our newtype
+ * exactly as we did before but we extends `NewtypeF` or `SubtypeF` and we do
+ * not specify any type parameter. We then define our type alias as a type
+ * parameterized on some type `A`:
+ *
+ * {{{
+ * object Sum extends SubtypeF
+ * type Sum[A] = Sum.Type[A]
+ *
+ * object Prod extends SubtypeF
+ * type Prod[A] = Prod.Type[A]
+ * }}}
+ *
+ * We can then parameterize our newtype on different types:
+ *
+ * {{{
+ * implicit val IntInstance: Associative[Sum[Int]] with Identity[Sum[Int]] = ???
+ * implicit val LongInstance: Associative[Sum[Long]] with Identity[Sum[Long]] = ???
+ *
+ * def sum[A](as: List[A])(implicit A: Associative[Sum[A]] with Identity[Sum[A]]): A =
+ *   Sum.unwrap(Sum.wrapAll(as).foldLeft(A.identity)((b, a) => A.combine(b, a)))
+ * }}}
+ *
+ * sum(List(1, 2, 3))
+ * sum(List(1L, 2L, 3L))
+ * }}}
+ *
+ * Just as with other newtypes, `apply`, `wrap`, and `wrapAll` are available to
+ * convert instances of the underlying type to instances of the newtype and
+ * `unapply`, `unwrap`, and `unwrapAll` can be used to convert instances of the
+ * newtype back to instances of the underlying type. Variants for subtypes are
+ * also available.
+ */
+private[prelude] sealed trait NewtypeModuleF {
   def newtypeF: NewtypeF
 
   def subtypeF: SubtypeF
@@ -10,16 +67,44 @@ sealed trait NewtypeModuleF {
   sealed trait NewtypeF {
     type Type[A]
 
+    /**
+     * Converts an instance of the underlying type to an instance of the
+     * newtype.
+     */
     def apply[A](value: A): Type[A] = wrap(value)
 
+    /**
+     * Allows pattern matching on newtype instances to convert them back to
+     * instances of the underlying type.
+     */
     def unapply[A](value: Type[A]): Some[A] = Some(unwrap(value))
 
+    /**
+     * Converts an instance of the underlying type to an instance of the
+     * newtype.
+     */
     def wrap[A](value: A): Type[A] = wrapAll[Id, A](value)
 
+    /**
+     * Converts an instance of the newtype back to an instance of the
+     * underlying type.
+     */
     def unwrap[A](value: Type[A]): A = unwrapAll[Id, A](value)
 
+    /**
+     * Converts an instance of a type parameterized on the underlying type
+     * to an instance of a type parameterized on the newtype. For example,
+     * this could be used to convert a list of instances of the underlying
+     * type to a list of instances of the newtype.
+     */
     def wrapAll[F[_], A](value: F[A]): F[Type[A]]
 
+    /**
+     * Converts an instance of a type parameterized on the newtype back to an
+     * instance of a type parameterized on the underlying type. For example,
+     * this could be used to convert a list of instances of the newtype back
+     * to a list of instances of the underlying type.
+     */
     def unwrapAll[F[_], A](value: F[Type[A]]): F[A]
   }
 
@@ -52,6 +137,16 @@ private[prelude] object NewtypeModuleF {
 trait NewtypeFExports {
   import NewtypeModuleF._
 
+  /**
+   * The class of objects corresponding to parameterized newtypes. Users should
+   * implement an object that extends this class to create their own
+   * parameterized newtypes
+   *
+   * {{{
+   * object Sum extends NewtypeF
+   * type Sum[A] = Sum.Type[A]
+   * }}}
+   */
   abstract class NewtypeF extends instance.NewtypeF {
     val newtypeF: instance.NewtypeF =
       instance.newtypeF
@@ -65,6 +160,16 @@ trait NewtypeFExports {
       newtypeF.unwrapAll(value)
   }
 
+  /**
+   * The class of objects corresponding to parameterized subtypes. Users should
+   * implement an object that extends this class to create their own
+   * parameterized subtypes
+   *
+   * {{{
+   * object Sum extends SubtypeF
+   * type Sum[A] = Sum.Type[A]
+   * }}}
+   */
   abstract class SubtypeF extends instance.SubtypeF {
     val subtypeF: instance.SubtypeF =
       instance.subtypeF

--- a/src/main/scala/zio/prelude/coherent/AssociativeCoherent.scala
+++ b/src/main/scala/zio/prelude/coherent/AssociativeCoherent.scala
@@ -16,4 +16,19 @@ trait AssociativeCoherent {
         associative0.combine(l, r)
       override def checkEqual(l: A, r: A): Boolean = equal0.equal(l, r)
     }
+
+  /**
+   * Derives an `Associative[A] with Identity[A]` given an Associative[A]` and
+   * an `Identity[A]`.
+   */
+  implicit def associativeIdentity[A](
+    implicit associative0: Associative[A],
+    identity0: Identity[A]
+  ): Associative[A] with Identity[A] =
+    new Associative[A] with Identity[A] {
+      override def combine(l: => A, r: => A): A =
+        associative0.combine(l, r)
+      override val identity: A =
+        identity0.identity
+    }
 }

--- a/src/main/scala/zio/prelude/newtypes/package.scala
+++ b/src/main/scala/zio/prelude/newtypes/package.scala
@@ -1,27 +1,60 @@
 package zio.prelude
 
 package object newtypes {
+
   object Sum extends SubtypeF
+
+  /**
+   * A newtype representing addition.
+   */
   type Sum[A] = Sum.Type[A]
 
   object Prod extends SubtypeF
+
+  /**
+   * A newtype representing multiplication.
+   */
   type Prod[A] = Prod.Type[A]
 
   object Or extends Subtype[Boolean]
+
+  /**
+   * A newtype representing logical disjunction.
+   */
   type Or = Or.Type
 
   object And extends Subtype[Boolean]
+
+  /**
+   * A newtype represeting logical conjunction.
+   */
   type And = And.Type
 
   object First extends SubtypeF
+
+  /**
+   * A newtype representing taking the first of two elements.
+   */
   type First[A] = First.Type[A]
 
   object Last extends SubtypeF
+
+  /**
+   * A newtype representing taking the last of two elements.
+   */
   type Last[A] = Last.Type[A]
 
   object Min extends SubtypeF
+
+  /**
+   * A newtype representing taking the min of two elements.
+   */
   type Min[A] = Min.Type[A]
 
   object Max extends SubtypeF
+
+  /**
+   * A newtype representing taking the max of two elements.
+   */
   type Max[A] = Max.Type[A]
 }

--- a/src/test/scala/zio/prelude/NewtypeSpec.scala
+++ b/src/test/scala/zio/prelude/NewtypeSpec.scala
@@ -1,34 +1,73 @@
 package zio.prelude
 
+import zio.prelude.newtypes._
 import zio.test._
 import zio.test.Assertion._
 
 object NewtypeSpec extends DefaultRunnableSpec {
 
-  object Natural extends SubtypeSmart[Int](isGreaterThanEqualTo(0))
-  type Natural = Natural.Type
-
-  def isInvalid[E](assertion: Assertion[::[E]]): Assertion[Validation[E, Any]] =
-    assertionRec("isInvalid")(Render.param(assertion))(assertion) {
-      case Validation.Failure(e, es) => Some(::(e, es.toList))
-      case _                         => None
-    }
-
-  def isValid[A](assertion: Assertion[A]): Assertion[Validation[Any, A]] =
-    assertionRec("isValid")(Render.param(assertion))(assertion) {
-      case Validation.Success(a) => Some(a)
-      case _                     => None
-    }
-
   def spec = suite("NewtypeSpec")(
     suite("NewtypeSmart")(
       test("valid values") {
-        assert(Natural.make(0))(isValid(anything))
+        assert(Natural.make(0))(isSuccessV(anything))
       },
       test("invalid values") {
         val expected = List("-1 did not satisfy isGreaterThanEqualTo(0)")
-        assert(Natural.make(-1))(isInvalid(equalTo(expected)))
+        assert(Natural.make(-1))(isFailureV(equalTo(expected)))
+      }
+    ),
+    suite("examples from documentation")(
+      test("meter") {
+        val x = Meter(3.4)
+        val y = Meter(4.3)
+        val z = x + y
+        assert(Meter.unwrap(z))(equalTo(3.4 + 4.3))
+      },
+      test("exists") {
+        assert(exists(List(true, false))(identity))(isTrue)
+      },
+      test("forall") {
+        assert(forall(List(true, false))(identity))(isFalse)
+      },
+      test("sumInt") {
+        val actual   = sum(List(1, 2, 3))
+        val expected = 6
+        assert(actual)(equalTo(expected))
+      },
+      test("sumLong") {
+        val actual   = sum(List(1L, 2L, 3L))
+        val expected = 6L
+        assert(actual)(equalTo(expected))
       }
     )
   )
+
+  object Meter extends Newtype[Double]
+  type Meter = Meter.Type
+
+  implicit class MeterSyntax(private val self: Meter) extends AnyVal {
+    def +(that: Meter): Meter =
+      Meter.wrap(Meter.unwrap(self) + Meter.unwrap(that))
+  }
+
+  def foldMap[A, B](as: List[A])(f: A => B)(implicit B: Associative[B] with Identity[B]) =
+    as.foldLeft(B.identity)((b, a) => B.combine(b, f(a)))
+
+  def exists[A](as: List[A])(f: A => Boolean): Boolean =
+    Or.unwrap(foldMap(as)(a => Or(f(a))))
+
+  def forall[A](as: List[A])(f: A => Boolean): Boolean =
+    And.unwrap(foldMap(as)(a => And(f(a))))
+
+  object Natural extends SubtypeSmart[Int](isGreaterThanEqualTo(0))
+  type Natural = Natural.Type
+
+  object IntSum extends Newtype[Int]
+  type IntSum = IntSum.Type
+
+  object IntMult extends Newtype[Int]
+  type IntMult = IntMult.Type
+
+  def sum[A](as: List[A])(implicit A: Associative[Sum[A]] with Identity[Sum[A]]): A =
+    Sum.unwrap(Sum.wrapAll(as).foldLeft(A.identity)((b, a) => A.combine(b, a)))
 }


### PR DESCRIPTION
Resolves #36. Adds documentation for `Newtype` and `NewtypeF`. I also made the modules `private[prelude]`. I think that points users to the proper way to use this functionality through the exports but happy to revert.