### PR TITLE
Consolidate Associative Instances

### DIFF
--- a/src/main/scala/zio/prelude/Associative.scala
+++ b/src/main/scala/zio/prelude/Associative.scala
@@ -61,85 +61,92 @@ object Associative extends Lawful[AssociativeEqual] {
   def apply[A](implicit associative: Associative[A]): Associative[A] = associative
 
   /**
-   * Constructs an `Associative` instance from a function.
+   * Constructs an `Associative` instance from an associative binary operator.
    */
   def make[A](f: (A, A) => A): Associative[A] =
     (l, r) => f(l, r)
 
   /**
-   * The `Commutative` and `Identity` instance for the conjunction of `Boolean`
+   * The `Commutative` and `Inverse` instance for the conjunction of `Boolean`
    * values.
    */
-  implicit val BooleanConjunctionCommutativeIdentity: Commutative[And] with Identity[And] =
-    new Commutative[And] with Identity[And] {
+  implicit val BooleanConjunctionCommutativeInverse: Commutative[And] with Inverse[And] =
+    new Commutative[And] with Inverse[And] {
       def combine(l: => And, r: => And): And = And(l && r)
       val identity: And                      = And(true)
+      def inverse(l: => And, r: => And): And = And(l || !r)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the disjunction of `Boolean` values.
-   */
-  implicit val BooleanDisjunctionCommutativeIdentity: Commutative[Or] with Identity[Or] =
-    new Commutative[Or] with Identity[Or] {
-      def combine(l: => Or, r: => Or): Or = Or(l | r)
-      val identity: Or                    = Or(false)
-    }
-
-  /**
-   * The `Commutative` and `Identity` instance for the product of `Boolean`
+   * The `Commutative` and `Inverse` instance for the disjunction of `Boolean`
    * values.
    */
-  implicit val BooleanProdCommutativeIdentity: Commutative[Prod[Boolean]] with Identity[Prod[Boolean]] =
-    new Commutative[Prod[Boolean]] with Identity[Prod[Boolean]] {
+  implicit val BooleanDisjunctionCommutativeInverse: Commutative[Or] with Inverse[Or] =
+    new Commutative[Or] with Inverse[Or] {
+      def combine(l: => Or, r: => Or): Or = Or(l || r)
+      val identity: Or                    = Or(false)
+      def inverse(l: => Or, r: => Or): Or = Or(l && !r)
+    }
+
+  /**
+   * The `Commutative` and `Inverse` instance for the product of `Boolean`
+   * values.
+   */
+  implicit val BooleanProdCommutativeInverse: Commutative[Prod[Boolean]] with Identity[Prod[Boolean]] =
+    new Commutative[Prod[Boolean]] with Inverse[Prod[Boolean]] {
       def combine(l: => Prod[Boolean], r: => Prod[Boolean]): Prod[Boolean] = Prod(l && r)
       val identity: Prod[Boolean]                                          = Prod(true)
+      def inverse(l: => Prod[Boolean], r: => Prod[Boolean]): Prod[Boolean] = Prod(l || !r)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the sum of `Boolean` values.
+   * The `Commutative` and `Inverse` instance for the sum of `Boolean` values.
    */
-  implicit val BooleanSumCommutativeIdentity: Commutative[Sum[Boolean]] with Identity[Sum[Boolean]] =
-    new Commutative[Sum[Boolean]] with Identity[Sum[Boolean]] {
+  implicit val BooleanSumCommutativeInverse: Commutative[Sum[Boolean]] with Inverse[Sum[Boolean]] =
+    new Commutative[Sum[Boolean]] with Inverse[Sum[Boolean]] {
       def combine(l: => Sum[Boolean], r: => Sum[Boolean]): Sum[Boolean] = Sum(l || r)
       val identity: Sum[Boolean]                                        = Sum(false)
+      def inverse(l: => Sum[Boolean], r: => Sum[Boolean]): Sum[Boolean] = Sum(l && !r)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the product of `Byte`
-   * values.
+   * The `Commutative` and `Inverse` instance for the product of `Byte` values.
    */
-  implicit val ByteProdCommutativeIdentity: Commutative[Prod[Byte]] with Identity[Prod[Byte]] =
-    new Commutative[Prod[Byte]] with Identity[Prod[Byte]] {
+  implicit val ByteProdCommutativeInverse: Commutative[Prod[Byte]] with Inverse[Prod[Byte]] =
+    new Commutative[Prod[Byte]] with Inverse[Prod[Byte]] {
       def combine(l: => Prod[Byte], r: => Prod[Byte]): Prod[Byte] = Prod((l * r).toByte)
       val identity: Prod[Byte]                                    = Prod(1)
+      def inverse(l: => Prod[Byte], r: => Prod[Byte]): Prod[Byte] = Prod((l / r).toByte)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the sum of `Byte` values.
+   * The `Commutative` and `Inverse` instance for the sum of `Byte` values.
    */
-  implicit val ByteSumCommutativeIdentity: Commutative[Sum[Byte]] with Identity[Sum[Byte]] =
-    new Commutative[Sum[Byte]] with Identity[Sum[Byte]] {
+  implicit val ByteSumCommutativeInverse: Commutative[Sum[Byte]] with Inverse[Sum[Byte]] =
+    new Commutative[Sum[Byte]] with Inverse[Sum[Byte]] {
       def combine(l: => Sum[Byte], r: => Sum[Byte]): Sum[Byte] = Sum((l + r).toByte)
       val identity: Sum[Byte]                                  = Sum(0)
+      def inverse(l: => Sum[Byte], r: => Sum[Byte]): Sum[Byte] = Sum((l - r).toByte)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the product of `Char`
-   * values.
+   * The `Commutative` and `Inverse` instance for the product of `Char` values.
    */
-  implicit val CharProdCommutativeIdentity: Commutative[Prod[Char]] with Identity[Prod[Char]] =
-    new Commutative[Prod[Char]] with Identity[Prod[Char]] {
+  implicit val CharProdCommutativeInverse: Commutative[Prod[Char]] with Inverse[Prod[Char]] =
+    new Commutative[Prod[Char]] with Inverse[Prod[Char]] {
       def combine(l: => Prod[Char], r: => Prod[Char]): Prod[Char] = Prod((l * r).toChar)
       val identity: Prod[Char]                                    = Prod(1)
+      def inverse(l: => Prod[Char], r: => Prod[Char]): Prod[Char] = Prod((l / r).toChar)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the sum of `Char` values.
+   * The `Commutative` and `Inverse` instance for the sum of `Char` values.
    */
-  implicit val CharSumCommutativeIdentity: Commutative[Sum[Char]] with Identity[Sum[Char]] =
-    new Commutative[Sum[Char]] with Identity[Sum[Char]] {
+  implicit val CharSumCommutativeInverse: Commutative[Sum[Char]] with Inverse[Sum[Char]] =
+    new Commutative[Sum[Char]] with Inverse[Sum[Char]] {
       def combine(l: => Sum[Char], r: => Sum[Char]): Sum[Char] = Sum((l + r).toChar)
       val identity: Sum[Char]                                  = Sum(0)
+      def inverse(l: => Sum[Char], r: => Sum[Char]): Sum[Char] = Sum((l - r).toChar)
     }
 
   /**
@@ -159,67 +166,83 @@ object Associative extends Lawful[AssociativeEqual] {
     derive.derive(associative)
 
   /**
-   * The `Commutative` and `Identity` instance for the product of `Double`
+   * The `Commutative` and `Inverse` instance for the product of `Double`
    * values.
    */
-  implicit val DoubleProdCommutativeIdentity: Commutative[Prod[Double]] with Identity[Prod[Double]] =
-    new Commutative[Prod[Double]] with Identity[Prod[Double]] {
+  implicit val DoubleProdCommutativeInverse: Commutative[Prod[Double]] with Inverse[Prod[Double]] =
+    new Commutative[Prod[Double]] with Inverse[Prod[Double]] {
       def combine(l: => Prod[Double], r: => Prod[Double]): Prod[Double] = Prod(l * r)
       val identity: Prod[Double]                                        = Prod(1)
+      def inverse(l: => Prod[Double], r: => Prod[Double]): Prod[Double] = Prod(l / r)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the product of `Double`
-   * values.
+   * The `Commutative` and `Inverse` instance for the sum of `Double` values.
    */
-  implicit val DoubleSumCommutativeIdentity: Commutative[Sum[Double]] with Identity[Sum[Double]] =
-    new Commutative[Sum[Double]] with Identity[Sum[Double]] {
+  implicit val DoubleSumCommutativeInverse: Commutative[Sum[Double]] with Inverse[Sum[Double]] =
+    new Commutative[Sum[Double]] with Inverse[Sum[Double]] {
       def combine(l: => Sum[Double], r: => Sum[Double]): Sum[Double] = Sum(l + r)
       val identity: Sum[Double]                                      = Sum(0)
+      def inverse(l: => Sum[Double], r: => Sum[Double]): Sum[Double] = Sum(l - r)
     }
+
+  /**
+   * Derives an `Identity[Either[E, A]]` given an `Identity[A]`.
+   */
+  implicit def EitherIdentity[E, A: Identity]: Identity[Either[E, A]] =
+    Identity.make(
+      Right(Identity[A].identity), {
+        case (Left(l), _)         => Left(l)
+        case (_, Left(r))         => Left(r)
+        case (Right(l), Right(r)) => Right(l <> r)
+      }
+    )
 
   /**
    * The `Associative` instance for the first of `A` values.
    */
-  implicit def firstAssociative[A]: Associative[First[A]] =
+  implicit def FirstAssociative[A]: Associative[First[A]] =
     make((l: First[A], _: First[A]) => l)
 
   /**
-   * The `Commutative` and `Identity` instance for the product of `Float`
+   * The `Commutative` and `Inverse` instance for the product of `Float`
    * values.
    */
-  implicit val FloatProdCommutativeIdentity: Commutative[Prod[Float]] with Identity[Prod[Float]] =
-    new Commutative[Prod[Float]] with Identity[Prod[Float]] {
+  implicit val FloatProdCommutativeInverse: Commutative[Prod[Float]] with Inverse[Prod[Float]] =
+    new Commutative[Prod[Float]] with Inverse[Prod[Float]] {
       def combine(l: => Prod[Float], r: => Prod[Float]): Prod[Float] = Prod(l * r)
       val identity: Prod[Float]                                      = Prod(1)
+      def inverse(l: => Prod[Float], r: => Prod[Float]): Prod[Float] = Prod(l / r)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the sum of `Float`
-   * values.
+   * The `Commutative` and `Inverse` instance for the sum of `Float` values.
    */
-  implicit val FloatSumCommutativeIdentity: Commutative[Sum[Float]] with Identity[Sum[Float]] =
-    new Commutative[Sum[Float]] with Identity[Sum[Float]] {
+  implicit val FloatSumCommutativeInverse: Commutative[Sum[Float]] with Inverse[Sum[Float]] =
+    new Commutative[Sum[Float]] with Inverse[Sum[Float]] {
       def combine(l: => Sum[Float], r: => Sum[Float]): Sum[Float] = Sum(l + r)
       val identity: Sum[Float]                                    = Sum(0)
+      def inverse(l: => Sum[Float], r: => Sum[Float]): Sum[Float] = Sum(l - r)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the product of `Int` values.
+   * The `Commutative` and `Inverse` instance for the product of `Int` values.
    */
-  implicit val IntProdCommutativeIdentity: Commutative[Prod[Int]] with Identity[Prod[Int]] =
-    new Commutative[Prod[Int]] with Identity[Prod[Int]] {
+  implicit val IntProdCommutativeInverse: Commutative[Prod[Int]] with Inverse[Prod[Int]] =
+    new Commutative[Prod[Int]] with Inverse[Prod[Int]] {
       def combine(l: => Prod[Int], r: => Prod[Int]): Prod[Int] = Prod(l * r)
       val identity: Prod[Int]                                  = Prod(1)
+      def inverse(l: => Prod[Int], r: => Prod[Int]): Prod[Int] = Prod(l / r)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the sum of `Int` values.
+   * The `Commutative` and `Inverse` instance for the sum of `Int` values.
    */
-  implicit val IntSumCommutativeIdentity: Commutative[Sum[Int]] with Identity[Sum[Int]] =
-    new Commutative[Sum[Int]] with Identity[Sum[Int]] {
+  implicit val IntSumCommutativeInverse: Commutative[Sum[Int]] with Inverse[Sum[Int]] =
+    new Commutative[Sum[Int]] with Inverse[Sum[Int]] {
       def combine(l: => Sum[Int], r: => Sum[Int]): Sum[Int] = Sum(l + r)
       val identity: Sum[Int]                                = Sum(0)
+      def inverse(l: => Sum[Int], r: => Sum[Int]): Sum[Int] = Sum(l - r)
     }
 
   /**
@@ -235,22 +258,23 @@ object Associative extends Lawful[AssociativeEqual] {
     Identity.make[List[A]](Nil, _ ++ _)
 
   /**
-   * The `Commutative` and `Identity` instance for the product of `Long`
-   * values.
+   * The `Commutative` and `Inverse` instance for the product of `Long` values.
    */
-  implicit val LongProdCommutativeIdentity: Commutative[Prod[Long]] with Identity[Prod[Long]] =
-    new Commutative[Prod[Long]] with Identity[Prod[Long]] {
+  implicit val LongProdCommutativeInverse: Commutative[Prod[Long]] with Inverse[Prod[Long]] =
+    new Commutative[Prod[Long]] with Inverse[Prod[Long]] {
       def combine(l: => Prod[Long], r: => Prod[Long]): Prod[Long] = Prod(l * r)
       val identity: Prod[Long]                                    = Prod(1)
+      def inverse(l: => Prod[Long], r: => Prod[Long]): Prod[Long] = Prod(l / r)
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the sum of `Long` values.
+   * The `Commutative` and `Inverse` instance for the sum of `Long` values.
    */
-  implicit val LongSumCommutativeIdentity: Commutative[Sum[Long]] with Identity[Sum[Long]] =
-    new Commutative[Sum[Long]] with Identity[Sum[Long]] {
+  implicit val LongSumCommutativeInverse: Commutative[Sum[Long]] with Inverse[Sum[Long]] =
+    new Commutative[Sum[Long]] with Inverse[Sum[Long]] {
       def combine(l: => Sum[Long], r: => Sum[Long]): Sum[Long] = Sum(l + r)
       val identity: Sum[Long]                                  = Sum(0)
+      def inverse(l: => Sum[Long], r: => Sum[Long]): Sum[Long] = Sum(l - r)
     }
 
   /**
@@ -291,45 +315,45 @@ object Associative extends Lawful[AssociativeEqual] {
    * Derives an `Identity[Option[A]]` given an `Associative[A]`.
    */
   implicit def OptionIdentity[A: Associative]: Identity[Option[A]] =
-    new Identity[Option[A]] {
-      def identity: Option[A] = None
-
-      def combine(l: => Option[A], r: => Option[A]): Option[A] =
-        (l, r) match {
-          case (Some(l), Some(r)) => Some(l <> r)
-          case (Some(l), None)    => Some(l)
-          case (None, Some(r))    => Some(r)
-          case _                  => None
-        }
-    }
+    Identity.make(
+      None, {
+        case (Some(l), Some(r)) => Some(l <> r)
+        case (Some(l), None)    => Some(l)
+        case (None, Some(r))    => Some(r)
+        case _                  => None
+      }
+    )
 
   /**
-   * The `Commutative` and `Identity` instance for the union of `Set[A]`
+   * The `Commutative` and `Inverse` instance for the union of `Set[A]`
    * values.
    */
-  implicit def SetCommutativeIdentity[A]: Commutative[Set[A]] with Identity[Set[A]] =
-    new Commutative[Set[A]] with Identity[Set[A]] {
+  implicit def SetCommutativeInverse[A]: Commutative[Set[A]] with Inverse[Set[A]] =
+    new Commutative[Set[A]] with Inverse[Set[A]] {
       def combine(l: => Set[A], r: => Set[A]): Set[A] = l | r
       val identity: Set[A]                            = Set.empty
+      def inverse(l: => Set[A], r: => Set[A]): Set[A] = l &~ r
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the product of `Short`
+   * The `Commutative` and `Inverse` instance for the product of `Short`
    * values.
    */
-  implicit val ShortProdCommutativeIdentity: Commutative[Prod[Short]] with Identity[Prod[Short]] =
-    new Commutative[Prod[Short]] with Identity[Prod[Short]] {
+  implicit val ShortProdCommutativeInverse: Commutative[Prod[Short]] with Inverse[Prod[Short]] =
+    new Commutative[Prod[Short]] with Inverse[Prod[Short]] {
       def combine(l: => Prod[Short], r: => Prod[Short]): Prod[Short] = Prod((l * r).toShort)
       val identity: Prod[Short]                                      = Prod(1)
+      def inverse(l: => Prod[Short], r: => Prod[Short]): Prod[Short] = Prod((l / r).toShort)
     }
 
   /**
    * The `Commutative` and `Identity` instance for the sum of `Short` values.
    */
-  implicit val ShortSumCommutativeIdentity: Commutative[Sum[Short]] with Identity[Sum[Short]] =
-    new Commutative[Sum[Short]] with Identity[Sum[Short]] {
+  implicit val ShortSumCommutativeIdentity: Commutative[Sum[Short]] with Inverse[Sum[Short]] =
+    new Commutative[Sum[Short]] with Inverse[Sum[Short]] {
       def combine(l: => Sum[Short], r: => Sum[Short]): Sum[Short] = Sum((l + r).toShort)
       val identity: Sum[Short]                                    = Sum(0)
+      def inverse(l: => Sum[Short], r: => Sum[Short]): Sum[Short] = Sum((l - r).toShort)
     }
 
   /**

--- a/src/main/scala/zio/prelude/Commutative.scala
+++ b/src/main/scala/zio/prelude/Commutative.scala
@@ -1,50 +1,65 @@
 package zio.prelude
 
 import zio.prelude.coherent.CommutativeEqual
-import zio.prelude.newtypes.{ And, Max, Min, Or, Prod, Sum }
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
 
-trait Commutative[A] extends Associative[A] {
-  self =>
+/**
+ * The `Commutative` type class describes a binary operator for a type `A` that
+ * is both associative and commutative. This means that `a1 <> a2` is equal to
+ * `a2 <> a1` for all values `a1` and `a2`. Examples of commutative operations
+ * include addition for integers, but not concatenation for strings.
+ *
+ * Commutative operators are useful because combining values with a commutative
+ * operation results in the same value regardless of the order in which values
+ * are combined, allowing us to combine values in the order that is most
+ * efficient and allowing us to return determinate values even when the order
+ * of original values is indeterminate.
+ */
+trait Commutative[A] extends Associative[A] { self =>
+
+  /**
+   * Returns a new `Commutative` instance that describes the same binary
+   * operator but applied in reverse order. Since the operation is commutative
+   * this instance is guaranteed to return the same results as the original
+   * instance but one order of combination or the other may be more efficient
+   * in certain cases.
+   */
   final def commute: Commutative[A] = Commutative((l, r) => self.combine(r, l))
 }
 
 object Commutative extends Lawful[CommutativeEqual] {
 
+  /**
+   * The commutative law states that for some binary operator `*`, for all
+   * values `a1` and `a2`, the following must hold:
+   *
+   * {{{
+   * a1 * a2 === a2 * a1
+   * }}}
+   */
   val commutativeLaw: Laws[CommutativeEqual] =
     new Laws.Law2[CommutativeEqual]("commutativeLaw") {
       def apply[A: CommutativeEqual](a1: A, a2: A): TestResult =
         (a1 <> a2) <-> (a2 <> a1)
     }
 
+  /**
+   * The set of all laws that instances of `Commutative` must satisfy.
+   */
   val laws: Laws[CommutativeEqual] =
     commutativeLaw
 
+  /**
+   * Summons an implicit `Commutative[A]`.
+   */
   def apply[A](implicit commutative: Commutative[A]): Commutative[A] = commutative
 
+  /**
+   * Constructs a `Commutative` instance from a function.
+   */
   def make[A](f: (A, A) => A): Commutative[A] =
     (l, r) => f(l, r)
-
-  implicit val BooleanConjunctionCommutative: Commutative[And] = Commutative.make((l, r) => And(l && r))
-
-  implicit val BooleanDisjunctionCommutative: Commutative[Or] = Commutative.make((l, r) => Or(l || r))
-
-  implicit val BooleanProdCommutative: Commutative[Prod[Boolean]] =
-    Commutative.make((l, r) => Prod(l && r))
-
-  implicit val BooleanSumCommutative: Commutative[Sum[Boolean]] =
-    Commutative.make((l, r) => Sum(l || r))
-
-  implicit val ByteProdCommutative: Commutative[Prod[Byte]] =
-    Commutative.make((l, r) => Prod((l * r).toByte))
-
-  implicit val ByteSumCommutative: Commutative[Sum[Byte]] =
-    Commutative.make((l, r) => Sum((l + r).toByte))
-
-  implicit val CharProdCommutative: Commutative[Prod[Char]] = Commutative.make((l, r) => Prod((l * r).toChar))
-
-  implicit val CharSumCommutative: Commutative[Sum[Char]] = Commutative.make((l, r) => Sum((l + r).toChar))
 
   /**
    * Derives a `Commutative[F[A]]` given a `Derive[F, Commutative]` and a
@@ -56,12 +71,10 @@ object Commutative extends Lawful[CommutativeEqual] {
   ): Commutative[F[A]] =
     derive.derive(commutative)
 
-  implicit val DoubleProdCommutative: Commutative[Prod[Double]] =
-    Commutative.make((l, r) => Prod(l * r))
-
-  implicit val DoubleSumCommutative: Commutative[Sum[Double]] =
-    Commutative.make((l, r) => Sum(l + r))
-
+  /**
+   * Derives a `Commutative[Either[E, A]]` given a `Commutative[E]` and a
+   * `Commutative[A]`.
+   */
   implicit def EitherCommutative[E: Commutative, A: Commutative]: Commutative[Either[E, A]] =
     new Commutative[Either[E, A]] {
       def combine(l: => Either[E, A], r: => Either[E, A]): Either[E, A] =
@@ -73,24 +86,9 @@ object Commutative extends Lawful[CommutativeEqual] {
         }
     }
 
-  implicit val FloatProdCommutative: Commutative[Prod[Float]] =
-    Commutative.make((l, r) => Prod(l * r))
-
-  implicit val FloatSumCommutative: Commutative[Sum[Float]] =
-    Commutative.make((l, r) => Sum(l + r))
-
-  implicit val IntProdCommutative: Commutative[Prod[Int]] =
-    Commutative.make((l, r) => Prod(l * r))
-
-  implicit val IntSumCommutative: Commutative[Sum[Int]] =
-    Commutative.make((l, r) => Sum(l + r))
-
-  implicit val LongProdCommutative: Commutative[Prod[Long]] =
-    Commutative.make((l, r) => Prod(l * r))
-
-  implicit val LongSumCommutative: Commutative[Sum[Long]] =
-    Commutative.make((l, r) => Sum(l + r))
-
+  /**
+   * Derives a `Commutative[Map[K, V]]` given a `Commutative[V]`.
+   */
   implicit def MapCommutative[K, V: Commutative]: Commutative[Map[K, V]] =
     new Commutative[Map[K, V]] {
 
@@ -100,12 +98,9 @@ object Commutative extends Lawful[CommutativeEqual] {
         }
     }
 
-  implicit def MaxCommutative[A: Ord]: Commutative[Max[A]] =
-    make((l: Max[A], r: Max[A]) => if (l >= r) l else r)
-
-  implicit def MinCommutative[A: Ord]: Commutative[Min[A]] =
-    make((l: Min[A], r: Min[A]) => if (l <= r) l else r)
-
+  /**
+   * Derives a `Commutative[Option[A]]` given a `Commutative[A]`
+   */
   implicit def OptionCommutative[A: Commutative]: Commutative[Option[A]] =
     new Commutative[Option[A]] {
       def combine(l: => Option[A], r: => Option[A]): Option[A] =
@@ -117,26 +112,30 @@ object Commutative extends Lawful[CommutativeEqual] {
         }
     }
 
-  implicit def SetCommutative[A]: Commutative[Set[A]] = Commutative.make(_ | _)
-
-  implicit val ShortProdCommutative: Commutative[Prod[Short]] =
-    Commutative.make((l, r) => Prod((l * r).toShort))
-
-  implicit val ShortSumCommutative: Commutative[Sum[Short]] =
-    Commutative.make((l, r) => Sum((l + r).toShort))
-
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple2Commutative[A: Commutative, B: Commutative]: Commutative[(A, B)] =
     new Commutative[(A, B)] {
       def combine(l: => (A, B), r: => (A, B)): (A, B) =
         (l._1 <> r._1, l._2 <> r._2)
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple3Commutative[A: Commutative, B: Commutative, C: Commutative]: Commutative[(A, B, C)] =
     new Commutative[(A, B, C)] {
       def combine(l: => (A, B, C), r: => (A, B, C)): (A, B, C) =
         (l._1 <> r._1, l._2 <> r._2, l._3 <> r._3)
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple4Commutative[A: Commutative, B: Commutative, C: Commutative, D: Commutative]
     : Commutative[(A, B, C, D)] =
     new Commutative[(A, B, C, D)] {
@@ -144,6 +143,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         (l._1 <> r._1, l._2 <> r._2, l._3 <> r._3, l._4 <> r._4)
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple5Commutative[A: Commutative, B: Commutative, C: Commutative, D: Commutative, E: Commutative]
     : Commutative[(A, B, C, D, E)] =
     new Commutative[(A, B, C, D, E)] {
@@ -151,6 +154,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         (l._1 <> r._1, l._2 <> r._2, l._3 <> r._3, l._4 <> r._4, l._5 <> r._5)
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple6Commutative[
     A: Commutative,
     B: Commutative,
@@ -164,6 +171,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         (l._1 <> r._1, l._2 <> r._2, l._3 <> r._3, l._4 <> r._4, l._5 <> r._5, l._6 <> r._6)
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple7Commutative[
     A: Commutative,
     B: Commutative,
@@ -178,6 +189,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         (l._1 <> r._1, l._2 <> r._2, l._3 <> r._3, l._4 <> r._4, l._5 <> r._5, l._6 <> r._6, l._7 <> r._7)
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple8Commutative[
     A: Commutative,
     B: Commutative,
@@ -193,6 +208,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         (l._1 <> r._1, l._2 <> r._2, l._3 <> r._3, l._4 <> r._4, l._5 <> r._5, l._6 <> r._6, l._7 <> r._7, l._8 <> r._8)
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple9Commutative[
     A: Commutative,
     B: Commutative,
@@ -219,6 +238,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple10Commutative[
     A: Commutative,
     B: Commutative,
@@ -250,6 +273,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple11Commutative[
     A: Commutative,
     B: Commutative,
@@ -283,6 +310,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple12Commutative[
     A: Commutative,
     B: Commutative,
@@ -318,6 +349,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple13Commutative[
     A: Commutative,
     B: Commutative,
@@ -355,6 +390,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple14Commutative[
     A: Commutative,
     B: Commutative,
@@ -394,6 +433,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple15Commutative[
     A: Commutative,
     B: Commutative,
@@ -435,6 +478,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple16Commutative[
     A: Commutative,
     B: Commutative,
@@ -478,6 +525,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple17Commutative[
     A: Commutative,
     B: Commutative,
@@ -523,6 +574,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple18Commutative[
     A: Commutative,
     B: Commutative,
@@ -570,6 +625,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple19Commutative[
     A: Commutative,
     B: Commutative,
@@ -619,6 +678,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple20Commutative[
     A: Commutative,
     B: Commutative,
@@ -670,6 +733,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple21Commutative[
     A: Commutative,
     B: Commutative,
@@ -723,6 +790,10 @@ object Commutative extends Lawful[CommutativeEqual] {
         )
     }
 
+  /**
+   * Derives a `Commutative` for a product type given a `Commutative` for each
+   * element of the product type.
+   */
   implicit def Tuple22Commutative[
     A: Commutative,
     B: Commutative,

--- a/src/main/scala/zio/prelude/Commutative.scala
+++ b/src/main/scala/zio/prelude/Commutative.scala
@@ -56,7 +56,7 @@ object Commutative extends Lawful[CommutativeEqual] {
   def apply[A](implicit commutative: Commutative[A]): Commutative[A] = commutative
 
   /**
-   * Constructs a `Commutative` instance from a function.
+   * Constructs a `Commutative` instance from a commutative binary operator.
    */
   def make[A](f: (A, A) => A): Commutative[A] =
     (l, r) => f(l, r)

--- a/src/main/scala/zio/prelude/Identity.scala
+++ b/src/main/scala/zio/prelude/Identity.scala
@@ -55,7 +55,7 @@ object Identity extends Lawful[EqualIdentity] {
     }
 
   /**
-   * The set of all laws that instances of `Associative` must satisfy.
+   * The set of all laws that instances of `Identity` must satisfy.
    */
   val laws: Laws[EqualIdentity] =
     leftIdentityLaw + rightIdentityLaw
@@ -66,7 +66,8 @@ object Identity extends Lawful[EqualIdentity] {
   def apply[A](implicit Identity: Identity[A]): Identity[A] = Identity
 
   /**
-   * Constructs an `Identity` instance from a function and an identity element.
+   * Constructs an `Identity` instance from an associative binary operator and
+   * an identity element.
    */
   def make[A](identity0: A, op: (A, A) => A): Identity[A] =
     new Identity[A] {
@@ -80,20 +81,6 @@ object Identity extends Lawful[EqualIdentity] {
    */
   implicit def DeriveIdentity[F[_], A](implicit derive: Derive[F, Identity], identity: Identity[A]): Identity[F[A]] =
     derive.derive(identity)
-
-  /**
-   * Derives an `Identity[Either[E, A]]` given an `Identity[A]`.
-   */
-  implicit def EitherIdentity[E, A: Identity]: Identity[Either[E, A]] =
-    new Identity[Either[E, A]] {
-      def identity: Either[E, A] = Right(Identity[A].identity)
-      def combine(l: => Either[E, A], r: => Either[E, A]): Either[E, A] =
-        (l, r) match {
-          case (Left(l), _)         => Left(l)
-          case (_, Left(r))         => Left(r)
-          case (Right(l), Right(r)) => Right(l <> r)
-        }
-    }
 
   /**
    * Derives an `Identity` for a product type given an `Identity` for each

--- a/zio-prelude.code-workspace
+++ b/zio-prelude.code-workspace
@@ -3,5 +3,10 @@
 		{
 			"path": "."
 		}
-	]
+	],
+	"settings": {
+		"files.watcherExclude": {
+			"**/target": true
+		}
+	}
 }


### PR DESCRIPTION
Resolves #219.

Consolidates all instances in `Associative` hierarchy in their common super types since instances defined in a companion object of a parent are also in implicit scope.