### PR TITLE
Add Contravariant Instances for ZIO Prelude Types

### DIFF
--- a/src/main/scala/zio/prelude/Equal.scala
+++ b/src/main/scala/zio/prelude/Equal.scala
@@ -121,6 +121,15 @@ object Equal extends Lawful[Equal] {
     reflexiveLaw + symmetryLaw + transitivityLaw
 
   /**
+   * The contravariant instance for `Equal`.
+   */
+  implicit val EqualContravariant: Contravariant[Equal] =
+    new Contravariant[Equal] {
+      def contramap[A, B](f: B => A): Equal[A] => Equal[B] =
+        _.contramap(f)
+    }
+
+  /**
    * Summons an implicit `Equal[A]`.
    */
   def apply[A](implicit equal: Equal[A]): Equal[A] =

--- a/src/main/scala/zio/prelude/Hash.scala
+++ b/src/main/scala/zio/prelude/Hash.scala
@@ -103,6 +103,15 @@ object Hash extends Lawful[Hash] with HashCoherent {
     consistencyLaw + Equal.laws
 
   /**
+   * The contravariant instance for `Hash`.
+   */
+  implicit val HashContravariant: Contravariant[Hash] =
+    new Contravariant[Hash] {
+      def contramap[A, B](f: B => A): Hash[A] => Hash[B] =
+        _.contramap(f)
+    }
+
+  /**
    * Summons an implicit `Hash[A]`.
    */
   def apply[A](implicit hash: Hash[A]): Hash[A] =

--- a/src/main/scala/zio/prelude/Ord.scala
+++ b/src/main/scala/zio/prelude/Ord.scala
@@ -192,6 +192,15 @@ object Ord extends Lawful[Ord] {
       Equal.laws
 
   /**
+   * The contravariant instance for `Ord`.
+   */
+  implicit val OrdContravariant: Contravariant[Ord] =
+    new Contravariant[Ord] {
+      def contramap[A, B](f: B => A): Ord[A] => Ord[B] =
+        _.contramap(f)
+    }
+
+  /**
    * Summons an implicit `Ord[A]`.
    */
   def apply[A](implicit ord: Ord[A]): Ord[A] =


### PR DESCRIPTION
Adds instances for `Equal`, `Hash`, and `Ord`.