### PR TITLE
[Discussion] Put Id's type classes into its companion object

### DIFF
--- a/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1016,17 +1016,6 @@ object AssociativeBoth extends LawfulF.Invariant[AssociativeBothDeriveEqualInvar
     }
 
   /**
-   * The `IdentityBoth` (and `AssociativeBoth`) instance for `Id`.
-   */
-  implicit val IdIdentityBoth: IdentityBoth[Id] =
-    new IdentityBoth[Id] {
-      val any: Id[Any] = Id(())
-
-      def both[A, B](fa: => Id[A], fb: => Id[B]): Id[(A, B)] =
-        Id(Id.unwrap(fa) -> Id.unwrap(fb))
-    }
-
-  /**
    * The `IdentityBoth` (and `AssociativeBoth`) instance for `List`.
    */
   implicit val ListIdentityBoth: IdentityBoth[List] =

--- a/src/main/scala/zio/prelude/AssociativeFlatten.scala
+++ b/src/main/scala/zio/prelude/AssociativeFlatten.scala
@@ -107,16 +107,6 @@ object AssociativeFlatten extends LawfulF.Covariant[AssociativeFlattenCovariantD
     }
 
   /**
-   * The `AssociativeFlatten` and `IdentityFlatten` instance for `Id`.
-   */
-  implicit val IdIdentityFlatten: IdentityFlatten[Id] =
-    new IdentityFlatten[Id] {
-      def any: Id[Any] = Id(())
-
-      def flatten[A](ffa: Id[Id[A]]): Id[A] = Id.unwrap(ffa)
-    }
-
-  /**
    * The `AssociativeFlatten` and `IdentityFlatten` instance for `List`.
    */
   implicit val ListIdentityFlatten: IdentityFlatten[List] =

--- a/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -60,14 +60,6 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     }
 
   /**
-   * The `CommutativeBoth` instance for `Id`.
-   */
-  implicit val IdCommutativeBoth: CommutativeBoth[Id] =
-    new CommutativeBoth[Id] {
-      def both[A, B](fa: => Id[A], fb: => Id[B]): Id[(A, B)] = Id((Id.unwrap(fa), Id.unwrap(fb)))
-    }
-
-  /**
    * The `CommutativeBoth` instance for `List`.
    */
   implicit def ListCommutativeBoth: CommutativeBoth[List] =

--- a/src/main/scala/zio/prelude/Id.scala
+++ b/src/main/scala/zio/prelude/Id.scala
@@ -1,6 +1,49 @@
 package zio.prelude
 
 trait IdExports {
-  object Id extends NewtypeF
+
   type Id[+A] = Id.Type[A]
+
+  object Id extends NewtypeF {
+
+    /**
+     * The `CommutativeBoth` instance for `Id`.
+     */
+    implicit val IdCommutativeBoth: CommutativeBoth[Id] =
+      new CommutativeBoth[Id] {
+        def both[A, B](fa: => Id[A], fb: => Id[B]): Id[(A, B)] = Id((Id.unwrap(fa), Id.unwrap(fb)))
+      }
+
+    /**
+     * The `Covariant` (and thus `Invariant`) instance for `Id`.
+     */
+    implicit val IdCovariant: Covariant[Id] =
+      new Covariant[Id] {
+        def map[A, B](f: A => B): Id[A] => Id[B] = { id =>
+          Id(f(Id.unwrap(id)))
+        }
+      }
+
+    /**
+     * The `IdentityBoth` (and `AssociativeBoth`) instance for `Id`.
+     */
+    implicit val IdIdentityBoth: IdentityBoth[Id] =
+      new IdentityBoth[Id] {
+        val any: Id[Any] = Id(())
+
+        def both[A, B](fa: => Id[A], fb: => Id[B]): Id[(A, B)] =
+          Id(Id.unwrap(fa) -> Id.unwrap(fb))
+      }
+
+    /**
+     * The `AssociativeFlatten` and `IdentityFlatten` instance for `Id`.
+     */
+    implicit val IdIdentityFlatten: IdentityFlatten[Id] =
+      new IdentityFlatten[Id] {
+        def any: Id[Any] = Id(())
+
+        def flatten[A](ffa: Id[Id[A]]): Id[A] = Id.unwrap(ffa)
+      }
+  }
+
 }

--- a/src/main/scala/zio/prelude/Invariant.scala
+++ b/src/main/scala/zio/prelude/Invariant.scala
@@ -591,16 +591,6 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
       }
     }
 
-  /**
-   * The `Covariant` (and thus `Invariant`) instance for `Id`.
-   */
-  implicit val IdCovariant: Covariant[Id] =
-    new Covariant[Id] {
-      def map[A, B](f: A => B): Id[A] => Id[B] = { id =>
-        Id(f(Id.unwrap(id)))
-      }
-    }
-
   implicit val IdentityInvariant: Invariant[Identity] =
     new Invariant[Identity] {
       def invmap[A, B](f: A <=> B): Identity[A] <=> Identity[B] =

--- a/src/main/scala/zio/prelude/NewtypeModuleF.scala
+++ b/src/main/scala/zio/prelude/NewtypeModuleF.scala
@@ -45,7 +45,6 @@ package zio.prelude
  *
  * def sum[A](as: List[A])(implicit A: Associative[Sum[A]] with Identity[Sum[A]]): A =
  *   Sum.unwrap(Sum.wrapAll(as).foldLeft(A.identity)((b, a) => A.combine(b, a)))
- * }}}
  *
  * sum(List(1, 2, 3))
  * sum(List(1L, 2L, 3L))


### PR DESCRIPTION
This doesn't seem to be possible. `zio.prelude.Id` type is just a type variable, so the `zio.prelude.Id` object isn't actually a companion object and thus Scala doesn't look there for implicits :disappointed: 
```scala
[error] /home/ondra/Projects/zio-prelude/src/main/scala/zio/prelude/Traversable.scala:136:50: No implicit IdentityBoth defined for zio.prelude.Id.
[error]     (fa: F[A]) => Id.unwrap(foreach[Id, A, B](fa)((a: A) => Id(f(a))))
[error]                                                  ^
```

/cc @adamgfraser @jdegoes 
