### PR TITLE
Function application helpers

### DIFF
--- a/src/main/scala/zio/prelude/package.scala
+++ b/src/main/scala/zio/prelude/package.scala
@@ -1,5 +1,6 @@
 package zio
 
+import com.github.ghik.silencer.silent
 import zio.test.{ assert, TestResult }
 
 package object prelude
@@ -112,4 +113,22 @@ package object prelude
     def lessOrEqual(that: A)(implicit ord: Ord[A]): TestResult =
       assert(self)(isLessThanEqualTo(that))
   }
+
+  implicit class AnySyntax[A](private val a: A) extends AnyVal {
+
+    @silent("side-effecting nullary methods are discouraged")
+    /* Ignores the value, if you explicitly want to do so and avoids "Unused value" compiler warnings. */
+    def ignore: Unit = ()
+
+    /** Applies function `f` to a value `a`, like `f(a)`, but in flipped order and doesn't need parentheses. Can be chained, like `x |> f |> g`. */
+    def |>[B](f: A => B): B = f(a)
+
+    /** Applies the function `f` to the value `a`, ignores the result, and returns the original value `a`. Practical for debugging, like `x.someMethod.tee(println(_)).someOtherMethod...` . Similar to the `tee` UNIX command. */
+    def tap(f: A => Any): A = {
+      val _ = f(a)
+      a
+    }
+
+  }
+
 }


### PR DESCRIPTION
`|>` is an "operator" for function application, popular in other languages (some times under different name). It's great advantage is that it doesn't need parentheses around its arguments, thus greatly improving the comfort of writing and is still easily readable. Uses can look like `x |> f |> g`. It is useful especially in functional programming, because application of multiple (small, focused) functions is more prevalent than in imperative/OO programming.
It is similar to [`pipe` introduced in Scala 2.13](https://www.scala-lang.org/api/current/scala/util/ChainingOps.html), but that one has several disadvantages
 * it's only in 2.13
 * needs an explicit import
 * it's not `|>` which is an "operator", thus
 * `anArgument |> someMethod |> someOtherFunction` is much easier to read than `anArgument.pipe(someMethod).pipe(someOtherFunction)`, especially if the names are more involved

`ignore` is an extension method that works on any value, which allows the programmer to explicitly ignore/discard such (typically non-Unit) value by turning it into a `()` (using `.ignore`). Doing so, avoids the `Unused value` compiler warnings. It is analogous to `ZIO#ignore`, which does the same thing for `ZIO` values. It is useful especially in functional programming, because ignoring a non-Unit value is typically an issue in contrast to imperative/OO programming, where this can be a benign thing. That means, we want the compiler to check for `Unused value` diligently, but in the rare cases, where we want to discard the value, we want it to be easy, yet explicit. `.ignore` is the exactly that. (`val _ = f(x); val _ = g(y, z); ...` can't be done in Scala <= 2.12, because it takes `_` as an identifier, instead of pattern-match wildcard.)

`tap` is a practical function, especially for debugging purposes. But it relies on side effects to work and since ZIO prelude is supposed to be about pure functional programming, so it's debatable, if it's a good fit for ZIO Prelude.

These functions are a great addition to the ZIO Prelude library, which, as the name suggests, attempts to complement (if not outright replace) the official standard library of Scala, where this functionality is missing.