### PR TITLE
Explore Zero Import Syntax

### DIFF
--- a/src/main/scala/Example.scala
+++ b/src/main/scala/Example.scala
@@ -1,0 +1,10 @@
+object Example extends App {
+
+  import zio.prelude.Equal
+
+  1 === 1
+
+  val laws = Equal.laws
+
+  val intEqual = Equal.instance[Int]
+}

--- a/src/main/scala/zio/prelude/MulitSet.scala
+++ b/src/main/scala/zio/prelude/MulitSet.scala
@@ -233,7 +233,7 @@ object MultiSet {
    * limitations of Scala's `Map`, this uses object equality on the keys.
    */
   implicit def MultiSetEqual[A, B: Equal]: Equal[MultiSet[A, B]] =
-    Equal[Map[A, B]].contramap(_.map)
+    Equal.instance[Map[A, B]].contramap(_.map)
 
   /**
    * The `EqualF` instance for `MultiSet`.

--- a/src/main/scala/zio/prelude/package.scala
+++ b/src/main/scala/zio/prelude/package.scala
@@ -1,5 +1,7 @@
 package zio
 
+import scala.language.implicitConversions
+
 import zio.test.{ assert, TestResult }
 
 package object prelude
@@ -13,7 +15,6 @@ package object prelude
     with CovariantSyntax
     with ContravariantSyntax
     with DebugSyntax
-    with EqualSyntax
     with HashSyntax
     with IdExports
     with IdentitySyntax
@@ -38,6 +39,12 @@ package object prelude
 
   type EReader[-R, +E, +A] = zio.prelude.fx.ZPure[Unit, Unit, R, E, A]
   val EReader: zio.prelude.fx.ZPure.type = zio.prelude.fx.ZPure
+
+  type Equal[-A] = zio.prelude.typeclasses.Equal[A]
+  val Equal: zio.prelude.typeclasses.Equal.type = zio.prelude.typeclasses.Equal
+
+  implicit def Equal[A](l: A): zio.prelude.typeclasses.Equal.EqualOps[A] =
+    new zio.prelude.typeclasses.Equal.EqualOps[A](l)
 
   object classic {
     type Semigroup[A]            = Associative[A]


### PR DESCRIPTION
This PR explore zero import implicit syntax based on the Izumi approach of giving the implicit conversion to the syntax class the same name as the type class. For example:

```scala
  implicit def Equal[A](l: A): EqualOps[A] =
    new EqualOps[A](l)
```

This way whenever the user imports the type class they get the syntax so you don't need `import zio.prelude._` everywhere:

```scala
object Example extends App {
  import zio.prelude.Equal
  1 === 1
}
```

There are a couple of issues with this approach.

First, it isn't really zero import. In the example above you obviously had to import `zio.prelude.Equal`. It avoids any additional import beyond the type class just to get the syntax but you can't just do `1 === 1` with no imports like you could if the syntax was defined in the companion object of `Int` (which is not possible).

Second, using the same name for this method, the `Equal` trait, and the `Equal` companion object (which also has its own `apply` method) can cause some issues for the Scala compiler. In particular, it seems that all of these have to be defined in the same compilation unit to avoid issues (e.g. all being defined in the package object). The problem with this is that it would make the package object gigantic because you would have all the type classes in there instead of in separate files. To avoid this you have to rename the type classes or put them in a separate namespace and then alias them in the package object.

In this PR I created a new `typeclasses` packages and moved the `Equal` trait and companion object there. Then in the `zio.prelude` package object I define aliases and an implicit conversion like so:

```scala
  type Equal[-A] = zio.prelude.typeclasses.Equal[A]
  val Equal: zio.prelude.typeclasses.Equal.type = zio.prelude.typeclasses.Equal

  implicit def Equal[A](l: A): zio.prelude.typeclasses.Equal.EqualOps[A] =
    new zio.prelude.typeclasses.Equal.EqualOps[A](l)
```

With this we get the desired result with I think relatively minimal side effects.

The one other downside is that the `apply` syntax to summon instances of a type class doesn't seem to work with this encoding. I am proposing replacing that with `instance`, so instead of `Equal[A]` you would do `Equal.instance[A]`. It is not as nice but it may be worth it for the zero import syntax.

Feedback welcome.