### PR TITLE
Small improvements to the *Both and *Either hierarchies

### DIFF
--- a/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -35,7 +35,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
    * The set of law laws that instances of `CommutativeBoth` must satisfy.
    */
   val laws: LawsF.Invariant[CommutativeBothDeriveEqualInvariant, Equal] =
-    commutativeLaw
+    commutativeLaw + AssociativeBoth.laws
 
   /**
    * Summons an implicit `CommutativeBoth[F]`.

--- a/src/main/scala/zio/prelude/CommutativeEither.scala
+++ b/src/main/scala/zio/prelude/CommutativeEither.scala
@@ -37,7 +37,7 @@ object CommutativeEither extends LawfulF.Invariant[CommutativeEitherDeriveEqualI
    * The set of law laws that instances of `CommutativeEither` must satisfy.
    */
   val laws: LawsF.Invariant[CommutativeEitherDeriveEqualInvariant, Equal] =
-    commutativeLaw
+    commutativeLaw + AssociativeEither.laws
 
   /**
    * The `CommutativeEither` instance for `Future`.

--- a/src/main/scala/zio/prelude/Equal.scala
+++ b/src/main/scala/zio/prelude/Equal.scala
@@ -151,21 +151,27 @@ object Equal extends Lawful[Equal] {
       )
 
   /**
-   * The `CommutativeBoth` instance for `Equal`.
+   * The `CommutativeBoth` and `IdentityBoth` (and thus `AssociativeBoth`) instance for `Equal`.
    */
