### PR TITLE
Fix Compilation Errors

### DIFF
--- a/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -374,15 +374,6 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
     }
 
   /**
-   * The `CommutativeBoth` instance for `NonEmptyList`.
-   */
-  implicit val NonEmptyListCommutativeBoth: CommutativeBoth[NonEmptyList] =
-    new CommutativeBoth[NonEmptyList] {
-      def both[A, B](fa: => NonEmptyList[A], fb: => NonEmptyList[B]): NonEmptyList[(A, B)] =
-        fa.zip(fb)
-    }
-
-  /**
    * The `Covariant` instance for `NonEmptyList`.
    */
   implicit val NonEmptyListCovariant: Covariant[NonEmptyList] =
@@ -514,6 +505,15 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
 }
 
 trait LowPriorityNonEmptyListImplicits {
+
+  /**
+   * The `CommutativeBoth` instance for `NonEmptyList`.
+   */
+  implicit val NonEmptyListCommutativeBoth: CommutativeBoth[NonEmptyList] =
+    new CommutativeBoth[NonEmptyList] {
+      def both[A, B](fa: => NonEmptyList[A], fb: => NonEmptyList[B]): NonEmptyList[(A, B)] =
+        fa.zip(fb)
+    }
 
   /**
    * Derives a `Hash[NonEmptyList[A]]` given a `Hash[A]`.

--- a/src/main/scala/zio/prelude/Validation.scala
+++ b/src/main/scala/zio/prelude/Validation.scala
@@ -149,24 +149,6 @@ object Validation extends LowPriorityValidationImplicits {
   final case class Success[+A](value: A)                 extends Validation[Nothing, A]
 
   /**
-   * The `AssociativeBoth` instance for `Validation`.
-   */
-  implicit def ValidationAssociativeBoth[E]: AssociativeBoth[({ type lambda[x] = Validation[E, x] })#lambda] =
-    new AssociativeBoth[({ type lambda[x] = Validation[E, x] })#lambda] {
-      def both[A, B](fa: => Validation[E, A], fb: => Validation[E, B]): Validation[E, (A, B)] =
-        fa.zipPar(fb)
-    }
-
-  /**
-   * The `CommutativeBoth` instance for `Validation`.
-   */
-  implicit def ValidationCommutativeBoth[E]: CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda] =
-    new CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda] {
-      def both[A, B](fa: => Validation[E, A], fb: => Validation[E, B]): Validation[E, (A, B)] =
-        fa.zipPar(fb)
-    }
-
-  /**
    * The `Covariant` instance for `Validation`.
    */
   implicit def ValidationCovariant[E]: Covariant[({ type lambda[+x] = Validation[E, x] })#lambda] =
@@ -1294,6 +1276,15 @@ object Validation extends LowPriorityValidationImplicits {
 }
 
 trait LowPriorityValidationImplicits {
+
+  /**
+   * The `CommutativeBoth` instance for `Validation`.
+   */
+  implicit def ValidationCommutativeBoth[E]: CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda] =
+    new CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda] {
+      def both[A, B](fa: => Validation[E, A], fb: => Validation[E, B]): Validation[E, (A, B)] =
+        fa.zipPar(fb)
+    }
 
   /**
    * Derives a `Hash[Validation[E, A]]` given a `Hash[E]` and a `Hash[A]`.

--- a/src/test/scala/zio/prelude/NewtypeSpec.scala
+++ b/src/test/scala/zio/prelude/NewtypeSpec.scala
@@ -7,17 +7,16 @@ import zio.test._
 import zio.test.Assertion._
 
 object NewtypeSpec extends DefaultRunnableSpec {
-  trait Dummy[A]  
+  trait Dummy[A]
 
   object Age extends Newtype[Int] {
     // type Instances
-    implicit val dummyType: Dummy[Age] = new Dummy[Age]{}
+    implicit val dummyType: Dummy[Age] = new Dummy[Age] {}
   }
   // Age.newtype.Type with Age.Instances
   type Age = Age.Type
 
   implicitly[Dummy[Age]]
-
 
   def spec = suite("NewtypeSpec")(
     suite("NewtypeSmart")(

--- a/src/test/scala/zio/prelude/NonEmptyListSpec.scala
+++ b/src/test/scala/zio/prelude/NonEmptyListSpec.scala
@@ -41,7 +41,7 @@ object NonEmptyListSpec extends DefaultRunnableSpec {
       testM("covariant")(checkAllLaws(Covariant)(GenFs.nonEmptyList, Gen.anyInt)),
       testM("equal")(checkAllLaws(Equal)(genNonEmptyList)),
       testM("hash")(checkAllLaws(Hash)(genNonEmptyList)),
-      testM("identityBoth")(checkAllLaws(CommutativeBoth)(GenFs.nonEmptyList, Gen.anyInt)),
+      testM("identityBoth")(checkAllLaws(IdentityBoth)(GenFs.nonEmptyList, Gen.anyInt)),
       testM("identityFlatten")(checkAllLaws(IdentityFlatten)(GenFs.nonEmptyList, Gen.anyInt)),
       testM("ord")(checkAllLaws(Ord)(genNonEmptyList))
     ),


### PR DESCRIPTION
Now that `CommutativeBoth` extends `IdentityBoth` we need to prioritize a couple of instances to avoid ambiguity.