### PR TITLE
Add Traversable.compose

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Contravariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Contravariant.scala
@@ -46,7 +46,7 @@ trait Contravariant[F[-_]] extends ContravariantSubset[F, AnyType] with Invarian
   /**
    * Compose two contravariant functors.
    */
-  final def compose[G[-_]](g: Contravariant[G]): Covariant[({ type lambda[+A] = F[G[A]] })#lambda] =
+  final def compose[G[-_]](implicit g: Contravariant[G]): Covariant[({ type lambda[+A] = F[G[A]] })#lambda] =
     new Covariant[({ type lambda[+A] = F[G[A]] })#lambda] {
       def map[A, B](f: A => B): F[G[A]] => F[G[B]] = self.contramap(g.contramap(f))
     }
@@ -54,7 +54,7 @@ trait Contravariant[F[-_]] extends ContravariantSubset[F, AnyType] with Invarian
   /**
    * Compose contravariant and covariant functors.
    */
-  final def compose[G[+_]](g: Covariant[G]): Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] =
+  final def compose[G[+_]](implicit g: Covariant[G]): Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] =
     new Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] {
       def contramap[A, B](f: B => A): F[G[A]] => F[G[B]] = self.contramap(g.map(f))
     }

--- a/core/shared/src/main/scala/zio/prelude/Covariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Covariant.scala
@@ -48,7 +48,7 @@ trait Covariant[F[+_]] extends CovariantSubset[F, AnyType] with Invariant[F] { s
   /**
    * Compose two covariant functors.
    */
-  final def compose[G[+_]](g: Covariant[G]): Covariant[({ type lambda[+A] = F[G[A]] })#lambda] =
+  final def compose[G[+_]](implicit g: Covariant[G]): Covariant[({ type lambda[+A] = F[G[A]] })#lambda] =
     new Covariant[({ type lambda[+A] = F[G[A]] })#lambda] {
       def map[A, B](f: A => B): F[G[A]] => F[G[B]] = self.map(g.map(f))
     }
@@ -56,7 +56,7 @@ trait Covariant[F[+_]] extends CovariantSubset[F, AnyType] with Invariant[F] { s
   /**
    * Compose covariant and contravariant functors.
    */
-  final def compose[G[-_]](g: Contravariant[G]): Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] =
+  final def compose[G[-_]](implicit g: Contravariant[G]): Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] =
     new Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] {
       def contramap[A, B](f: B => A): F[G[A]] => F[G[B]] = self.map(g.contramap(f))
     }

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -35,7 +35,7 @@ trait Invariant[F[_]] { self =>
   /**
    * Compose two invariant functors.
    */
-  final def composeInvariant[G[_]](g: Invariant[G]): Invariant[({ type lambda[A] = F[G[A]] })#lambda] =
+  final def compose[G[_]](implicit g: Invariant[G]): Invariant[({ type lambda[A] = F[G[A]] })#lambda] =
     new Invariant[({ type lambda[A] = F[G[A]] })#lambda] {
       def invmap[A, B](f: A <=> B): F[G[A]] <=> F[G[B]] = self.invmap(g.invmap(f))
     }


### PR DESCRIPTION
Also:
 - rename `composeInvariant` to just `compose`
 - make `compose` parameters implicit so that we can call `.compose[G]`

I didn't find any tests.

And btw, `Applicative` functors compose too, but by splitting them into `Covariant` and `IdentityBoth` we lose that ability 😞 