-  implicit val EqualCommutativeBoth: CommutativeBoth[Equal] =
-    new CommutativeBoth[Equal] {
+  implicit val EqualCommutativeIdentityBoth: CommutativeBoth[Equal] with IdentityBoth[Equal] =
+    new CommutativeBoth[Equal] with IdentityBoth[Equal] {
+      val any: Equal[Any] =
+        AnyHashOrd
+
       def both[A, B](fa: => Equal[A], fb: => Equal[B]): Equal[(A, B)] =
         fa.both(fb)
     }
 
   /**
-   * The `CommutativeEither` instance for `Equal`.
+   * The `CommutativeEither` and `IdentityEither` (and thus `AssociativeEither`) instance for `Equal`.
    */
-  implicit val EqualCommutativeEither: CommutativeEither[Equal] =
-    new CommutativeEither[Equal] {
+  implicit val EqualCommutativeIdentityEither: CommutativeEither[Equal] with IdentityEither[Equal] =
+    new CommutativeEither[Equal] with IdentityEither[Equal] {
       def either[A, B](fa: => Equal[A], fb: => Equal[B]): Equal[Either[A, B]] =
         fa.either(fb)
+
+      val none: Equal[Nothing] =
+        NothingHashOrd
     }
 
   /**
@@ -175,28 +181,6 @@ object Equal extends Lawful[Equal] {
     new Contravariant[Equal] {
       def contramap[A, B](f: B => A): Equal[A] => Equal[B] =
         _.contramap(f)
-    }
-
-  /**
-   * The `IdentityBoth` instance for `Equal`.
-   */
-  implicit val EqualIdentityBoth: IdentityBoth[Equal] =
-    new IdentityBoth[Equal] {
-      val any: Equal[Any]                                             =
-        AnyHashOrd
-      def both[A, B](fa: => Equal[A], fb: => Equal[B]): Equal[(A, B)] =
-        fa.both(fb)
-    }
-
-  /**
-   * The `IdentityEither` instance for `Equal`.
-   */
-  implicit val EqualIdentityEither: IdentityEither[Equal] =
-    new IdentityEither[Equal] {
-      def either[A, B](fa: => Equal[A], fb: => Equal[B]): Equal[Either[A, B]] =
-        fa.either(fb)
-      val none: Equal[Nothing]                                                =
-        NothingHashOrd
     }
 
   /**

--- a/src/main/scala/zio/prelude/Hash.scala
+++ b/src/main/scala/zio/prelude/Hash.scala
@@ -111,6 +111,30 @@ object Hash extends Lawful[Hash] {
     }
 
   /**
+   * The `IdentityBoth` (and thus `AssociativeBoth`) instance for `Hash`.
+   */
+  implicit val HashIdentityBoth: IdentityBoth[Hash] =
+    new IdentityBoth[Hash] {
+      val any: Hash[Any] =
+        Equal.AnyHashOrd
+
+      def both[A, B](fa: => Hash[A], fb: => Hash[B]): Hash[(A, B)] =
+        fa.both(fb)
+    }
+
+  /**
+   * The `IdentityEither` (and thus `AssociativeEither`) instance for `Hash`.
+   */
+  implicit val HashIdentityEither: IdentityEither[Hash] =
+    new IdentityEither[Hash] {
+      def either[A, B](fa: => Hash[A], fb: => Hash[B]): Hash[Either[A, B]] =
+        fa.either(fb)
+
+      val none: Hash[Nothing] =
+        Equal.NothingHashOrd
+    }
+
+  /**
    * Summons an implicit `Hash[A]`.
    */
   def apply[A](implicit hash: Hash[A]): Hash[A] =

--- a/src/main/scala/zio/prelude/IdentityBoth.scala
+++ b/src/main/scala/zio/prelude/IdentityBoth.scala
@@ -56,7 +56,7 @@ object IdentityBoth extends LawfulF.Invariant[DeriveEqualIdentityBothInvariant, 
    * The set of law laws that instances of `IdentityBoth` must satisfy.
    */
   val laws: LawsF.Invariant[DeriveEqualIdentityBothInvariant, Equal] =
-    leftIdentityLaw + rightIdentityLaw
+    leftIdentityLaw + rightIdentityLaw + AssociativeBoth.laws
 
   /**
    * Summons an implicit `IdentityBoth[F]`.

--- a/src/main/scala/zio/prelude/IdentityEither.scala
+++ b/src/main/scala/zio/prelude/IdentityEither.scala
@@ -52,7 +52,7 @@ object IdentityEither extends LawfulF.Invariant[DeriveEqualIdentityEitherInvaria
    * The set of law laws that instances of `IdentityEither` must satisfy.
    */
   val laws: LawsF.Invariant[DeriveEqualIdentityEitherInvariant, Equal] =
-    leftIdentityLaw + rightIdentityLaw
+    leftIdentityLaw + rightIdentityLaw + AssociativeEither.laws
 
   /**
    * Summons an implicit `IdentityEither[F]`.

--- a/src/main/scala/zio/prelude/coherent/coherent.scala
+++ b/src/main/scala/zio/prelude/coherent/coherent.scala
@@ -60,7 +60,7 @@ object AssociativeFlattenCovariantDeriveEqual {
     }
 }
 
-trait CommutativeBothDeriveEqualInvariant[F[_]] extends CommutativeBoth[F] with DeriveEqual[F] with Invariant[F]
+trait CommutativeBothDeriveEqualInvariant[F[_]] extends AssociativeBothDeriveEqualInvariant[F] with CommutativeBoth[F]
 
 object CommutativeBothDeriveEqualInvariant {
   implicit def derive[F[_]](implicit
@@ -75,7 +75,9 @@ object CommutativeBothDeriveEqualInvariant {
     }
 }
 
-trait CommutativeEitherDeriveEqualInvariant[F[_]] extends CommutativeEither[F] with DeriveEqual[F] with Invariant[F]
+trait CommutativeEitherDeriveEqualInvariant[F[_]]
+    extends AssociativeEitherDeriveEqualInvariant[F]
+    with CommutativeEither[F]
 
 object CommutativeEitherDeriveEqualInvariant {
   implicit def derive[F[_]](implicit
@@ -149,7 +151,7 @@ object CovariantDeriveEqualIdentityFlatten {
     }
 }
 
-trait DeriveEqualIdentityBothInvariant[F[_]] extends DeriveEqual[F] with IdentityBoth[F] with Invariant[F]
+trait DeriveEqualIdentityBothInvariant[F[_]] extends AssociativeBothDeriveEqualInvariant[F] with IdentityBoth[F]
 
 object DeriveEqualIdentityBothInvariant {
   implicit def derive[F[_]](implicit
@@ -165,7 +167,7 @@ object DeriveEqualIdentityBothInvariant {
     }
 }
 
-trait DeriveEqualIdentityEitherInvariant[F[_]] extends DeriveEqual[F] with IdentityEither[F] with Invariant[F]
+trait DeriveEqualIdentityEitherInvariant[F[_]] extends AssociativeEitherDeriveEqualInvariant[F] with IdentityEither[F]
 
 object DeriveEqualIdentityEitherInvariant {
   implicit def derive[F[_]](implicit


### PR DESCRIPTION
Add instances for `Hash`.
Condense the instances for `Equal`.