### PR TITLE
Derive (Associative/Identity)Both from Covariant and (Associative/Identity)Flatten

### DIFF
--- a/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -57,6 +57,14 @@ object AssociativeBoth extends LawfulF.Invariant[AssociativeBothDeriveEqualInvar
   val laws: LawsF.Invariant[AssociativeBothDeriveEqualInvariant, Equal] =
     associativityLaw
 
+  def fromCovariantAssociativeFlatten[F[+_]](implicit
+    covariant: Covariant[F],
+    identityFlatten: AssociativeFlatten[F]
+  ): AssociativeBoth[F] =
+    new AssociativeBoth[F] {
+      override def both[A, B](fa: => F[A], fb: => F[B]): F[(A, B)] = fa.map(a => fb.map(b => (a, b))).flatten
+    }
+
   /**
    * Combines 2 `F` values using the provided function `f`.
    */

--- a/src/main/scala/zio/prelude/IdentityBoth.scala
+++ b/src/main/scala/zio/prelude/IdentityBoth.scala
@@ -63,6 +63,17 @@ object IdentityBoth extends LawfulF.Invariant[DeriveEqualIdentityBothInvariant, 
    */
   def apply[F[_]](implicit identityBoth: IdentityBoth[F]): IdentityBoth[F] =
     identityBoth
+
+  def fromCovariantIdentityFlatten[F[+_]](implicit
+    covariant: Covariant[F],
+    identityFlatten: IdentityFlatten[F]
+  ): IdentityBoth[F] = new IdentityBoth[F] {
+
+    override def both[A, B](fa: => F[A], fb: => F[B]): F[(A, B)] = fa.map(a => fb.map(b => (a, b))).flatten
+
+    override def any: F[Any] = identityFlatten.any
+
+  }
 }
 
 trait IdentityBothSyntax {


### PR DESCRIPTION
Is this what you had in mind @felher?
As mentioned on Discord, these derivations can't be automatic, because that would conflict with existing `Associative`/`Identity` `-Flatten` instances.
/cc @adamgfraser 
