### PR TITLE
Associative and Commutative make methods can now use SAMs

### DIFF
--- a/src/main/scala/zio/prelude/Associative.scala
+++ b/src/main/scala/zio/prelude/Associative.scala
@@ -33,9 +33,7 @@ object Associative extends Lawful[AssociativeEqual] {
   def apply[A](implicit associative: Associative[A]): Associative[A] = associative
 
   def make[A](f: (A, A) => A): Associative[A] =
-    new Associative[A] {
-      def combine(l: => A, r: => A): A = f(l, r)
-    }
+    (l, r) => f(l, r)
 
   implicit val BooleanConjunctionAssociative: Associative[And] =
     make[And]((l, r) => And(l && r))

--- a/src/main/scala/zio/prelude/Commutative.scala
+++ b/src/main/scala/zio/prelude/Commutative.scala
@@ -22,9 +22,7 @@ object Commutative extends Lawful[CommutativeEqual] {
   def apply[A](implicit commutative: Commutative[A]): Commutative[A] = commutative
 
   def make[A](f: (A, A) => A): Commutative[A] =
-    new Commutative[A] {
-      def combine(l: => A, r: => A): A = f(l, r)
-    }
+    (l, r) => f(l, r)
 
   implicit val BooleanConjunctionCommutative: Commutative[And] = Commutative.make((l, r) => And(l && r))
 


### PR DESCRIPTION
This was done on earlier PR today for `Closure`. I just overlooked Associative and Commutative and suggest doing it for them to be consistent.