### PR TITLE
Install JRE, hopefully fixes issues of using wrong Java version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ install_jdk: &install_jdk
         elif [ $JDK_VERSION == 8 ]; then
           sudo apt install -y openjdk-8-jre-headless
           ls -alh /usr/lib/jvm/
-          sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/bin/java
+          sudo update-alternatives --set java /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java
         fi
         java -version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,9 +42,10 @@ install_jdk: &install_jdk
         fi
         sudo apt update
         if [ $JDK_VERSION == 11 ]; then
+          sudo apt remove -y openjdk-8-jre-headless
           sudo apt install -y adoptopenjdk-11-hotspot-jre
         elif [ $JDK_VERSION == 8 ]; then
-          sudo apt install -y openjdk-8-jdk
+          sudo apt install -y openjdk-8-jre-headless
         fi
         java -version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,10 @@ install_jdk: &install_jdk
         fi
         sudo apt update
         if [ $JDK_VERSION == 11 ]; then
-          sudo apt install -y adoptopenjdk-11-hotspot-jre
+          sudo apt install -y --no-install-recommends adoptopenjdk-11-hotspot-jre
           sudo update-alternatives --set java /usr/lib/jvm/adoptopenjdk-11-hotspot-jre-amd64/bin/java
         elif [ $JDK_VERSION == 8 ]; then
-          sudo apt install -y openjdk-8-jre-headless
+          sudo apt install -y --no-install-recommends openjdk-8-jre-headless
           ls -alh /usr/lib/jvm/
           sudo update-alternatives --set java /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java
         fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ install_jdk: &install_jdk
         elif [ $JDK_VERSION == 8 ]; then
           sudo apt install -y --no-install-recommends openjdk-8-jre-headless
           ls -alh /usr/lib/jvm/
+          sudo update-alternatives --list java
           sudo update-alternatives --set java /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java
         fi
         java -version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ install_jdk: &install_jdk
         fi
         sudo apt update
         if [ $JDK_VERSION == 11 ]; then
-          sudo apt install -y adoptopenjdk-11-hotspot
+          sudo apt install -y adoptopenjdk-11-hotspot-jre
         elif [ $JDK_VERSION == 8 ]; then
           sudo apt install -y openjdk-8-jdk
         fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,10 +42,11 @@ install_jdk: &install_jdk
         fi
         sudo apt update
         if [ $JDK_VERSION == 11 ]; then
-          sudo apt remove -y openjdk-8-jre-headless
           sudo apt install -y adoptopenjdk-11-hotspot-jre
+          sudo update-alternatives --set java /usr/lib/jvm/adoptopenjdk-11-hotspot-jre-amd64/bin/java
         elif [ $JDK_VERSION == 8 ]; then
           sudo apt install -y openjdk-8-jre-headless
+          sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/bin/java
         fi
         java -version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,9 +46,7 @@ install_jdk: &install_jdk
           sudo update-alternatives --set java /usr/lib/jvm/adoptopenjdk-11-hotspot-jre-amd64/bin/java
         elif [ $JDK_VERSION == 8 ]; then
           sudo apt install -y --no-install-recommends openjdk-8-jre-headless
-          ls -alh /usr/lib/jvm/
-          sudo update-alternatives --list java
-          sudo update-alternatives --set java /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java
+          sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
         fi
         java -version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ install_jdk: &install_jdk
           sudo update-alternatives --set java /usr/lib/jvm/adoptopenjdk-11-hotspot-jre-amd64/bin/java
         elif [ $JDK_VERSION == 8 ]; then
           sudo apt install -y openjdk-8-jre-headless
+          ls -alh /usr/lib/jvm/
           sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/bin/java
         fi
         java -version


### PR DESCRIPTION
There's potentially serious issue with using Java 8 (instead of 11 where we want it). It's visible if you see the output of `java -version` in the Install Java step in CircleCI.
Hopefully, this will fix it.
/cc @mijicd @softinio 
