### PR TITLE
Embrace HashSet in ZSet implementation

### DIFF
--- a/src/main/scala/zio/prelude/Hash.scala
+++ b/src/main/scala/zio/prelude/Hash.scala
@@ -1,10 +1,11 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-
-import zio.{ Chunk, NonEmptyChunk }
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
+import zio.{ Chunk, NonEmptyChunk }
+
+import scala.annotation.implicitNotFound
+import scala.collection.immutable.SortedMap
 
 /**
  * `Hash[A]` provides implicit evidence that a value of type `A` can be hashed.
@@ -230,6 +231,17 @@ object Hash extends Lawful[Hash] {
    */
   implicit def SetHash[A]: Hash[Set[A]] =
     default
+
+  /**
+   * Derives a `Hash[SortedMap[A, B]]` given a `Hash[A]` and `Hash[B]`.
+   */
+  implicit def SortedMapHash[A: Hash, B: Hash]: Hash[SortedMap[A, B]] =
+    make(
+      _.toList.hash,
+      (map1, map2) =>
+        map1.size == map2.size &&
+          map1.forall { case (key, value) => map2.get(key).fold(false)(_ === value) }
+    )
 
   /**
    * Hashing for `String` values.

--- a/src/test/scala/zio/prelude/ZSetSpec.scala
+++ b/src/test/scala/zio/prelude/ZSetSpec.scala
@@ -16,7 +16,7 @@ object ZSetSpec extends DefaultRunnableSpec {
     }
 
   def genZSet[R <: Random with Sized, A, B](a: Gen[R, A], b: Gen[R, B]): Gen[R, ZSet[A, B]] =
-    Gen.mapOf(a, b).map(ZSet.fromMap)
+    Gen.mapOf(a, b).map(ZSet.fromMap(_: Map[A, B]))
 
   val smallInts: Gen[Random with Sized, Chunk[Int]] =
     Gen.chunkOf(Gen.int(-10, 10))


### PR DESCRIPTION
The implementation of `ZSet` stands on `HashSet`, it's better to admit and embrace it than to hide it behind "just" `Map`.
