### PR TITLE
Use IntelliJ's default order for Organize Imports

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -20,11 +20,11 @@ Disable {
 OrganizeImports {
   expandRelative = true
   groupedImports = Merge
+  # IntelliJ IDEA's order so that they don't fight each other
   groups = [
     "java."
-    "scala."
-    "zio."
     "*"
+    "scala."
   ]
 }
 

--- a/core/jvm/src/test/scala/zio/prelude/AssociativeParIterableSpec.scala
+++ b/core/jvm/src/test/scala/zio/prelude/AssociativeParIterableSpec.scala
@@ -1,10 +1,9 @@
 package zio.prelude
 
+import com.github.ghik.silencer.silent
 import zio.blocking.Blocking
 import zio.prelude.newtypes.Sum
 import zio.test._
-
-import com.github.ghik.silencer.silent
 
 @silent
 object AssociativeParIterableSpec extends DefaultRunnableSpec {

--- a/core/jvm/src/test/scala/zio/prelude/CommutativeEitherSpec.scala
+++ b/core/jvm/src/test/scala/zio/prelude/CommutativeEitherSpec.scala
@@ -1,9 +1,9 @@
 package zio.prelude
 
-import scala.concurrent.{ Future, blocking }
-
 import zio.ZIO
 import zio.test._
+
+import scala.concurrent.{ Future, blocking }
 
 object CommutativeEitherSpec extends DefaultRunnableSpec {
 

--- a/core/jvm/src/test/scala/zio/prelude/IdentityParIterableSpec.scala
+++ b/core/jvm/src/test/scala/zio/prelude/IdentityParIterableSpec.scala
@@ -1,10 +1,9 @@
 package zio.prelude
 
+import com.github.ghik.silencer.silent
 import zio.blocking.Blocking
 import zio.prelude.newtypes.Sum
 import zio.test._
-
-import com.github.ghik.silencer.silent
 
 @silent
 object IdentityParIterableSpec extends DefaultRunnableSpec {

--- a/core/shared/src/main/scala/zio/prelude/Associative.scala
+++ b/core/shared/src/main/scala/zio/prelude/Associative.scala
@@ -1,12 +1,12 @@
 package zio.prelude
 
-import scala.annotation.tailrec
-
 import zio.prelude.coherent.AssociativeEqual
 import zio.prelude.newtypes.{ And, First, Last, Max, Min, Or, Prod, Sum }
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
 import zio.{ Chunk, NonEmptyChunk }
+
+import scala.annotation.tailrec
 
 /**
  * The `Associative[A]` type class describes an associative binary operator

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1,9 +1,5 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-import scala.concurrent.Future
-import scala.util.{ Success, Try }
-
 import zio._
 import zio.prelude.coherent.AssociativeBothDeriveEqualInvariant
 import zio.prelude.newtypes.{ AndF, Failure, OrF }
@@ -11,6 +7,10 @@ import zio.stm.ZSTM
 import zio.stream.{ ZSink, ZStream }
 import zio.test.TestResult
 import zio.test.laws._
+
+import scala.annotation.implicitNotFound
+import scala.concurrent.Future
+import scala.util.{ Success, Try }
 
 /**
  * An associative binary operator that combines two values of types `F[A]`

--- a/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
@@ -1,15 +1,15 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.Try
-
 import zio._
 import zio.prelude.coherent.AssociativeEitherDeriveEqualInvariant
 import zio.prelude.newtypes.Failure
 import zio.stream.ZStream
 import zio.test.TestResult
 import zio.test.laws._
+
+import scala.annotation.implicitNotFound
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Try
 
 /**
  * An associative binary operator that combines two values of types `F[A]`

--- a/core/shared/src/main/scala/zio/prelude/AssociativeFlatten.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeFlatten.scala
@@ -1,14 +1,14 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-import scala.concurrent.Future
-import scala.util.{ Success, Try }
-
 import zio._
 import zio.prelude.coherent.AssociativeFlattenCovariantDeriveEqual
 import zio.stream.ZStream
 import zio.test.TestResult
 import zio.test.laws._
+
+import scala.annotation.implicitNotFound
+import scala.concurrent.Future
+import scala.util.{ Success, Try }
 
 /**
  * `AssociativeFlatten` describes a type that can be "flattened" in an

--- a/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -1,13 +1,13 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-
 import zio._
 import zio.prelude.coherent.CommutativeBothDeriveEqualInvariant
 import zio.prelude.newtypes.{ AndF, Failure, OrF }
 import zio.stream.{ ZSink, ZStream }
 import zio.test.TestResult
 import zio.test.laws._
+
+import scala.annotation.implicitNotFound
 
 /**
  * A commutative binary operator that combines two values of types `F[A]` and

--- a/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
@@ -1,13 +1,13 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-import scala.concurrent.{ ExecutionContext, Future, Promise }
-
 import zio.ZIO
 import zio.prelude.coherent.CommutativeEitherDeriveEqualInvariant
 import zio.stream.{ ZSink, ZStream }
 import zio.test.TestResult
 import zio.test.laws._
+
+import scala.annotation.implicitNotFound
+import scala.concurrent.{ ExecutionContext, Future, Promise }
 
 /**
  * A commutative binary operator that combines two values of types `F[A]` and

--- a/core/shared/src/main/scala/zio/prelude/Debug.scala
+++ b/core/shared/src/main/scala/zio/prelude/Debug.scala
@@ -1,8 +1,8 @@
 package zio.prelude
 
-import scala.collection.immutable.ListMap
-
 import zio.{ Chunk, NonEmptyChunk }
+
+import scala.collection.immutable.ListMap
 
 trait Debug[-A] {
   def debug(a: A): Debug.Repr

--- a/core/shared/src/main/scala/zio/prelude/Derive.scala
+++ b/core/shared/src/main/scala/zio/prelude/Derive.scala
@@ -1,8 +1,8 @@
 package zio.prelude
 
-import scala.util.Try
-
 import zio.{ Cause, Chunk, Exit, NonEmptyChunk }
+
+import scala.util.Try
 
 /**
  * `Derive[F, Typeclass]` represents a universally quantified function from

--- a/core/shared/src/main/scala/zio/prelude/Equal.scala
+++ b/core/shared/src/main/scala/zio/prelude/Equal.scala
@@ -1,14 +1,14 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-import scala.util.Try
-import scala.{ math => sm }
-
 import zio.Exit.{ Failure, Success }
 import zio.prelude.coherent.HashOrd
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
 import zio.{ Cause, Chunk, Exit, Fiber, NonEmptyChunk, ZTrace }
+
+import scala.annotation.implicitNotFound
+import scala.util.Try
+import scala.{ math => sm }
 
 /**
  * `Equal[A]` provides implicit evidence that two values of type `A` can be

--- a/core/shared/src/main/scala/zio/prelude/GenFs.scala
+++ b/core/shared/src/main/scala/zio/prelude/GenFs.scala
@@ -1,14 +1,14 @@
 package zio.prelude
 
-import scala.concurrent.Future
-import scala.util.Try
-
 import zio.prelude.newtypes.Failure
 import zio.random.Random
 import zio.test.Gen.oneOf
 import zio.test._
 import zio.test.laws.GenF
 import zio.{ Cause, Exit, NonEmptyChunk }
+
+import scala.concurrent.Future
+import scala.util.Try
 
 /**
  * Provides higher kinded generators.

--- a/core/shared/src/main/scala/zio/prelude/Hash.scala
+++ b/core/shared/src/main/scala/zio/prelude/Hash.scala
@@ -1,10 +1,10 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
 import zio.{ Chunk, NonEmptyChunk }
+
+import scala.annotation.implicitNotFound
 
 /**
  * `Hash[A]` provides implicit evidence that a value of type `A` can be hashed.

--- a/core/shared/src/main/scala/zio/prelude/IdentityBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/IdentityBoth.scala
@@ -1,12 +1,11 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-
+import com.github.ghik.silencer.silent
 import zio.prelude.coherent.DeriveEqualIdentityBothInvariant
 import zio.test.TestResult
 import zio.test.laws._
 
-import com.github.ghik.silencer.silent
+import scala.annotation.implicitNotFound
 
 /**
  * A binary operator that combines two values of types `F[A]` and `F[B]` to

--- a/core/shared/src/main/scala/zio/prelude/IdentityEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/IdentityEither.scala
@@ -1,10 +1,10 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-
 import zio.prelude.coherent.DeriveEqualIdentityEitherInvariant
 import zio.test.TestResult
 import zio.test.laws._
+
+import scala.annotation.implicitNotFound
 
 /**
  * A binary operator that combines two values of types `F[A]` and `F[B]` to

--- a/core/shared/src/main/scala/zio/prelude/IdentityFlatten.scala
+++ b/core/shared/src/main/scala/zio/prelude/IdentityFlatten.scala
@@ -1,10 +1,10 @@
 package zio.prelude
 
-import scala.annotation.implicitNotFound
-
 import zio.prelude.coherent.CovariantDeriveEqualIdentityFlatten
 import zio.test.TestResult
 import zio.test.laws._
+
+import scala.annotation.implicitNotFound
 
 /**
  * `IdentityFlatten` described a type that can be "flattened" in an

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -1,8 +1,5 @@
 package zio.prelude
 
-import scala.concurrent.{ ExecutionContext, Future }
-import scala.util.Try
-
 import zio.prelude.newtypes.{ Failure, FailureIn, FailureOut }
 import zio.stm.ZSTM
 import zio.stream.{ ZSink, ZStream }
@@ -21,6 +18,9 @@ import zio.{
   ZRef,
   ZRefM
 }
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.Try
 
 trait Invariant[F[_]] { self =>
 

--- a/core/shared/src/main/scala/zio/prelude/Inverse.scala
+++ b/core/shared/src/main/scala/zio/prelude/Inverse.scala
@@ -1,10 +1,10 @@
 package zio.prelude
 
-import scala.annotation.tailrec
-
 import zio.prelude.coherent.EqualInverse
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
+
+import scala.annotation.tailrec
 
 /**
  * The `Inverse` type class describes an associative binary operator for a

--- a/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -1,12 +1,12 @@
 package zio.prelude
 
-import scala.annotation.tailrec
-import scala.language.implicitConversions
-import scala.util.hashing.MurmurHash3
-
 import zio.NonEmptyChunk
 import zio.prelude.NonEmptyList._
 import zio.prelude.newtypes.{ Max, Min, Prod, Sum }
+
+import scala.annotation.tailrec
+import scala.language.implicitConversions
+import scala.util.hashing.MurmurHash3
 
 /**
  * A `NonEmptyList[A]` is a list of one or more values of type A. Unlike a

--- a/core/shared/src/main/scala/zio/prelude/NonEmptySet.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptySet.scala
@@ -1,8 +1,8 @@
 package zio.prelude
 
-import scala.language.implicitConversions
-
 import zio.NonEmptyChunk
+
+import scala.language.implicitConversions
 
 final class NonEmptySet[A] private (private val set: Set[A]) { self =>
 

--- a/core/shared/src/main/scala/zio/prelude/Ord.scala
+++ b/core/shared/src/main/scala/zio/prelude/Ord.scala
@@ -1,13 +1,13 @@
 package zio.prelude
 
-import scala.annotation.{ implicitNotFound, tailrec }
-import scala.{ math => sm }
-
 import zio.prelude.Equal._
 import zio.prelude.coherent.HashOrd
 import zio.test.TestResult
 import zio.test.laws.{ Lawful, Laws }
 import zio.{ Chunk, NonEmptyChunk }
+
+import scala.annotation.{ implicitNotFound, tailrec }
+import scala.{ math => sm }
 
 /**
  * `Ord[A]` provides implicit evidence that values of type `A` have a total

--- a/core/shared/src/main/scala/zio/prelude/Validation.scala
+++ b/core/shared/src/main/scala/zio/prelude/Validation.scala
@@ -1,10 +1,10 @@
 package zio.prelude
 
-import scala.util.Try
-
 import zio.prelude.Validation._
 import zio.test.Assertion
 import zio.{ IO, ZIO }
+
+import scala.util.Try
 
 /**
  * `Validation` represents either a successful value of type `A` or a

--- a/core/shared/src/main/scala/zio/prelude/ZNonEmptySet.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZNonEmptySet.scala
@@ -1,8 +1,8 @@
 package zio.prelude
 
-import scala.language.implicitConversions
-
 import zio.prelude.newtypes.{ Max, Prod, Sum }
+
+import scala.language.implicitConversions
 
 /**
  * Similar to `ZSet`, a `ZNonEmptySet[A, B]` is a guaranteed non-empty set of `A` values where `B` represents some notion of

--- a/core/shared/src/main/scala/zio/prelude/ZSet.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZSet.scala
@@ -1,9 +1,9 @@
 package zio.prelude
 
+import zio.prelude.newtypes.{ Max, Min, Prod, Sum }
+
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable.HashMap
-
-import zio.prelude.newtypes.{ Max, Min, Prod, Sum }
 
 /**
  * A `ZSet[A, B]` is a set of `A` values where `B` represents some notion of

--- a/core/shared/src/main/scala/zio/prelude/Zivariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Zivariant.scala
@@ -1,11 +1,11 @@
 package zio.prelude
 
-import scala.Predef.{ identity => id }
-
 import zio.prelude.newtypes.Failure
 import zio.stm.ZSTM
 import zio.stream.ZStream
 import zio.{ ZIO, ZLayer, ZManaged }
+
+import scala.Predef.{ identity => id }
 
 /**
  * Abstract over type constructor with 3 parameters: on first as contravariant

--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -1,12 +1,12 @@
 package zio.prelude.fx
 
-import scala.annotation.switch
-import scala.util.Try
-import scala.util.control.NonFatal
-
 import zio.internal.Stack
 import zio.prelude._
 import zio.{ CanFail, NeedsEnv }
+
+import scala.annotation.switch
+import scala.util.Try
+import scala.util.control.NonFatal
 
 /**
  * `ZPure[S1, S2, R, E, A]` is a purely functional description of a computation

--- a/core/shared/src/main/scala/zio/prelude/package.scala
+++ b/core/shared/src/main/scala/zio/prelude/package.scala
@@ -1,8 +1,7 @@
 package zio
 
-import zio.test.{ TestResult, assert }
-
 import com.github.ghik.silencer.silent
+import zio.test.{ TestResult, assert }
 
 package object prelude
     extends Assertions

--- a/core/shared/src/test/scala/zio/prelude/AssociativeSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/AssociativeSpec.scala
@@ -1,10 +1,9 @@
 package zio.prelude
 
+import com.github.ghik.silencer.silent
 import zio.prelude.newtypes.{ And, Or, Prod, Sum }
 import zio.test.laws._
 import zio.test.{ testM, _ }
-
-import com.github.ghik.silencer.silent
 
 object AssociativeSpec extends DefaultRunnableSpec {
 

--- a/core/shared/src/test/scala/zio/prelude/DebugSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/DebugSpec.scala
@@ -1,10 +1,10 @@
 package zio.prelude
 
-import scala.collection.immutable.ListMap
-
 import zio.prelude.Debug.{ Renderer, Repr, _ }
 import zio.random.Random
 import zio.test.{ TestResult, _ }
+
+import scala.collection.immutable.ListMap
 
 object DebugSpec extends DefaultRunnableSpec {
 

--- a/core/shared/src/test/scala/zio/prelude/IdentitySpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/IdentitySpec.scala
@@ -1,10 +1,9 @@
 package zio.prelude
 
+import com.github.ghik.silencer.silent
 import zio.prelude.newtypes.{ And, Max, Min, Or, Prod, Sum }
 import zio.test.laws._
 import zio.test.{ DefaultRunnableSpec, _ }
-
-import com.github.ghik.silencer.silent
 
 object IdentitySpec extends DefaultRunnableSpec {
 

--- a/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
@@ -2,13 +2,13 @@ package zio.prelude.fx
 
 import java.util.NoSuchElementException
 
-import scala.util.Try
-
 import zio.CanFail
 import zio.prelude._
 import zio.random.Random
 import zio.test.Assertion.{ anything, isLeft, isNone, isRight, isSome, isSubtype }
 import zio.test._
+
+import scala.util.Try
 
 object ZPureSpec extends DefaultRunnableSpec {
 


### PR DESCRIPTION
Many of our contributors use IntelliJ and it's then causing friction, when they bum up against unhappy linter step in CI (even though they believe they've made everything orderly).