### PR TITLE
Debug.Repr.Constructor uses =

### DIFF
--- a/src/main/scala/zio/prelude/Debug.scala
+++ b/src/main/scala/zio/prelude/Debug.scala
@@ -37,7 +37,7 @@ object Debug {
       case Repr.KeyValue(k, v) => s"${k.render(Simple)} -> ${v.render(Simple)}"
       case Repr.Object(_, n)   => n
       case Repr.Constructor(_, n, reprs) =>
-        s"$n(${reprs.map(kv => s"${kv._1} -> ${kv._2.render(Simple)}").mkString(", ")})"
+        s"$n(${reprs.map(kv => s"${kv._1} = ${kv._2.render(Simple)}").mkString(", ")})"
       case Repr.VConstructor(List("scala"), n, reprs) if n.matches("^Tuple\\d+$") =>
         s"(${reprs.map(_.render(Simple)).mkString(", ")})"
       case Repr.VConstructor(_, n, reprs) => s"$n(${reprs.map(_.render(Simple)).mkString(", ")})"
@@ -47,7 +47,7 @@ object Debug {
       case Repr.KeyValue(k, v) => s"key: ${k.render(Full)} -> value: ${v.render(Full)}"
       case Repr.Object(ns, n)  => (ns :+ n).mkString(".")
       case Repr.Constructor(ns, n, reprs) =>
-        (ns :+ s"$n(${reprs.map(kv => s"${kv._1} -> ${kv._2.render(Full)}").mkString(", ")})").mkString(".")
+        (ns :+ s"$n(${reprs.map(kv => s"${kv._1} = ${kv._2.render(Full)}").mkString(", ")})").mkString(".")
       case Repr.VConstructor(ns, n, reprs) =>
         (ns :+ n).mkString(".") + s"(${reprs.map(_.render(Full)).mkString(", ")})"
       case any => Simple(any)
@@ -61,6 +61,7 @@ object Debug {
   sealed trait Repr { self =>
     def render(renderer: Renderer): String = renderer(self)
     def render: String                     = render(Renderer.Simple)
+    override def toString: String          = render // to show a nice view in IDEs, REPL, etc
   }
 
   object Repr {

--- a/src/test/scala/zio/prelude/DebugSpec.scala
+++ b/src/test/scala/zio/prelude/DebugSpec.scala
@@ -115,7 +115,7 @@ object DebugSpec extends DefaultRunnableSpec {
           check(genTestCase)(c =>
             assert(c.debug.render(Renderer.Simple)) {
               val str = s""""${c.string}""""
-              equalTo(s"TestCase(string -> $str, number -> ${c.number}, list -> ${c.list})")
+              equalTo(s"TestCase(string = $str, number = ${c.number}, list = ${c.list})")
             }
           )
         ),
@@ -180,7 +180,7 @@ object DebugSpec extends DefaultRunnableSpec {
           check(genTestCase)(c =>
             assert(c.debug.render(Renderer.Full)) {
               val str = s""""${c.string}""""
-              equalTo(s"DebugSpec.TestCase(string -> $str, number -> ${c.number}, list -> scala.${c.list})")
+              equalTo(s"DebugSpec.TestCase(string = $str, number = ${c.number}, list = scala.${c.list})")
             }
           )
         ),


### PR DESCRIPTION
Scala uses `=` for assigning values to named parameters