### PR TITLE
Implement CommutativeEither Instance for Future

### DIFF
--- a/src/main/scala/zio/prelude/CommutativeEither.scala
+++ b/src/main/scala/zio/prelude/CommutativeEither.scala
@@ -1,5 +1,7 @@
 package zio.prelude
 
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+
 import zio.ZIO
 import zio.prelude.coherent.CommutativeEitherDeriveEqualInvariant
 import zio.stream.{ ZSink, ZStream }
@@ -44,6 +46,15 @@ object CommutativeEither extends LawfulF.Invariant[CommutativeEitherDeriveEqualI
    */
   val laws: LawsF.Invariant[CommutativeEitherDeriveEqualInvariant, Equal] =
     commutativeLaw
+
+  /**
+   * The `CommutativeEither` instance for `Future`.
+   */
+  implicit def FutureCommutativeEither(implicit ec: ExecutionContext): CommutativeEither[Future] =
+    new CommutativeEither[Future] {
+      def either[A, B](fa: => Future[A], fb: => Future[B]): Future[Either[A, B]] =
+        Promise[Either[A, B]].completeWith(fa.map(Left(_))).completeWith(fb.map(Right(_))).future
+    }
 
   /**
    * The `CommutativeEither` instance for `ZIO`.

--- a/src/test/scala/zio/prelude/CommutativeEitherSpec.scala
+++ b/src/test/scala/zio/prelude/CommutativeEitherSpec.scala
@@ -1,11 +1,22 @@
 package zio.prelude
 
+import scala.concurrent.Future
+
+import zio.ZIO
 import zio.test._
 
 object CommutativeEitherSpec extends DefaultRunnableSpec {
 
   def spec = suite("CommutativeEitherSpec")(
-    suite("laws")(
-      )
+    testM("FutureCommutativeEither returns the first future that is completed") {
+      for {
+        l <- ZIO.fromFuture { implicit ec =>
+              Future.unit <|> Future.never
+            }
+        r <- ZIO.fromFuture { implicit ec =>
+              Future.never <|> Future.unit
+            }
+      } yield assert(l.swap)(equalTo(r))
+    }
   )
 }


### PR DESCRIPTION
Resolves #136.

This is basically the equivalent of `Future.firstCompletedOf`.

Note that there is a slight difference with the semantics of `ZIO#raceEither` because `raceEither` returns the first to complete successfully, whether this returns the first to complete at all. I think this may actually be more fundamental. In particular, with the current semantics of `raceEither` I don't think think `ZIO.never` is an identity element because `ZIO.fail(e) <|> ZIO.never != ZIO.fail(e)`.