### PR TITLE
Improve NonEmptyList and Validation instances

### DIFF
--- a/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -482,10 +482,10 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
     Hash.make(_.map(_.hash).hashCode, _.corresponds(_)(_ === _))
 
   /**
-   * The `CommutativeBoth` and `IdentityBoth` (and thus `AssociativeBoth`) instance for `NonEmptyList`.
+   * The `IdentityBoth` (and thus `AssociativeBoth`) instance for `NonEmptyList`.
    */
-  implicit val NonEmptyListCommutativeIdentityBoth: CommutativeBoth[NonEmptyList] with IdentityBoth[NonEmptyList] =
-    new CommutativeBoth[NonEmptyList] with IdentityBoth[NonEmptyList] {
+  implicit val NonEmptyListIdentityBoth: IdentityBoth[NonEmptyList] =
+    new IdentityBoth[NonEmptyList] {
       val any: NonEmptyList[Any]                                                           =
         single(())
       def both[A, B](fa: => NonEmptyList[A], fb: => NonEmptyList[B]): NonEmptyList[(A, B)] =
@@ -582,6 +582,15 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
 }
 
 trait LowPriorityNonEmptyListImplicits {
+
+  /**
+   * The `CommutativeBoth` instance for `NonEmptyList`.
+   */
+  implicit val NonEmptyListCommutativeBoth: CommutativeBoth[NonEmptyList] =
+    new CommutativeBoth[NonEmptyList] {
+      def both[A, B](fa: => NonEmptyList[A], fb: => NonEmptyList[B]): NonEmptyList[(A, B)] =
+        fa.zip(fb)
+    }
 
   /**
    * Derives an `Ord[NonEmptyList[A]]` given an `Ord[A]`.

--- a/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -484,7 +484,7 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
   /**
    * The `CommutativeBoth` and `IdentityBoth` (and thus `AssociativeBoth`) instance for `NonEmptyList`.
    */
-  implicit val NonEmptyListIdentityBoth: CommutativeBoth[NonEmptyList] with IdentityBoth[NonEmptyList] =
+  implicit val NonEmptyListCommutativeIdentityBoth: CommutativeBoth[NonEmptyList] with IdentityBoth[NonEmptyList] =
     new CommutativeBoth[NonEmptyList] with IdentityBoth[NonEmptyList] {
       val any: NonEmptyList[Any]                                                           =
         single(())

--- a/src/main/scala/zio/prelude/Validation.scala
+++ b/src/main/scala/zio/prelude/Validation.scala
@@ -229,7 +229,7 @@ object Validation extends LowPriorityValidationImplicits {
   /**
    * The `CommutativeBoth` and `IdentityBoth` (and thus `AssociativeBoth`) instance for Validation.
    */
-  implicit def ValidationIdentityBoth[E]: CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda]
+  implicit def ValidationCommutativeIdentityBoth[E]: CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda]
     with IdentityBoth[({ type lambda[x] = Validation[E, x] })#lambda] =
     new CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda]
       with IdentityBoth[({ type lambda[x] = Validation[E, x] })#lambda] {

--- a/src/main/scala/zio/prelude/Validation.scala
+++ b/src/main/scala/zio/prelude/Validation.scala
@@ -221,21 +221,23 @@ object Validation extends LowPriorityValidationImplicits {
     }
 
   /**
-   * The `IdentityBoth` instance for `Validation`.
+   * Derives a `Hash[Validation[E, A]]` given a `Hash[E]` and a `Hash[A]`.
    */
-  implicit def ValidationIdentityBoth[E]: IdentityBoth[({ type lambda[x] = Validation[E, x] })#lambda] =
-    new IdentityBoth[({ type lambda[x] = Validation[E, x] })#lambda] {
+  implicit def ValidationHash[E: Hash, A: Hash]: Hash[Validation[E, A]] =
+    Hash[NonEmptyChunk[E]].eitherWith(Hash[A])(_.toEither)
+
+  /**
+   * The `CommutativeBoth` and `IdentityBoth` (and thus `AssociativeBoth`) instance for Validation.
+   */
+  implicit def ValidationIdentityBoth[E]: CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda]
+    with IdentityBoth[({ type lambda[x] = Validation[E, x] })#lambda] =
+    new CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda]
+      with IdentityBoth[({ type lambda[x] = Validation[E, x] })#lambda] {
       val any: Validation[Nothing, Any]                                                       =
         Validation.unit
       def both[A, B](fa: => Validation[E, A], fb: => Validation[E, B]): Validation[E, (A, B)] =
         fa.zipPar(fb)
     }
-
-  /**
-   * Derives an `Ord[Validation[E, A]]` given na `Ord[E]` and an `Ord[A]`.
-   */
-  implicit def ValidationOrd[E: Ord, A: Ord]: Ord[Validation[E, A]] =
-    Ord[NonEmptyChunk[E]].eitherWith(Ord[A])(_.toEither)
 
   /**
    * The `Traversable` instance for `Validation`.
@@ -1308,17 +1310,8 @@ object Validation extends LowPriorityValidationImplicits {
 trait LowPriorityValidationImplicits {
 
   /**
-   * The `CommutativeBoth` instance for `Validation`.
+   * Derives an `Ord[Validation[E, A]]` given na `Ord[E]` and an `Ord[A]`.
    */
-  implicit def ValidationCommutativeBoth[E]: CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda] =
-    new CommutativeBoth[({ type lambda[x] = Validation[E, x] })#lambda] {
-      def both[A, B](fa: => Validation[E, A], fb: => Validation[E, B]): Validation[E, (A, B)] =
-        fa.zipPar(fb)
-    }
-
-  /**
-   * Derives a `Hash[Validation[E, A]]` given a `Hash[E]` and a `Hash[A]`.
-   */
-  implicit def ValidationHash[E: Hash, A: Hash]: Hash[Validation[E, A]] =
-    Hash[NonEmptyChunk[E]].eitherWith(Hash[A])(_.toEither)
+  implicit def ValidationOrd[E: Ord, A: Ord]: Ord[Validation[E, A]] =
+    Ord[NonEmptyChunk[E]].eitherWith(Ord[A])(_.toEither)
 }


### PR DESCRIPTION
`Hash` instance should be preferred over `Ord`, because it could contain short-circuiting `equal` implementation
