### PR TITLE
Add Traversable Instances

### DIFF
--- a/src/main/scala-2.12/TraversableVersionSpecific.scala
+++ b/src/main/scala-2.12/TraversableVersionSpecific.scala
@@ -1,0 +1,27 @@
+package zio.prelude
+
+import scala.collection.generic.CanBuildFrom
+
+trait TraversableVersionSpecific {
+
+  /**
+   * Derives a `Traverable[F]` from an `Iterable[F]`.
+   */
+  implicit def IterableTraversable[F[+a] <: Iterable[a]](implicit derive: DeriveCanBuildFrom[F]): Traversable[F] =
+    new Traversable[F] {
+      def foreach[G[+_]: IdentityBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+        fa.foldLeft(derive.derive[B](fa).succeed)((bs, a) => bs.zipWith(f(a))(_ += _)).map(_.result())
+    }
+
+  trait DeriveCanBuildFrom[F[+_]] {
+    def derive[A]: CanBuildFrom[F[Any], A, F[A]]
+  }
+
+  object DeriveCanBuildFrom {
+    implicit def default[F[+_]](implicit bf: CanBuildFrom[F[Any], Any, F[Any]]): DeriveCanBuildFrom[F] =
+      new DeriveCanBuildFrom[F] {
+        def derive[A]: CanBuildFrom[F[Any], A, F[A]] =
+          bf.asInstanceOf[CanBuildFrom[F[Any], A, F[A]]]
+      }
+  }
+}

--- a/src/main/scala-2.13/TraversableVersionSpecific.scala
+++ b/src/main/scala-2.13/TraversableVersionSpecific.scala
@@ -1,0 +1,27 @@
+package zio.prelude
+
+import scala.collection.BuildFrom
+
+trait TraversableVersionSpecific {
+
+  /**
+   * Derives a `Traverable[F]` from an `Iterable[F]`.
+   */
+  implicit def IterableTraversable[F[+a] <: Iterable[a]](implicit derive: DeriveBuildFrom[F]): Traversable[F] =
+    new Traversable[F] {
+      def foreach[G[+_]: IdentityBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+        fa.foldLeft(derive.derive[B].newBuilder(fa).succeed)((bs, a) => bs.zipWith(f(a))(_ += _)).map(_.result())
+    }
+
+  trait DeriveBuildFrom[F[+_]] {
+    def derive[A]: BuildFrom[F[Any], A, F[A]]
+  }
+
+  object DeriveBuildFrom {
+    implicit def default[F[+_]](implicit bf: BuildFrom[F[Any], Any, F[Any]]): DeriveBuildFrom[F] =
+      new DeriveBuildFrom[F] {
+        def derive[A]: BuildFrom[F[Any], A, F[A]] =
+          bf.asInstanceOf[BuildFrom[F[Any], A, F[A]]]
+      }
+  }
+}

--- a/src/main/scala/zio/prelude/Traversable.scala
+++ b/src/main/scala/zio/prelude/Traversable.scala
@@ -217,7 +217,7 @@ trait Traversable[F[+_]] extends Covariant[F] {
     foreach(fa)(a => State((n: Int) => (n + 1, (a, n)))).runResult(0)
 }
 
-object Traversable {
+object Traversable extends TraversableVersionSpecific {
 
   /**
    * Summons an implicit `Traversable`.
@@ -242,6 +242,27 @@ object Traversable {
       def foreach[G[+_]: IdentityBoth: Covariant, A, B](list: List[A])(f: A => G[B]): G[List[B]] =
         list.foldRight[G[List[B]]](Nil.succeed)((a, bs) => f(a).zipWith(bs)(_ :: _))
       override def map[A, B](f: A => B): List[A] => List[B] = _.map(f)
+    }
+
+  /**
+   * The `Traversable` instance for `Map`.
+   */
+  implicit def MapTraversable[K]: Traversable[({ type lambda[+v] = Map[K, v] })#lambda] =
+    new Traversable[({ type lambda[+v] = Map[K, v] })#lambda] {
+      def foreach[G[+_]: IdentityBoth: Covariant, V, V2](map: Map[K, V])(f: V => G[V2]): G[Map[K, V2]] =
+        map.foldLeft[G[Map[K, V2]]](Map.empty.succeed) {
+          case (map, (k, v)) =>
+            map.zipWith(f(v))((map, v2) => map + (k -> v2))
+        }
+    }
+
+  /**
+   * The `Traversable` instance for `Vector`.
+   */
+  implicit val VectorTraversable: Traversable[Vector] =
+    new Traversable[Vector] {
+      def foreach[G[+_]: IdentityBoth: Covariant, A, B](vector: Vector[A])(f: A => G[B]): G[Vector[B]] =
+        vector.foldLeft[G[Vector[B]]](Vector.empty.succeed)((bs, a) => bs.zipWith(f(a))(_ :+ _))
     }
 }
 

--- a/src/test/scala/zio/prelude/TraversableSpec.scala
+++ b/src/test/scala/zio/prelude/TraversableSpec.scala
@@ -178,6 +178,13 @@ object TraversableSpec extends DefaultRunnableSpec {
       val expected = as.zipWithIndex
       val actual   = Traversable.ListTraversable.zipWithIndex(as)
       assert(actual)(equalTo(expected))
+    },
+    testM("Traversable can be derived from Iterable") {
+      check(genList, genInt, genIntFunction2) { (as, s, f) =>
+        val actual   = Traversable[Seq].foldLeft(as)(s)(f)
+        val expected = as.foldLeft(s)(f)
+        assert(actual)(equalTo(expected))
+      }
     }
   )
 }


### PR DESCRIPTION
Adds `Traversable` instances for `Map`, `Vector`, and any subtype of `Iterable`.