### PR TITLE
Add Experimental Module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val experimentalNative = core.native
   .settings(crossScalaVersions := Seq(scalaVersion.value))
   .settings(skip in Test := true)
   .settings(skip in doc := true)
-  .settings(       // Exclude from Intellij because Scala Native projects break it - https://github.com/scala-native/scala-native/issues/1007#issuecomment-370402092
+  .settings( // Exclude from Intellij because Scala Native projects break it - https://github.com/scala-native/scala-native/issues/1007#issuecomment-370402092
     SettingKey[Boolean]("ide-skip-project") := true
   )
   .settings(sources in (Compile, doc) := Seq.empty)

--- a/build.sbt
+++ b/build.sbt
@@ -26,15 +26,15 @@ addCommandAlias("fix", "; all compile:scalafix test:scalafix; all scalafmtSbt sc
 addCommandAlias("check", "; scalafmtSbtCheck; scalafmtCheckAll; compile:scalafix --check; test:scalafix --check")
 addCommandAlias(
   "testJVM",
-  ";coreJVM/test"
+  ";coreJVM/test;experimentalJVM/test"
 )
 addCommandAlias(
   "testJS",
-  ";coreJS/test"
+  ";coreJS/test;experimentalJVM/test"
 )
 addCommandAlias(
   "testNative",
-  ";coreNative/test:compile"
+  ";coreNative/test:compile;experimentalJVM/test"
 )
 
 val zioVersion = "1.0.3"
@@ -49,6 +49,9 @@ lazy val root = project
     coreJVM,
     coreJS,
     coreNative,
+    experimentalJVM,
+    experimentalJS,
+    experimentalNative,
     benchmarks,
     docs
   )

--- a/build.sbt
+++ b/build.sbt
@@ -102,6 +102,35 @@ lazy val coreNative = core.native
     ScalafixPlugin // for some reason `ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)` isn't enough
   )
 
+lazy val experimental = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .in(file("experimental"))
+  .dependsOn(core)
+  .settings(stdSettings("zio-prelude-experimental"))
+  .settings(crossProjectSettings)
+  .settings(buildInfoSettings("zio.prelude.experimental"))
+
+lazy val experimentalJVM    = core.jvm
+  .settings(dottySettings)
+  .settings(libraryDependencies += "dev.zio" %%% "zio-test-sbt" % zioVersion)
+
+lazy val experimentalJS     = core.js
+  .settings(jsSettings)
+  .settings(libraryDependencies += "dev.zio" %%% "zio-test-sbt" % zioVersion)
+
+lazy val experimentalNative = core.native
+  .settings(scalaVersion := Scala211)
+  .settings(crossScalaVersions := Seq(scalaVersion.value))
+  .settings(skip in Test := true)
+  .settings(skip in doc := true)
+  .settings(       // Exclude from Intellij because Scala Native projects break it - https://github.com/scala-native/scala-native/issues/1007#issuecomment-370402092
+    SettingKey[Boolean]("ide-skip-project") := true
+  )
+  .settings(sources in (Compile, doc) := Seq.empty)
+  .settings(
+    resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+    dependencyOverrides += "dev.zio" %%% "zio" % "1.0.3+68-eaa7424f-SNAPSHOT"
+  )
+
 lazy val benchmarks = project.module
   .settings(
     skip.in(publish) := true,


### PR DESCRIPTION
Resolves #412.

Adds `experimental` module under namespace `zio.prelude.experimental`. We have a lot of really interesting work going on regarding zivariant, semiring, and lattice structures among others. I think we are being hampered a bit because these things are pushing the boundaries in various directions so we don't want to merge them but that also means it is harder for people to try them out or do further work on top of them. This way we can be more liberal in getting things into the experimental package and then if we feel good about them or get traction we can potentially move to the main package.