### PR TITLE
Explore Alternative Encoding Of Inverse

### DIFF
--- a/src/main/scala/zio/prelude/Invariant.scala
+++ b/src/main/scala/zio/prelude/Invariant.scala
@@ -75,13 +75,13 @@ object Invariant {
             Inverse.make[B](
               f.to(a.identity),
               (l, r) => f.to(a.combine(f.from(l), f.from(r))),
-              v => f.to(a.inverse(f.from(v)))
+              (l, r) => f.to(a.inverse(f.from(l), f.from(r)))
             ),
           (b: Inverse[B]) =>
             Inverse.make[A](
               f.from(b.identity),
               (l, r) => f.from(b.combine(f.to(l), f.to(r))),
-              v => f.from(b.inverse(f.to(v)))
+              (l, r) => f.from(b.inverse(f.to(l), f.to(r)))
             )
         )
     }

--- a/src/main/scala/zio/prelude/MulitSet.scala
+++ b/src/main/scala/zio/prelude/MulitSet.scala
@@ -77,8 +77,8 @@ final class MultiSet[+A, +B] private (private val map: Map[A @uncheckedVariance,
       that.map.foldLeft(self.map.asInstanceOf[Map[A1, B1]]) {
         case (map, (a, b1)) =>
           map.get(a) match {
-            case Some(b) => map + (a -> ev.combine(b, ev.inverse(b1)))
-            case None    => map + (a -> ev.inverse(b1))
+            case Some(b) => map + (a -> ev.inverse(b, b1))
+            case None    => map + (a -> ev.inverse(ev.identity, b1))
           }
       }
     }

--- a/src/main/scala/zio/prelude/coherent/coherent.scala
+++ b/src/main/scala/zio/prelude/coherent/coherent.scala
@@ -214,7 +214,7 @@ object EqualInverse {
     new EqualInverse[A] {
       def combine(l: => A, r: => A): A                       = inverse0.combine(l, r)
       def identity: A                                        = inverse0.identity
-      def inverse(a: A): A                                   = inverse0.inverse(a)
+      def inverse(l: => A, r: => A): A                       = inverse0.inverse(l, r)
       override protected def checkEqual(l: A, r: A): Boolean = equal0.equal(l, r)
     }
 }


### PR DESCRIPTION
In general `Inverse` lets us express a concept of "subtraction" by combining a value with the inverse of another value. However, one disadvantage of the current encoding is that we can't do this for types like the natural numbers. We would like to be able to express a concept of subtraction that just returns zero if the right hand side is greater than the left hand side. But we can't do that in a polymorphic way today because `Inverse` requires us to actually construct an inverse value and negative numbers are not in the set of natural numbers.

This PR explores an alternative encoding where `Inverse` is defined as:

```scala
trait Inverse[A] extends Identity[A] {
  def inverse(l: => A, r: => A): A
}
```

The law is then:

```scala
  val rightInverseLaw: Laws[EqualInverse] =
    new Laws.Law1[EqualInverse]("rightInverseLaw") {
      def apply[A](a: A)(implicit I: EqualInverse[A]): TestResult =
        I.inverse(I.combine(I.identity, a), a) <-> I.identity
```

In other words, inverse is now a binary operation, conceptually "subtraction" and the law is that adding any value to the identity element and then subtracting that same value should return the identity element.

This works for all the existing instances and also allows us to define additional instances so I think it is preferable.