### PR TITLE
Remove Unnecessary Variance Annotations

### DIFF
--- a/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -30,7 +30,7 @@ object AssociativeBoth extends LawfulF.Invariant[AssociativeBothDeriveEqualInvar
   /**
    * Summons an implicit `AssociativeBoth[F]`.
    */
-  def apply[F[+_]](implicit associativeBoth: AssociativeBoth[F]): AssociativeBoth[F] =
+  def apply[F[_]](implicit associativeBoth: AssociativeBoth[F]): AssociativeBoth[F] =
     associativeBoth
 
   /**

--- a/src/main/scala/zio/prelude/AssociativeEither.scala
+++ b/src/main/scala/zio/prelude/AssociativeEither.scala
@@ -55,7 +55,7 @@ object AssociativeEither extends LawfulF.Invariant[AssociativeEitherDeriveEqualI
   /**
    * Summons an implicit `AssociativeEither[F]`.
    */
-  def apply[F[+_]](implicit associativeEither: AssociativeEither[F]): AssociativeEither[F] =
+  def apply[F[_]](implicit associativeEither: AssociativeEither[F]): AssociativeEither[F] =
     associativeEither
 
   /**

--- a/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -47,7 +47,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Summons an implicit `CommutativeBoth[F]`.
    */
-  def apply[F[+_]](implicit commutativeBoth: CommutativeBoth[F]): CommutativeBoth[F] =
+  def apply[F[_]](implicit commutativeBoth: CommutativeBoth[F]): CommutativeBoth[F] =
     commutativeBoth
 
   /**

--- a/src/main/scala/zio/prelude/CommutativeEither.scala
+++ b/src/main/scala/zio/prelude/CommutativeEither.scala
@@ -87,7 +87,7 @@ object CommutativeEither extends LawfulF.Invariant[CommutativeEitherDeriveEqualI
   /**
    * Summons an implicit `CommutativeEither[F]`.
    */
-  def apply[F[+_]](implicit commutativeEither: CommutativeEither[F]): CommutativeEither[F] =
+  def apply[F[_]](implicit commutativeEither: CommutativeEither[F]): CommutativeEither[F] =
     commutativeEither
 }
 


### PR DESCRIPTION
Resolves #182. Removes unnecessary variance annotations from summoner methods for for type classes that do not require it. Thanks to @ahoy-jon for reporting!