### PR TITLE
Add Laws for Traversable and NonEmptyTraversable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ inThisBuild(
 addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
-val zioVersion = "1.0.0-RC20+23-1f4eedc9-SNAPSHOT"
+val zioVersion = "1.0.0-RC21-2"
 resolvers += Resolver.sonatypeRepo("snapshots")
 libraryDependencies ++= Seq(
   "dev.zio" %% "zio"          % zioVersion,

--- a/src/main/scala/zio/prelude/GenFs.scala
+++ b/src/main/scala/zio/prelude/GenFs.scala
@@ -11,45 +11,19 @@ import zio.test.laws.GenF
  */
 object GenFs {
 
-  def nonEmptyList: GenF[Random with Sized, NonEmptyList] =
-    new GenF[Random with Sized, NonEmptyList] {
-      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A]): Gen[R1, NonEmptyList[A]] =
-        Gens.nonEmptyListOf(gen)
-    }
-
-  def tuple2[R <: Random with Sized, A](a: Gen[R, A]): GenF[R, ({ type lambda[+x] = (A, x) })#lambda] =
-    new GenF[R, ({ type lambda[+x] = (A, x) })#lambda] {
-      def apply[R1 <: R, B](b: Gen[R1, B]): Gen[R1, (A, B)] =
-        a.zip(b)
-    }
-
-  def tuple3[R <: Random with Sized, A, B](a: Gen[R, (A, B)]): GenF[R, ({ type lambda[+x] = ((A, B), x) })#lambda] =
-    new GenF[R, ({ type lambda[+x] = ((A, B), x) })#lambda] {
-      def apply[R1 <: R, C](b: Gen[R1, C]): Gen[R1, ((A, B), C)] =
-        a.zip(b)
-    }
-
-  def validation[R <: Random with Sized, E](e: Gen[R, E]): GenF[R, ({ type lambda[+x] = Validation[E, x] })#lambda] =
-    new GenF[R, ({ type lambda[+x] = Validation[E, x] })#lambda] {
-      def apply[R1 <: R, A](a: Gen[R1, A]): Gen[R1, Validation[E, A]] =
-        Gens.validation(e, a)
-    }
-
-  def validationFailure[R <: Random with Sized, A](
-    a: Gen[R, A]
-  ): GenF[R, ({ type lambda[+x] = Failure[Validation[x, A]] })#lambda] =
-    new GenF[R, ({ type lambda[+x] = Failure[Validation[x, A]] })#lambda] {
-      def apply[R1 <: R, E](e: Gen[R1, E]): Gen[R1, Failure[Validation[E, A]]] =
-        Gens.validation(e, a).map(Failure.wrap)
-    }
-
   /**
    * A generator of failed `Cause` values.
    */
-  val fail: GenF[Random with Sized, Cause] =
+  val cause: GenF[Random with Sized, Cause] =
     new GenF[Random with Sized, Cause] {
       def apply[R1 <: Random with Sized, A](gen: Gen[R1, A]): Gen[R1, Cause[A]] =
         Gen.causes(gen, Gen.throwable)
+    }
+
+  def either[R <: Random with Sized, E](e: Gen[R, E]): GenF[R, ({ type lambda[+a] = Either[E, a] })#lambda] =
+    new GenF[R, ({ type lambda[+a] = Either[E, a] })#lambda] {
+      def apply[R1 <: R, A](a: Gen[R1, A]): Gen[R1, Either[E, A]] =
+        Gen.either(e, a)
     }
 
   /**
@@ -64,6 +38,12 @@ object GenFs {
         }
     }
 
+  def map[R <: Random with Sized, K](k: Gen[R, K]): GenF[R, ({ type lambda[+v] = Map[K, v] })#lambda] =
+    new GenF[R, ({ type lambda[+v] = Map[K, v] })#lambda] {
+      def apply[R1 <: R, V](v: Gen[R1, V]): Gen[R1, Map[K, V]] =
+        Gen.mapOf(k, v)
+    }
+
   /**
    * A generator of `NonEmptyChunk` values.
    */
@@ -71,5 +51,40 @@ object GenFs {
     new GenF[Random with Sized, NonEmptyChunk] {
       def apply[R1 <: Random with Sized, A](gen: Gen[R1, A]): Gen[R1, NonEmptyChunk[A]] =
         Gen.chunkOf1(gen)
+    }
+
+  def nonEmptyList: GenF[Random with Sized, NonEmptyList] =
+    new GenF[Random with Sized, NonEmptyList] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A]): Gen[R1, NonEmptyList[A]] =
+        Gens.nonEmptyListOf(gen)
+    }
+
+  def tuple2[R <: Random with Sized, A](a: Gen[R, A]): GenF[R, ({ type lambda[+x] = (A, x) })#lambda] =
+    new GenF[R, ({ type lambda[+x] = (A, x) })#lambda] {
+      def apply[R1 <: R, B](b: Gen[R1, B]): Gen[R1, (A, B)] =
+        a.zip(b)
+    }
+
+  def tuple3[R <: Random with Sized, A, B, C](
+    a: Gen[R, A],
+    b: Gen[R, B]
+  ): GenF[R, ({ type lambda[+c] = (A, B, c) })#lambda] =
+    new GenF[R, ({ type lambda[+c] = (A, B, c) })#lambda] {
+      def apply[R1 <: R, C](c: Gen[R1, C]): Gen[R1, (A, B, C)] =
+        Gen.crossN(a, b, c)((a, b, c) => (a, b, c))
+    }
+
+  def validation[R <: Random with Sized, E](e: Gen[R, E]): GenF[R, ({ type lambda[+x] = Validation[E, x] })#lambda] =
+    new GenF[R, ({ type lambda[+x] = Validation[E, x] })#lambda] {
+      def apply[R1 <: R, A](a: Gen[R1, A]): Gen[R1, Validation[E, A]] =
+        Gens.validation(e, a)
+    }
+
+  def validationFailure[R <: Random with Sized, A](
+    a: Gen[R, A]
+  ): GenF[R, ({ type lambda[+x] = Failure[Validation[x, A]] })#lambda] =
+    new GenF[R, ({ type lambda[+x] = Failure[Validation[x, A]] })#lambda] {
+      def apply[R1 <: R, E](e: Gen[R1, E]): Gen[R1, Failure[Validation[E, A]]] =
+        Gens.validation(e, a).map(Failure.wrap)
     }
 }

--- a/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -404,7 +404,7 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
   /**
    * The `DeriveEqual` instance for `NonEmptyList`.
    */
-  implicit def NonEmptyListDeriveEqual: DeriveEqual[NonEmptyList] =
+  implicit val NonEmptyListDeriveEqual: DeriveEqual[NonEmptyList] =
     new DeriveEqual[NonEmptyList] {
       def derive[A: Equal]: Equal[NonEmptyList[A]] =
         NonEmptyListEqual

--- a/src/main/scala/zio/prelude/NonEmptyTraversable.scala
+++ b/src/main/scala/zio/prelude/NonEmptyTraversable.scala
@@ -1,7 +1,9 @@
 package zio.prelude
 
 import zio.{ ChunkBuilder, NonEmptyChunk }
+import zio.prelude.coherent.DeriveEqualNonEmptyTraversable
 import zio.prelude.newtypes.{ Max, Min }
+import zio.test.laws._
 
 /**
  * A `NonEmptyTraversable` describes a `Traversable` that is guaranteed to
@@ -126,7 +128,13 @@ trait NonEmptyTraversable[F[+_]] extends Traversable[F] {
   def toNonEmptyList[A](fa: F[A]): NonEmptyList[A] =
     reduceMapLeft(fa)(NonEmptyList.single)((as, a) => NonEmptyList.cons(a, as)).reverse
 }
-object NonEmptyTraversable {
+object NonEmptyTraversable extends LawfulF.Covariant[DeriveEqualNonEmptyTraversable, Equal] {
+
+  /**
+   * The set of all laws that instances of `NonEmptyTraversable` must satisfy.
+   */
+  val laws: LawsF.Covariant[DeriveEqualNonEmptyTraversable, Equal] =
+    Traversable.laws
 
   /**
    * Summons an implicit `NonEmptyTraversable`.

--- a/src/main/scala/zio/prelude/Traversable.scala
+++ b/src/main/scala/zio/prelude/Traversable.scala
@@ -1,7 +1,9 @@
 package zio.prelude
 
 import zio.{ Chunk, ChunkBuilder }
+import zio.prelude.coherent.DeriveEqualTraversable
 import zio.prelude.newtypes.{ And, First, Max, Min, Or, Prod, Sum }
+import zio.test.laws._
 
 /**
  * `Traversable` is an abstraction that describes the ability to iterate over
@@ -217,7 +219,13 @@ trait Traversable[F[+_]] extends Covariant[F] {
     foreach(fa)(a => State.modify((n: Int) => (n + 1, (a, n)))).runResult(0)
 }
 
-object Traversable extends TraversableVersionSpecific {
+object Traversable extends LawfulF.Covariant[DeriveEqualTraversable, Equal] with TraversableVersionSpecific {
+
+  /**
+   * The set of all laws that instances of `Traversable` must satisfy.
+   */
+  val laws: LawsF.Covariant[DeriveEqualTraversable, Equal] =
+    Covariant.laws
 
   /**
    * Summons an implicit `Traversable`.

--- a/src/main/scala/zio/prelude/coherent/coherent.scala
+++ b/src/main/scala/zio/prelude/coherent/coherent.scala
@@ -201,6 +201,36 @@ object DeriveEqualIdentityEitherInvariant {
     }
 }
 
+trait DeriveEqualNonEmptyTraversable[F[+_]] extends DeriveEqualTraversable[F] with NonEmptyTraversable[F]
+
+object DeriveEqualNonEmptyTraversable {
+  implicit def derive[F[+_]](
+    implicit deriveEqual0: DeriveEqual[F],
+    nonEmptyTraversable0: NonEmptyTraversable[F]
+  ): DeriveEqualNonEmptyTraversable[F] =
+    new DeriveEqualNonEmptyTraversable[F] {
+      def derive[A: Equal]: Equal[F[A]] =
+        deriveEqual0.derive
+      def foreach1[G[+_]: AssociativeBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+        nonEmptyTraversable0.foreach1(fa)(f)
+    }
+}
+
+trait DeriveEqualTraversable[F[+_]] extends CovariantDeriveEqual[F] with Traversable[F]
+
+object DeriveEqualTraversable {
+  implicit def derive[F[+_]](
+    implicit deriveEqual0: DeriveEqual[F],
+    traversable0: Traversable[F]
+  ): DeriveEqualTraversable[F] =
+    new DeriveEqualTraversable[F] {
+      def derive[A: Equal]: Equal[F[A]] =
+        deriveEqual0.derive
+      def foreach[G[+_]: IdentityBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+        traversable0.foreach(fa)(f)
+    }
+}
+
 trait EqualIdentity[A] extends ClosureEqual[A] with Identity[A]
 
 object EqualIdentity {

--- a/src/test/scala/zio/prelude/AssociativeFlattenSpec.scala
+++ b/src/test/scala/zio/prelude/AssociativeFlattenSpec.scala
@@ -1,7 +1,5 @@
 package zio.prelude
 
-import zio.prelude.IdentityFlattenSpec.genFEither
-import zio.prelude.CovariantSpec.genFMap
 import zio.test._
 import zio.test.laws._
 
@@ -10,11 +8,11 @@ object AssociativeFlattenSpec extends DefaultRunnableSpec {
   def spec = suite("AssociativeFlattenSpec")(
     suite("laws")(
       testM("chunk")(checkAllLaws(AssociativeFlatten)(GenF.chunk, Gen.chunkOf(Gen.anyString))),
-      testM("either")(checkAllLaws(AssociativeFlatten)(genFEither, Gen.anyInt)),
+      testM("either")(checkAllLaws(AssociativeFlatten)(GenFs.either(Gen.anyInt), Gen.anyInt)),
       testM("option")(checkAllLaws(AssociativeFlatten)(GenF.option, Gen.anyInt)),
       testM("list")(checkAllLaws(AssociativeFlatten)(GenF.list, Gen.anyString)),
       testM("vector")(checkAllLaws(AssociativeFlatten)(GenF.vector, Gen.anyString)),
-      testM("map")(checkAllLaws(AssociativeFlatten)(genFMap, Gen.anyInt))
+      testM("map")(checkAllLaws(AssociativeFlatten)(GenFs.map(Gen.anyInt), Gen.anyInt))
     )
   )
 }

--- a/src/test/scala/zio/prelude/CovariantSpec.scala
+++ b/src/test/scala/zio/prelude/CovariantSpec.scala
@@ -1,39 +1,22 @@
 package zio.prelude
 
-import zio.Exit
-import zio.random.Random
 import zio.test._
 import zio.test.laws._
 
 object CovariantSpec extends DefaultRunnableSpec {
-
-  val genFMap: GenF[Random with Sized, ({ type lambda[+x] = Map[Int, x] })#lambda] =
-    GenF.map(Gen.anyInt)
-
-  val genFEither: GenF[Random with Sized, ({ type lambda[+x] = Either[Int, x] })#lambda] =
-    GenF.either(Gen.anyInt)
-
-  val genFTuple: GenF[Random with Sized, ({ type lambda[+x] = (Int, x) })#lambda] =
-    GenFs.tuple2(Gen.anyInt)
-
-  val genFTuple3: GenF[Random with Sized, ({ type lambda[+x] = ((Int, Int), x) })#lambda] =
-    GenFs.tuple3(Gen.anyInt.zip(Gen.anyInt))
-
-  val genFExit: GenF[Random with Sized, ({ type lambda[+a] = Exit[Int, a] })#lambda] =
-    GenFs.exit(Gen.causes(Gen.anyInt, Gen.throwable))
 
   def spec = suite("CovariantSpec")(
     suite("laws")(
       testM("option")(checkAllLaws(Covariant)(GenF.option, Gen.anyInt)),
       testM("list")(checkAllLaws(Covariant)(GenF.list, Gen.anyInt)),
       testM("vector")(checkAllLaws(Covariant)(GenF.vector, Gen.anyInt)),
-      testM("map")(checkAllLaws(Covariant)(genFMap, Gen.anyInt)),
-      testM("either")(checkAllLaws(Covariant)(genFEither, Gen.anyInt)),
-      testM("tuple2")(checkAllLaws(Covariant)(genFTuple, Gen.anyInt)),
-      testM("tuple3")(checkAllLaws(Covariant)(genFTuple3, Gen.anyInt)),
-      testM("cause")(checkAllLaws(Covariant)(GenFs.fail, Gen.anyString)),
+      testM("map")(checkAllLaws(Covariant)(GenFs.map(Gen.anyInt), Gen.anyInt)),
+      testM("either")(checkAllLaws(Covariant)(GenFs.either(Gen.anyInt), Gen.anyInt)),
+      testM("tuple2")(checkAllLaws(Covariant)(GenFs.tuple2(Gen.anyInt), Gen.anyInt)),
+      testM("tuple3")(checkAllLaws(Covariant)(GenFs.tuple3(Gen.anyInt, Gen.anyInt), Gen.anyInt)),
+      testM("cause")(checkAllLaws(Covariant)(GenFs.cause, Gen.anyString)),
       testM("chunk")(checkAllLaws(Covariant)(GenF.chunk, Gen.anyInt)),
-      testM("exit")(checkAllLaws(Covariant)(genFExit, Gen.anyInt)),
+      testM("exit")(checkAllLaws(Covariant)(GenFs.exit(Gen.causes(Gen.anyInt, Gen.throwable)), Gen.anyInt)),
       testM("nonEmptyChunk")(checkAllLaws(Covariant)(GenFs.nonEmptyChunk, Gen.anyInt))
     )
   )

--- a/src/test/scala/zio/prelude/IdentityFlattenSpec.scala
+++ b/src/test/scala/zio/prelude/IdentityFlattenSpec.scala
@@ -1,18 +1,14 @@
 package zio.prelude
 
-import zio.random.Random
 import zio.test._
 import zio.test.laws._
 
 object IdentityFlattenSpec extends DefaultRunnableSpec {
 
-  val genFEither: GenF[Random with Sized, ({ type lambda[+x] = Either[Int, x] })#lambda] =
-    GenF.either(Gen.anyInt)
-
   def spec = suite("IdentityFlattenSpec")(
     suite("laws")(
       testM("chunk")(checkAllLaws(IdentityFlatten)(GenF.chunk, Gen.chunkOf(Gen.anyString))),
-      testM("either")(checkAllLaws(IdentityFlatten)(genFEither, Gen.anyInt)),
+      testM("either")(checkAllLaws(IdentityFlatten)(GenFs.either(Gen.anyInt), Gen.anyInt)),
       testM("option")(checkAllLaws(IdentityFlatten)(GenF.option, Gen.anyInt)),
       testM("list")(checkAllLaws(IdentityFlatten)(GenF.list, Gen.anyString)),
       testM("vector")(checkAllLaws(IdentityFlatten)(GenF.vector, Gen.anyString))

--- a/src/test/scala/zio/prelude/NonEmptyListSpec.scala
+++ b/src/test/scala/zio/prelude/NonEmptyListSpec.scala
@@ -43,6 +43,7 @@ object NonEmptyListSpec extends DefaultRunnableSpec {
       testM("hash")(checkAllLaws(Hash)(genNonEmptyList)),
       testM("identityBoth")(checkAllLaws(IdentityBoth)(GenFs.nonEmptyList, Gen.anyInt)),
       testM("identityFlatten")(checkAllLaws(IdentityFlatten)(GenFs.nonEmptyList, Gen.anyInt)),
+      testM("nonEmptyTraversable")(checkAllLaws(NonEmptyTraversable)(GenFs.nonEmptyList, Gen.anyInt)),
       testM("ord")(checkAllLaws(Ord)(genNonEmptyList))
     ),
     suite("methods")(

--- a/src/test/scala/zio/prelude/TraversableSpec.scala
+++ b/src/test/scala/zio/prelude/TraversableSpec.scala
@@ -3,6 +3,7 @@ package zio.prelude
 import zio.Chunk
 import zio.random.Random
 import zio.test._
+import zio.test.laws._
 
 object TraversableSpec extends DefaultRunnableSpec {
 
@@ -31,6 +32,14 @@ object TraversableSpec extends DefaultRunnableSpec {
     Gen.function2(genInt <*> genInt)
 
   def spec = suite("TraversableSpec")(
+    suite("instances")(
+      testM("chunk")(checkAllLaws(Traversable)(GenF.chunk, Gen.anyInt)),
+      testM("either")(checkAllLaws(Traversable)(GenFs.either(Gen.anyInt), Gen.anyInt)),
+      testM("list")(checkAllLaws(Traversable)(GenF.list, Gen.anyInt)),
+      testM("map")(checkAllLaws(Traversable)(GenFs.map(Gen.anyInt), Gen.anyInt)),
+      testM("option")(checkAllLaws(Traversable)(GenF.option, Gen.anyInt)),
+      testM("vector")(checkAllLaws(Traversable)(GenF.vector, Gen.anyInt))
+    ),
     suite("combinators")(
       testM("count") {
         check(genList, genBooleanFunction) { (as, f) =>


### PR DESCRIPTION
Right now these are just that traversing with the `Identity` effect satisfies the identity and compose laws. We could potentially add another variant of laws, `LawsF2`, that is parameterized on two type constructors with capabilities, to generalize this.