### PR TITLE
Harden Validation#equals

### DIFF
--- a/src/main/scala/zio/prelude/Validation.scala
+++ b/src/main/scala/zio/prelude/Validation.scala
@@ -40,7 +40,7 @@ sealed trait Validation[+E, +A] { self =>
    */
   override final def equals(that: Any): Boolean =
     (self, that) match {
-      case (Failure(es), Failure(e1s)) => es.toList.toSet == e1s.toList.toSet
+      case (Failure(es), Failure(e1s)) => es.groupBy(identity) == e1s.groupBy(identity)
       case (Success(a), Success(a1))   => a == a1
       case _                           => false
     }
@@ -185,7 +185,7 @@ object Validation extends LowPriorityValidationImplicits {
    */
   implicit def ValidationEqual[E, A: Equal]: Equal[Validation[E, A]] =
     Equal.make {
-      case (Failure(es), Failure(e1s)) => es.toList.toSet === e1s.toList.toSet
+      case (Failure(es), Failure(e1s)) => es.groupBy(identity) == e1s.groupBy(identity)
       case (Success(a), Success(a1))   => a === a1
       case _                           => false
     }


### PR DESCRIPTION
We want `Validation` values to be equal regardless of the order of failures. Currently we do this by converting the failures to a set before comparing two values for equality. But we could potentially have multiple identical failures, and I think we want equality to be independent of the order of failures but not of the number of failures. So instead of turning the failures into a set we turn them into a `Map[E, Int]` and compare those.