### PR TITLE
Add IdentityFlatten instances for ZIO

### DIFF
--- a/src/main/scala/zio/prelude/IdentityFlatten.scala
+++ b/src/main/scala/zio/prelude/IdentityFlatten.scala
@@ -72,7 +72,7 @@ object IdentityFlatten extends LawfulF.Covariant[CovariantEqualFIdentityFlatten,
    */
   implicit val IdentityFlattenCause: IdentityFlatten[Cause] =
     new IdentityFlatten[Cause] {
-      override def any: Cause[Any] = Cause.empty
+      override def any: Cause[Any] = Cause.fail(())
 
       override def flatten[A](ffa: Cause[Cause[A]]): Cause[A] = ffa.flatten
     }


### PR DESCRIPTION
Closes #132 

### Remarks

- No instance is provided for NonEmptyChunk as they don't have "zero".
- Some types are using unit, while the other have empty as "zero". While the compiler agrees with this, it might be worth mentioning it in the docs.