### PR TITLE
Float's Equal and Ord consistency

### DIFF
--- a/src/main/scala/zio/prelude/Equal.scala
+++ b/src/main/scala/zio/prelude/Equal.scala
@@ -258,7 +258,7 @@ object Equal extends Lawful[Equal] {
    * return `true`, which is different from the behavior of `Double#equals`.
    */
   implicit val DoubleEqual: Equal[Double] =
-    make((n1, n2) => java.lang.Double.doubleToLongBits(n1) == java.lang.Double.doubleToLongBits(n2))
+    make((n1, n2) => java.lang.Double.doubleToLongBits(n1) == java.lang.Double.doubleToLongBits(n2)) // because Double.compare (in Ord instance) uses doubleToLongBits
 
   /**
    * Derives an `Equal[Either[A, B]]` given an `Equal[A]` and an `Equal[B]`.
@@ -272,7 +272,7 @@ object Equal extends Lawful[Equal] {
    * return `true`, which is different from the behavior of `Float#equals`.
    */
   implicit val FloatEqual: Equal[Float] =
-    make((n1, n2) => java.lang.Float.floatToIntBits(n1) == java.lang.Float.floatToIntBits(n2))
+    make((n1, n2) => java.lang.Float.floatToIntBits(n1) == java.lang.Float.floatToIntBits(n2)) // because Float.compare (in Ord instance) uses floatToIntBits
 
   /**
    * Equality for `Int` values.

--- a/src/main/scala/zio/prelude/Equal.scala
+++ b/src/main/scala/zio/prelude/Equal.scala
@@ -258,7 +258,7 @@ object Equal extends Lawful[Equal] {
    * return `true`, which is different from the behavior of `Double#equals`.
    */
   implicit val DoubleEqual: Equal[Double] =
-    make((n1, n2) => java.lang.Double.doubleToRawLongBits(n1) == java.lang.Double.doubleToRawLongBits(n2))
+    make((n1, n2) => java.lang.Double.doubleToLongBits(n1) == java.lang.Double.doubleToLongBits(n2))
 
   /**
    * Derives an `Equal[Either[A, B]]` given an `Equal[A]` and an `Equal[B]`.
@@ -272,7 +272,7 @@ object Equal extends Lawful[Equal] {
    * return `true`, which is different from the behavior of `Float#equals`.
    */
   implicit val FloatEqual: Equal[Float] =
-    make((n1, n2) => java.lang.Float.floatToRawIntBits(n1) == java.lang.Float.floatToRawIntBits(n2))
+    make((n1, n2) => java.lang.Float.floatToIntBits(n1) == java.lang.Float.floatToIntBits(n2))
 
   /**
    * Equality for `Int` values.


### PR DESCRIPTION
Make `Equal[Float]` use floatToIntBits (not floatToRawIntBits) since that is what `Ord[Float]`'s `Float.compare` uses
https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/Float.java#L940
(`floatToIntBits` coalesces NaNs into one canonical NaN)

Side note: Why do we even define separate `Equal[Float]` instance anyway? Isn't having just `Ord[Float]` enough, since it's a subtype of `Equal`?

/cc @alexknvl and https://gist.github.com/alexknvl/28dd6a0693c2d92d45528a62f7df9e0e