### PR TITLE
Update NonEmptyList Instances

### DIFF
--- a/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -360,7 +360,7 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
   implicit val NonEmptyListAssociativeBothF: AssociativeBothF[NonEmptyList] =
     new AssociativeBothF[NonEmptyList] {
       def both[A, B](fa: => NonEmptyList[A], fb: => NonEmptyList[B]): NonEmptyList[(A, B)] =
-        fa.zip(fb)
+        fa.flatMap(a => fb.map(b => (a, b)))
     }
 
   /**
@@ -400,6 +400,17 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
     new EqualF[NonEmptyList] {
       def deriveEqual[A: Equal]: Equal[NonEmptyList[A]] =
         NonEmptyListEqual
+    }
+
+  /**
+   * The `IdentityBothF` instance for `NonEmptyList`.
+   */
+  implicit val NonEmptyListIdentityBothF: IdentityBothF[NonEmptyList] =
+    new IdentityBothF[NonEmptyList] {
+      def both[A, B](fa: => NonEmptyList[A], fb: => NonEmptyList[B]): NonEmptyList[(A, B)] =
+        fa.flatMap(a => fb.map(b => (a, b)))
+      val identity: NonEmptyList[Any] =
+        single(())
     }
 
   /**

--- a/src/test/scala/zio/prelude/NonEmptyListSpec.scala
+++ b/src/test/scala/zio/prelude/NonEmptyListSpec.scala
@@ -41,6 +41,7 @@ object NonEmptyListSpec extends DefaultRunnableSpec {
       testM("covariant")(checkAllLaws(Covariant)(GenFs.nonEmptyList, Gen.anyInt)),
       testM("equal")(checkAllLaws(Equal)(genNonEmptyList)),
       testM("hash")(checkAllLaws(Hash)(genNonEmptyList)),
+      testM("identityBothF")(checkAllLaws(CommutativeBothF)(GenFs.nonEmptyList, Gen.anyInt)),
       testM("ord")(checkAllLaws(Ord)(genNonEmptyList))
     ),
     suite("methods")(


### PR DESCRIPTION
Changes the `AssociativeF` instance to be the cartesian product. I think this works out nicely because then `zip` from `AssociativeF` will give you the cartesian product and `zipPar` from `CommutativeF` will give you pairwise zipping, which mirrors the behavior with `ZStream`. Also added an `IdentityF` instance that uses the cartesian product with the single element nonempty list as the identity value.