### PR TITLE
Newtype Tag extends Any

### DIFF
--- a/src/main/scala/zio/prelude/NewtypeModule.scala
+++ b/src/main/scala/zio/prelude/NewtypeModule.scala
@@ -308,7 +308,7 @@ trait NewtypeExports {
   abstract class Newtype[A] extends instance.Newtype[A] {
     val newtype: instance.Newtype[A] = instance.newtype[A]
 
-    trait Tag
+    trait Tag extends Any
     type Type = newtype.Type with Tag
 
     def wrapAll[F[_]](value: F[A]): F[Type] = newtype.wrapAll(value).asInstanceOf[F[Type]]
@@ -332,7 +332,7 @@ trait NewtypeExports {
   abstract class NewtypeSmart[A](assertion: Assertion[A]) extends instance.NewtypeSmart[A] {
     val newtype: instance.NewtypeSmart[A] = instance.newtypeSmart[A](assertion)
 
-    trait Tag
+    trait Tag extends Any
     type Type = newtype.Type with Tag
 
     def makeAll[F[+_]: Traversable](value: F[A]): Validation[String, F[Type]] =
@@ -358,7 +358,7 @@ trait NewtypeExports {
   abstract class Subtype[A] extends instance.Subtype[A] {
     val subtype: instance.Subtype[A] = instance.subtype[A]
 
-    trait Tag
+    trait Tag extends Any
     type Type = subtype.Type with Tag
 
     def wrapAll[F[_]](value: F[A]): F[Type] = subtype.wrapAll(value).asInstanceOf[F[Type]]
@@ -382,7 +382,7 @@ trait NewtypeExports {
   abstract class SubtypeSmart[A](assertion: Assertion[A]) extends instance.SubtypeSmart[A] {
     val subtype: instance.SubtypeSmart[A] = instance.subtypeSmart[A](assertion)
 
-    trait Tag
+    trait Tag extends Any
     type Type = subtype.Type with Tag
 
     def makeAll[F[+_]: Traversable](value: F[A]): Validation[String, F[Type]] =

--- a/src/test/scala/zio/prelude/NewtypeSpec.scala
+++ b/src/test/scala/zio/prelude/NewtypeSpec.scala
@@ -3,7 +3,6 @@ package zio.prelude
 import zio.NonEmptyChunk
 import zio.prelude.newtypes._
 import zio.test.Assertion._
-import zio.test.TestAspect.scala2Only
 import zio.test._
 
 object NewtypeSpec extends DefaultRunnableSpec {
@@ -52,7 +51,7 @@ object NewtypeSpec extends DefaultRunnableSpec {
           val expected = 6L
           assert(actual)(equalTo(expected))
         }
-      ) @@ scala2Only // https://github.com/zio/zio-prelude/issues/272
+      )
     )
 
   object Meter extends Newtype[Double]


### PR DESCRIPTION
Enables `NewtypeSpec` on Dotty.
If we drop Scala 2.11 we could use `type Tag` instead of `trait Tag`.
Not sure if you want to close #272 but `Tag` should be universal anyway.