### PR TITLE
new ZPure constructor 'modifyEither'

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -678,6 +678,15 @@ object ZPure {
     Modify(f)
 
   /**
+   * Constructs a computation that may fail from the specified modify function.
+   */
+  def modifyEither[S1, S2, E, A](f: S1 => Either[E, (S2, A)]): ZPure[S1, S2, Any, E, A] =
+    get.map(f).flatMap {
+      case Left(e)        => ZPure.fail(e)
+      case Right((s2, a)) => ZPure.succeed(a).asState(s2)
+    }
+
+  /**
    * Constructs a computation that extracts the second element of a tuple.
    */
   def second[S, B]: ZPure[S, S, (Any, B), Nothing, B] =

--- a/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
@@ -541,7 +541,15 @@ object ZPureSpec extends DefaultRunnableSpec {
             assert(ZPure.fromEffect("a".toInt).runEither(()))(
               isLeft(equalTo(exception))
             )
-          }
+          },
+          suite("modifyEither")(
+            test("success") {
+              assert(ZPure.modifyEither((_: Int) => Right((1, "success"))).run(0))(equalTo((1, "success")))
+            },
+            test("failure") {
+              assert(ZPure.modifyEither((_: Int) => Left("error")).runEither(0))(isLeft(equalTo("error")))
+            }
+          )
         )
       )
     )


### PR DESCRIPTION
I would like to propose this new `ZPure` constructor for constructing computations that may fail.