### PR TITLE
Initial support for scala-native

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,19 @@ testJVM: &testJVM
     - store_test_results:
         path: core/jvm/target/test-reports
 
+testNative: &testNative
+  steps:
+    - checkout
+    - <<: *load_cache
+    - <<: *install_jdk
+    - run:
+        name: Run tests
+        command: ./sbt -Dfatal.warnings=true ++${SCALA_VERSION}! compileNative
+    - <<: *clean_cache
+    - <<: *save_cache
+    - store_test_results:
+        path: core/jvm/target/test-reports
+
 release: &release
   steps:
       - checkout
@@ -233,6 +246,13 @@ jobs:
 
   test_211_jdk8_jvm:
     <<: *testJVM
+    <<: *machine_ubuntu
+    environment:
+      - <<: *scala_211
+      - <<: *jdk_8
+
+  test_211_jdk8_jvm:
+    <<: *testNative
     <<: *machine_ubuntu
     environment:
       - <<: *scala_211

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs:
       - <<: *scala_211
       - <<: *jdk_8
 
-  test_211_jdk8_jvm:
+  test_211_jdk8_native:
     <<: *testNative
     <<: *machine_ubuntu
     environment:

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ inThisBuild(
     pgpSecretRing := file("/tmp/secret.asc"),
     scmInfo := Some(
       ScmInfo(url("https://github.com/zio/zio-prelude/"), "scm:git:git@github.com:zio/zio-prelude.git")
-    ),
+    )
   )
 )
 
@@ -60,8 +60,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies ++= {
       val spc = List("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.0" % Optional)
       Seq(
-        "dev.zio" %%% "zio"          % zioVersion,
-        "dev.zio" %%% "zio-test"     % zioVersion,
+        "dev.zio" %%% "zio"      % zioVersion,
+        "dev.zio" %%% "zio-test" % zioVersion
       ) ++
         (scalaVersion.value match {
           case BuildHelper.Scala213   => spc
@@ -73,11 +73,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")))
   .enablePlugins(BuildInfoPlugin)
 
-lazy val coreJS = core.js
+lazy val coreJS     = core.js
   .settings(jsSettings)
   .settings(libraryDependencies += "dev.zio" %%% "zio-test-sbt" % zioVersion)
 
-lazy val coreJVM = core.jvm
+lazy val coreJVM    = core.jvm
   .settings(dottySettings)
   .settings(libraryDependencies += "dev.zio" %%% "zio-test-sbt" % zioVersion)
 
@@ -86,7 +86,7 @@ lazy val coreNative = core.native
   .settings(crossScalaVersions := Seq(scalaVersion.value))
   .settings(skip in Test := true)
   .settings(skip in doc := true)
-  .settings( // Exclude from Intellij because Scala Native projects break it - https://github.com/scala-native/scala-native/issues/1007#issuecomment-370402092
+  .settings(       // Exclude from Intellij because Scala Native projects break it - https://github.com/scala-native/scala-native/issues/1007#issuecomment-370402092
     SettingKey[Boolean]("ide-skip-project") := true
   )
   .settings(sources in (Compile, doc) := Seq.empty)

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ inThisBuild(
     pgpSecretRing := file("/tmp/secret.asc"),
     scmInfo := Some(
       ScmInfo(url("https://github.com/zio/zio-prelude/"), "scm:git:git@github.com:zio/zio-prelude.git")
-    )
+    ),
   )
 )
 
@@ -44,12 +44,13 @@ lazy val root = project
   .aggregate(
     coreJVM,
     coreJS,
+    coreNative,
     benchmarks,
     docs
   )
   .enablePlugins(ScalaJSPlugin)
 
-lazy val core = crossProject(JSPlatform, JVMPlatform)
+lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("core"))
   .settings(stdSettings("zio-prelude"))
   .settings(crossProjectSettings)
@@ -61,7 +62,6 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       Seq(
         "dev.zio" %%% "zio"          % zioVersion,
         "dev.zio" %%% "zio-test"     % zioVersion,
-        "dev.zio" %%% "zio-test-sbt" % zioVersion
       ) ++
         (scalaVersion.value match {
           case BuildHelper.Scala213   => spc
@@ -75,9 +75,28 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
 
 lazy val coreJS = core.js
   .settings(jsSettings)
+  .settings(libraryDependencies += "dev.zio" %%% "zio-test-sbt" % zioVersion)
 
 lazy val coreJVM = core.jvm
   .settings(dottySettings)
+  .settings(libraryDependencies += "dev.zio" %%% "zio-test-sbt" % zioVersion)
+
+lazy val coreNative = core.native
+  .settings(scalaVersion := Scala211)
+  .settings(crossScalaVersions := Seq(scalaVersion.value))
+  .settings(skip in Test := true)
+  .settings(skip in doc := true)
+  .settings( // Exclude from Intellij because Scala Native projects break it - https://github.com/scala-native/scala-native/issues/1007#issuecomment-370402092
+    SettingKey[Boolean]("ide-skip-project") := true
+  )
+  .settings(sources in (Compile, doc) := Seq.empty)
+  .settings(
+    resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+    dependencyOverrides += "dev.zio" %%% "zio" % "1.0.3+68-eaa7424f-SNAPSHOT"
+  )
+  .disablePlugins(
+    ScalafixPlugin // for some reason `ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)` isn't enough
+  )
 
 lazy val benchmarks = project.module
   .settings(

--- a/core/native/src/main/scala/PlatformSpecificAssociativeSyntax.scala
+++ b/core/native/src/main/scala/PlatformSpecificAssociativeSyntax.scala
@@ -1,0 +1,3 @@
+package zio.prelude
+
+trait PlatformSpecificAssociativeSyntax {}

--- a/core/native/src/main/scala/PlatformSpecificIdentitySyntax.scala
+++ b/core/native/src/main/scala/PlatformSpecificIdentitySyntax.scala
@@ -1,0 +1,3 @@
+package zio.prelude
+
+trait PlatformSpecificIdentitySyntax {}


### PR DESCRIPTION
Adds scala-native builds (https://github.com/zio/zio-prelude/issues/370), only works with latest snapshot because for `1.0.3` the `zio-stacktracer` dependency was not published.