### PR TITLE
Delete ZPure#eventually

### DIFF
--- a/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -195,13 +195,6 @@ sealed trait ZPure[-S1, +S2, -R, +E, +A] { self =>
     fold(Left(_), Right(_))
 
   /**
-   * Returns a computation that ignores errors and runs repeatedly until it
-   * eventually succeeds.
-   */
-  final def eventually: ZPure[S1, S2, R, Nothing, A] =
-    self orElse eventually
-
-  /**
    * Extends this computation with another computation that depends on the
    * result of this computation by running the first computation, using its
    * result to generate a second computation, and running that computation.


### PR DESCRIPTION
Given that the underlying type of `ZPure` is essentially `R => S1 => Either[E, (S2, A)]` I don't think there is a way that `eventually` can produce a different result on subsequent evaluations since it is otherwise pure and is not passing through the updated state on the error case.

Note that this is a little bit of judgment here on the ordering of effects. We could have instead said that the computation always produces an updated state and then also fails with an error or produces an `A` (e.g. `R => S1 => (S2, Either[E, A])`). I thought allowing the computation to fail and not even produce an updated state made sense, but I think you could do it either way.