### PR TITLE
add laws for Divariant using methods returning booleans

### DIFF
--- a/src/main/scala/zio/prelude/Contravariant.scala
+++ b/src/main/scala/zio/prelude/Contravariant.scala
@@ -33,7 +33,7 @@ trait ContravariantSubset[F[-_], Subset[_]] {
  * compares strings by computing their lengths with the provided function and
  * comparing those.
  */
-trait Contravariant[F[-_]] extends ContravariantSubset[F, AnyType] with Invariant[F]      {
+trait Contravariant[F[-_]] extends ContravariantSubset[F, AnyType] with Invariant[F] {
   final def contramapSubset[A, B: AnyType](f: B => A): F[A] => F[B] =
     contramap(f)
 
@@ -45,7 +45,8 @@ trait Contravariant[F[-_]] extends ContravariantSubset[F, AnyType] with Invarian
   final def invmap[A, B](f: A <=> B): F[A] <=> F[B] =
     Equivalence((fa: F[A]) => contramap(f.from)(fa), (fb: F[B]) => contramap(f.to)(fb))
 }
-object Contravariant       extends LawfulF.Contravariant[ContravariantDeriveEqual, Equal] {
+
+object Contravariant extends LawfulF.Contravariant[ContravariantDeriveEqual, Equal] {
 
   /**
    * Contramapping with the identity function must not change the structure.
@@ -88,14 +89,8 @@ object Contravariant       extends LawfulF.Contravariant[ContravariantDeriveEqua
   /**
    * The contravariant instance for `Function1[-A, +B] : [*, *] => *`.
    */
-  implicit def Function1Contravariant[B]: Contravariant[({ type lambda[-x] = x => B })#lambda] = {
-    type Function1B[-A] = Function1[A, B]
-
-    new Contravariant[Function1B] {
-      def contramap[A, C](function: C => A): (A => B) => (C => B) =
-        apply => c => apply(function(c))
-    }
-  }
+  implicit def Function1Contravariant[B]: Contravariant[({ type lambda[-x] = x => B })#lambda] =
+    Divariant.Function1Divariant.deriveContravariant[B]
 
   /**
    * The contravariant instance for `Function2`.

--- a/src/main/scala/zio/prelude/Covariant.scala
+++ b/src/main/scala/zio/prelude/Covariant.scala
@@ -190,10 +190,7 @@ object Covariant extends LawfulF.Covariant[CovariantDeriveEqual, Equal] {
    * The `Covariant` instance for `Function1`
    */
   implicit def Function1Covariant[T]: Covariant[({ type lambda[+x] = T => x })#lambda] =
-    new Covariant[({ type lambda[+x] = T => x })#lambda] {
-      override def map[A, B](f: A => B): (T => A) => T => B =
-        function => t => f(function(t))
-    }
+    Divariant.Function1Divariant.deriveCovariant[T]
 
   /**
    * The `Covariant` instance for `Function2`

--- a/src/main/scala/zio/prelude/Divariant.scala
+++ b/src/main/scala/zio/prelude/Divariant.scala
@@ -103,8 +103,8 @@ trait Divariant[:=>[-_, +_]] {
 object Divariant {
   final case class Join[:=>[-_, +_], A](value: A :=> A)
 
-  implicit val Function1Divariant: Divariant[({ type lambda[-A, +B] = A => B })#lambda] =
-    new Divariant[({ type lambda[-A, +B] = A => B })#lambda] {
+  implicit val Function1Divariant: Divariant[Function1] =
+    new Divariant[Function1] {
       override def leftContramap[A, B, C](c2a: C => A): (A => B) => C => B = { a2b => c =>
         c |> c2a |> a2b
       }

--- a/src/main/scala/zio/prelude/Divariant.scala
+++ b/src/main/scala/zio/prelude/Divariant.scala
@@ -19,6 +19,25 @@ trait Divariant[:=>[-_, +_]] {
 
   def rightMap[A, B, C](f: B => C): (A :=> B) => (A :=> C)
 
+  // laws for rightMap
+
+  def rightMapCompose[A, B, B2, B3](
+    ab: A :=> B,
+    f: B => B2,
+    g: B2 => B3
+  )(implicit eq: Equal[A :=> B3]): Boolean = {
+    val lhs: A :=> B => A :=> B3 = rightMap(g compose f)
+    val rhs: A :=> B => A :=> B3 = rightMap(g) compose rightMap(f)
+    eq.equal(lhs(ab), rhs(ab))
+  }
+
+  def rightMapIdentity[A, B](
+    ab: A :=> B
+  )(implicit eq: Equal[A :=> B]): Boolean = {
+    val lhs: A :=> B => A :=> B = rightMap(identity[B])
+    eq.equal(lhs(ab), ab)
+  }
+
   // laws for leftContramap
 
   def leftContramapCompose[A, B, A2, A3](


### PR DESCRIPTION
Resolve first part of #290 - simple implementation of the laws (no zio-test law testing yet)

Changes:
* add  `composition` and `identity` laws for `rightMap`:
```scala
rightMap(g compose f) == rightMap(g) compose rightMap(f)
rightMap(identity) == identity
```
* add `composition` and `identity` laws for `leftContramap`:
```scala
leftContramap(f compose g) === leftContramap(g) compose leftContramap(f)
leftContramap(identity) === identity
```
* add `composition` and `identity` laws for dimap
```scala
dimap(f compose g, h compose i) === dimap(g, h) compose dimap(f, i)
dimap(identity, identity) == identity
```
* add law that enforce coherence between dimap and righMap and leftContramap
```scala
dimap(f, g)  === rightMap(g) andThen rleftContramap(f)
```
* derive `Function1Contravariant` and `Function1Covariant` instead of manually implement them
* type lambda are not neccessary in
`Divariant[({ type lambda[-A, +B] = A => B })#lambda]` - it is enough to `Divariant[Function1]`
* extra new line between trait and object avoid akward formatting
* rename `leftMap` to `leftContramap` (if we add Bifunctor like thing then we would have a name clash)