### PR TITLE
Coherent Ord and Hash instance for Float (and Double)

### DIFF
--- a/src/main/scala/zio/prelude/Equal.scala
+++ b/src/main/scala/zio/prelude/Equal.scala
@@ -259,12 +259,23 @@ object Equal extends Lawful[Equal] {
     Derive[F, Equal].derive(Equal[A])
 
   /**
-   * Equality for `Double` values. Note that to honor the contract that a
-   * value is always equal to itself, comparing `Double.NaN` with itself will
-   * return `true`, which is different from the behavior of `Double#equals`.
+   * `Hash` and `Ord` (and thus also `Equal`) instance for `Double` values.
+   *
+   * Note that to honor the contract
+   *
+   *   * that a value is always equal to itself,
+   * comparing `Double.NaN` with itself will return `true`.
+   *
+   *   * of a total ordering,
+   * `Double.NaN` will be treated as greater than any other number.
    */
-  implicit val DoubleEqual: Equal[Double] =
-    make((n1, n2) => java.lang.Double.doubleToLongBits(n1) == java.lang.Double.doubleToLongBits(n2)) // because Double.compare (in Ord instance) uses doubleToLongBits
+  implicit val DoubleHashOrd: Hash[Double] with Ord[Double] = new coherent.HashOrd[Double] {
+
+    override protected def checkCompare(l: Double, r: Double): Ordering =
+      Ordering.fromCompare(java.lang.Double.compare(l, r))
+
+    override def hash(a: Double): Int = a.hashCode()
+  }
 
   /**
    * Derives an `Equal[Either[A, B]]` given an `Equal[A]` and an `Equal[B]`.
@@ -273,12 +284,23 @@ object Equal extends Lawful[Equal] {
     Equal[A] either Equal[B]
 
   /**
-   * Equality for `Float` values. Note that to honor the contract that a
-   * value is always equal to itself, comparing `Float.NaN` with itself will
-   * return `true`, which is different from the behavior of `Float#equals`.
+   * `Hash` and `Ord` (and thus also `Equal`) instance for `Float` values.
+   *
+   * Note that to honor the contract
+   *
+   *   * that a value is always equal to itself,
+   * comparing `Float.NaN` with itself will return `true`.
+   *
+   *   * of a total ordering,
+   * `Float.NaN` will be treated as greater than any other number.
    */
-  implicit val FloatEqual: Equal[Float] =
-    make((n1, n2) => java.lang.Float.floatToIntBits(n1) == java.lang.Float.floatToIntBits(n2)) // because Float.compare (in Ord instance) uses floatToIntBits
+  implicit val FloatHashOrd: Hash[Float] with Ord[Float] = new coherent.HashOrd[Float] {
+
+    override protected def checkCompare(l: Float, r: Float): Ordering =
+      Ordering.fromCompare(java.lang.Float.compare(l, r))
+
+    override def hash(a: Float): Int = a.hashCode()
+  }
 
   /**
    * Equality for `Int` values.

--- a/src/main/scala/zio/prelude/Hash.scala
+++ b/src/main/scala/zio/prelude/Hash.scala
@@ -163,22 +163,10 @@ object Hash extends Lawful[Hash] {
     derive.derive(hash)
 
   /**
-   * Hashing for `Double` values.
-   */
-  implicit val DoubleHash: Hash[Double] =
-    default
-
-  /**
    * Derives a `Hash[Either[A, B]]` given a `Hash[A]` and a `Hash[B]`.
    */
   implicit def EitherHash[A: Hash, B: Hash]: Hash[Either[A, B]] =
     Hash[A] either Hash[B]
-
-  /**
-   * Hashing for `Float` values.
-   */
-  implicit val FloatHash: Hash[Float] =
-    default
 
   /**
    * Hashing for `Int` values.

--- a/src/main/scala/zio/prelude/Ord.scala
+++ b/src/main/scala/zio/prelude/Ord.scala
@@ -313,24 +313,10 @@ object Ord extends Lawful[Ord] {
     derive.derive(ord)
 
   /**
-   * Ordering for `Double` values. Note that to honor the contract of a total
-   * ordering, `Double.NaN` will be treated as greater than any other number.
-   */
-  implicit val DoubleOrd: Ord[Double] =
-    make((n1, n2) => Ordering.fromCompare(java.lang.Double.compare(n1, n2)))
-
-  /**
    * Derives an `Ord[Either[A, B]]` given an `Ord[A]` and an `Ord[B]`.
    */
   implicit def EitherOrd[A: Ord, B: Ord]: Ord[Either[A, B]] =
     Ord[A] either Ord[B]
-
-  /**
-   * Ordering for `Float` values. Note that to honor the contract of a total
-   * ordering, `Flat.NaN` will be treated as greater than any other number.
-   */
-  implicit val FloatOrd: Ord[Float] =
-    make((n1, n2) => Ordering.fromCompare(java.lang.Float.compare(n1, n2)))
 
   /**
    * Ordering for `Int` values.


### PR DESCRIPTION
The instances weren't coherent before. `==` in Hash behaves differently from `java.lang.Float.compare`.