### PR TITLE
Add instances for Commutative, Idempotent for Min[BigDecimal], Max[BigDecimal], Prod[BigDecimal], and Sum[BigDecimal]

### DIFF
--- a/src/main/scala/zio/prelude/Associative.scala
+++ b/src/main/scala/zio/prelude/Associative.scala
@@ -133,7 +133,7 @@ object Associative extends Lawful[AssociativeEqual] {
   /**
    * The `Commutative`, `Idempotent` instance for the max of `BigDecimal` values
    */
-  implicit val BigDecimalMaxIdempotent: Commutative[Max[BigDecimal]] with Idempotent[Max[BigDecimal]] =
+  implicit val BigDecimalMaxCommutativeIdempotent: Commutative[Max[BigDecimal]] with Idempotent[Max[BigDecimal]] =
     new Commutative[Max[BigDecimal]] with Idempotent[Max[BigDecimal]] {
       override def combine(l: => Max[BigDecimal], r: => Max[BigDecimal]): Max[BigDecimal] = Max(l max r)
     }
@@ -141,7 +141,7 @@ object Associative extends Lawful[AssociativeEqual] {
   /**
    * The `Commutative`, `Idempotent` instance for the min of `BigDecimal` values
    */
-  implicit val BigDecimalMinIdempotent: Commutative[Min[BigDecimal]] with Idempotent[Min[BigDecimal]] =
+  implicit val BigDecimalMinCommutativeIdempotent: Commutative[Min[BigDecimal]] with Idempotent[Min[BigDecimal]] =
     new Commutative[Min[BigDecimal]] with Idempotent[Min[BigDecimal]] {
       override def combine(l: => Min[BigDecimal], r: => Min[BigDecimal]): Min[BigDecimal] = Min(l min r)
     }
@@ -149,7 +149,7 @@ object Associative extends Lawful[AssociativeEqual] {
   /**
    * The `Commutative`, `Idempotent` instance for the product of `BigDecimal` values
    */
-  implicit val BigDecimalProdIdempotent: Commutative[Prod[BigDecimal]] with Idempotent[Prod[BigDecimal]] =
+  implicit val BigDecimalProdCommutativeIdempotent: Commutative[Prod[BigDecimal]] with Idempotent[Prod[BigDecimal]] =
     new Commutative[Prod[BigDecimal]] with Idempotent[Prod[BigDecimal]] {
       override def combine(l: => Prod[BigDecimal], r: => Prod[BigDecimal]): Prod[BigDecimal] = Prod(l * r)
     }
@@ -157,7 +157,7 @@ object Associative extends Lawful[AssociativeEqual] {
   /**
    * The `Commutative`, `Idempotent` instance for the sum of `BigDecimal` values
    */
-  implicit val BigDecimalSumIdempotent: Commutative[Sum[BigDecimal]] with Idempotent[Sum[BigDecimal]] =
+  implicit val BigDecimalSumCommutativeIdempotent: Commutative[Sum[BigDecimal]] with Idempotent[Sum[BigDecimal]] =
     new Commutative[Sum[BigDecimal]] with Idempotent[Sum[BigDecimal]] {
       override def combine(l: => Sum[BigDecimal], r: => Sum[BigDecimal]): Sum[BigDecimal] = Sum(l + r)
     }

--- a/src/main/scala/zio/prelude/Associative.scala
+++ b/src/main/scala/zio/prelude/Associative.scala
@@ -131,6 +131,38 @@ object Associative extends Lawful[AssociativeEqual] {
     }
 
   /**
+   * The `Commutative`, `Idempotent` instance for the max of `BigDecimal` values
+   */
+  implicit val BigDecimalMaxIdempotent: Commutative[Max[BigDecimal]] with Idempotent[Max[BigDecimal]] =
+    new Commutative[Max[BigDecimal]] with Idempotent[Max[BigDecimal]] {
+      override def combine(l: => Max[BigDecimal], r: => Max[BigDecimal]): Max[BigDecimal] = Max(l max r)
+    }
+
+  /**
+   * The `Commutative`, `Idempotent` instance for the min of `BigDecimal` values
+   */
+  implicit val BigDecimalMinIdempotent: Commutative[Min[BigDecimal]] with Idempotent[Min[BigDecimal]] =
+    new Commutative[Min[BigDecimal]] with Idempotent[Min[BigDecimal]] {
+      override def combine(l: => Min[BigDecimal], r: => Min[BigDecimal]): Min[BigDecimal] = Min(l min r)
+    }
+
+  /**
+   * The `Commutative`, `Idempotent` instance for the product of `BigDecimal` values
+   */
+  implicit val BigDecimalProdIdempotent: Commutative[Prod[BigDecimal]] with Idempotent[Prod[BigDecimal]] =
+    new Commutative[Prod[BigDecimal]] with Idempotent[Prod[BigDecimal]] {
+      override def combine(l: => Prod[BigDecimal], r: => Prod[BigDecimal]): Prod[BigDecimal] = Prod(l * r)
+    }
+
+  /**
+   * The `Commutative`, `Idempotent` instance for the sum of `BigDecimal` values
+   */
+  implicit val BigDecimalSumIdempotent: Commutative[Sum[BigDecimal]] with Idempotent[Sum[BigDecimal]] =
+    new Commutative[Sum[BigDecimal]] with Idempotent[Sum[BigDecimal]] {
+      override def combine(l: => Sum[BigDecimal], r: => Sum[BigDecimal]): Sum[BigDecimal] = Sum(l + r)
+    }
+
+  /**
    * The `Commutative`, `Idempotent` and `Identity` instance for the max of `Byte` values.
    */
   implicit val ByteMaxIdempotentIdentity: Commutative[Max[Byte]] with Idempotent[Max[Byte]] with Identity[Max[Byte]] =


### PR DESCRIPTION
Add instances for Commutative, Idempotent for Min[BigDecimal], Max[BigDecimal], Prod[BigDecimal], and Sum[BigDecimal]

Fixes #385 , #384 , #383 , #382 