### PR TITLE
drop laws embedded into implementation

### DIFF
--- a/src/main/scala/zio/prelude/Contravariant.scala
+++ b/src/main/scala/zio/prelude/Contravariant.scala
@@ -42,19 +42,6 @@ trait Contravariant[F[-_]] extends ContravariantSubset[F, AnyType] with Invarian
    */
   def contramap[A, B](f: B => A): F[A] => F[B]
 
-  /**
-   * Contramapping with the identity function must be an identity function.
-   */
-  def identityLaw[A](fa: F[A])(implicit equal: Equal[F[A]]): Boolean =
-    contramap(identity[A])(fa) === fa
-
-  /**
-   * Contramapping by `f` followed by `g` must be the same as contramapping
-   * with the composition of `f` and `g`.
-   */
-  def compositionLaw[A, B, C](fa: F[A], f: C => B, g: B => A)(implicit equal: Equal[F[C]]): Boolean =
-    contramap(f)(contramap(g)(fa)) === contramap(f andThen g)(fa)
-
   final def invmap[A, B](f: A <=> B): F[A] <=> F[B] =
     Equivalence((fa: F[A]) => contramap(f.from)(fa), (fb: F[B]) => contramap(f.to)(fb))
 }


### PR DESCRIPTION
Looks like laws are defined LawsF/LawfulF for example in Covariant. Buf for Contravariant they were implemented this way:
```scala
object Contravariant  extends LawfulF.Contravariant[ContravariantDeriveEqual, Equal] {

  val identityLaw: LawsF.Contravariant[ContravariantDeriveEqual, Equal] = ...

  val compositionLaw: LawsF.Contravariant[ContravariantDeriveEqual, Equal] = ...

  val laws: LawsF.Contravariant[ContravariantDeriveEqual, Equal] =
    identityLaw + compositionLaw
}
```
but also baked into Contravariant trait:
```scala
  def identityLaw[A](fa: F[A])(implicit equal: Equal[F[A]]): Boolean =	
    contramap(identity[A])(fa) === fa	

  def compositionLaw[A, B, C](fa: F[A], f: C => B, g: B => A)(implicit equal: Equal[F[C]]): Boolean =	
    contramap(f)(contramap(g)(fa)) === contramap(f andThen g)(fa)
```

I removed second implementation. This seems consistent with other laws implementation.