### PR TITLE
Standardize names for CommutativeBoth functions

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -199,7 +199,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 2 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, B](
     a0: F[A0],
     a1: F[A1]
   )(
@@ -210,7 +210,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 3 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2]
@@ -224,7 +224,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 4 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -239,7 +239,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 5 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -255,7 +255,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 6 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -272,7 +272,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 7 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -290,7 +290,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 8 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -309,7 +309,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 9 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -329,7 +329,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 10 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -350,7 +350,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 11 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -373,7 +373,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 12 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -397,7 +397,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 13 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -422,7 +422,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 14 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -448,7 +448,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 15 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B](
+  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -475,7 +475,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 16 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[
+  def mapN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, B](
     a0: F[A0],
@@ -505,7 +505,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 17 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[
+  def mapN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, B](
     a0: F[A0],
@@ -536,7 +536,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 18 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[
+  def mapN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, B](
     a0: F[A0],
@@ -571,7 +571,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 19 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[
+  def mapN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, B](
     a0: F[A0],
@@ -610,7 +610,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 20 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[
+  def mapN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, B](
     a0: F[A0],
@@ -656,7 +656,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 21 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[
+  def mapN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, B](
     a0: F[A0],
@@ -706,7 +706,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 22 `F` values using the provided function `f` in parallel.
    */
-  def mapParN[F[
+  def mapN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21, B](
     a0: F[A0],
@@ -763,49 +763,49 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * Combines 2 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1](
     a0: F[A0],
     a1: F[A1]
   ): F[(A0, A1)] =
-    mapParN(a0, a1)((_, _))
+    mapN(a0, a1)((_, _))
 
   /**
    * Combines 3 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2]
   ): F[(A0, A1, A2)] =
-    mapParN(a0, a1, a2)((_, _, _))
+    mapN(a0, a1, a2)((_, _, _))
 
   /**
    * Combines 4 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
     a3: F[A3]
   ): F[(A0, A1, A2, A3)] =
-    mapParN(a0, a1, a2, a3)((_, _, _, _))
+    mapN(a0, a1, a2, a3)((_, _, _, _))
 
   /**
    * Combines 5 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
     a3: F[A3],
     a4: F[A4]
   ): F[(A0, A1, A2, A3, A4)] =
-    mapParN(a0, a1, a2, a3, a4)((_, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4)((_, _, _, _, _))
 
   /**
    * Combines 6 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -813,12 +813,12 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a4: F[A4],
     a5: F[A5]
   ): F[(A0, A1, A2, A3, A4, A5)] =
-    mapParN(a0, a1, a2, a3, a4, a5)((_, _, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4, a5)((_, _, _, _, _, _))
 
   /**
    * Combines 7 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -827,12 +827,12 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a5: F[A5],
     a6: F[A6]
   ): F[(A0, A1, A2, A3, A4, A5, A6)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6)((_, _, _, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4, a5, a6)((_, _, _, _, _, _, _))
 
   /**
    * Combines 8 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -842,12 +842,12 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a6: F[A6],
     a7: F[A7]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7)((_, _, _, _, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7)((_, _, _, _, _, _, _, _))
 
   /**
    * Combines 9 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -858,12 +858,12 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a7: F[A7],
     a8: F[A8]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8)((_, _, _, _, _, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8)((_, _, _, _, _, _, _, _, _))
 
   /**
    * Combines 10 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -875,12 +875,12 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a8: F[A8],
     a9: F[A9]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)((_, _, _, _, _, _, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9)((_, _, _, _, _, _, _, _, _, _))
 
   /**
    * Combines 11 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -893,12 +893,12 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a9: F[A9],
     a10: F[A10]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)((_, _, _, _, _, _, _, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)((_, _, _, _, _, _, _, _, _, _, _))
 
   /**
    * Combines 12 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -912,12 +912,12 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a10: F[A10],
     a11: F[A11]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)((_, _, _, _, _, _, _, _, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11)((_, _, _, _, _, _, _, _, _, _, _, _))
 
   /**
    * Combines 13 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -932,12 +932,12 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a11: F[A11],
     a12: F[A12]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)((_, _, _, _, _, _, _, _, _, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12)((_, _, _, _, _, _, _, _, _, _, _, _, _))
 
   /**
    * Combines 14 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -953,12 +953,12 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a12: F[A12],
     a13: F[A13]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)((_, _, _, _, _, _, _, _, _, _, _, _, _, _))
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13)((_, _, _, _, _, _, _, _, _, _, _, _, _, _))
 
   /**
    * Combines 15 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](
+  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -975,14 +975,14 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a13: F[A13],
     a14: F[A14]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)(
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14)(
       (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _)
     )
 
   /**
    * Combines 16 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[
+  def tupleN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](
     a0: F[A0],
@@ -1002,14 +1002,14 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a14: F[A14],
     a15: F[A15]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)(
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15)(
       (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)
     )
 
   /**
    * Combines 17 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[
+  def tupleN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](
     a0: F[A0],
@@ -1030,14 +1030,14 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a15: F[A15],
     a16: F[A16]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)(
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)(
       (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)
     )
 
   /**
    * Combines 18 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[
+  def tupleN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](
     a0: F[A0],
@@ -1059,14 +1059,14 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a16: F[A16],
     a17: F[A17]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)(
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17)(
       (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)
     )
 
   /**
    * Combines 19 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[
+  def tupleN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](
     a0: F[A0],
@@ -1089,14 +1089,14 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a17: F[A17],
     a18: F[A18]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)(
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18)(
       (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)
     )
 
   /**
    * Combines 20 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[
+  def tupleN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19](
     a0: F[A0],
@@ -1120,14 +1120,14 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a18: F[A18],
     a19: F[A19]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)(
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19)(
       (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)
     )
 
   /**
    * Combines 21 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[
+  def tupleN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20](
     a0: F[A0],
@@ -1152,14 +1152,14 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a19: F[A19],
     a20: F[A20]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)(
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20)(
       (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)
     )
 
   /**
    * Combines 22 `F` values into a tuple in a parallel manner.
    */
-  def tupleParN[F[
+  def tupleN[F[
     +_
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21](
     a0: F[A0],
@@ -1185,7 +1185,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
     a20: F[A20],
     a21: F[A21]
   ): F[(A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18, A19, A20, A21)] =
-    mapParN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)(
+    mapN(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20, a21)(
       (_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _)
     )
 }
@@ -1242,44 +1242,44 @@ trait CommutativeBothSyntax {
   }
   implicit class CommutativeBothTuple2Ops[F[+_], T1, T2](tf: => (F[T1], F[T2])) {
     def mapParN[R](f: (T1, T2) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
-      (CommutativeBoth.mapParN(_: F[T1], _: F[T2])(f)).tupled(tf)
+      (CommutativeBoth.mapN(_: F[T1], _: F[T2])(f)).tupled(tf)
 
     def tupleParN(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[(T1, T2)] =
-      (CommutativeBoth.tupleParN(_: F[T1], _: F[T2])).tupled(tf)
+      (CommutativeBoth.tupleN(_: F[T1], _: F[T2])).tupled(tf)
   }
 
   implicit class CommutativeBothTuple3Ops[F[+_], T1, T2, T3](tf: => (F[T1], F[T2], F[T3])) {
     def mapParN[R](f: (T1, T2, T3) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
-      (CommutativeBoth.mapParN(_: F[T1], _: F[T2], _: F[T3])(f)).tupled(tf)
+      (CommutativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3])(f)).tupled(tf)
 
     def tupleParN(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[(T1, T2, T3)] =
-      (CommutativeBoth.tupleParN(_: F[T1], _: F[T2], _: F[T3])).tupled(tf)
+      (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3])).tupled(tf)
   }
 
   implicit class CommutativeBothTuple4Ops[F[+_], T1, T2, T3, T4](tf: => (F[T1], F[T2], F[T3], F[T4])) {
     def mapParN[R](f: (T1, T2, T3, T4) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
-      (CommutativeBoth.mapParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4])(f)).tupled(tf)
+      (CommutativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4])(f)).tupled(tf)
 
     def tupleParN(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[(T1, T2, T3, T4)] =
-      (CommutativeBoth.tupleParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4])).tupled(tf)
+      (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4])).tupled(tf)
   }
 
   implicit class CommutativeBothTuple5Ops[F[+_], T1, T2, T3, T4, T5](tf: => (F[T1], F[T2], F[T3], F[T4], F[T5])) {
     def mapParN[R](f: (T1, T2, T3, T4, T5) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
-      (CommutativeBoth.mapParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5])(f)).tupled(tf)
+      (CommutativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5])(f)).tupled(tf)
 
     def tupleParN(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[(T1, T2, T3, T4, T5)] =
-      (CommutativeBoth.tupleParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5])).tupled(tf)
+      (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5])).tupled(tf)
   }
 
   implicit class CommutativeBothTuple6Ops[F[+_], T1, T2, T3, T4, T5, T6](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6])
   ) {
     def mapParN[R](f: (T1, T2, T3, T4, T5, T6) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
-      (CommutativeBoth.mapParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6])(f)).tupled(tf)
+      (CommutativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6])(f)).tupled(tf)
 
     def tupleParN(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[(T1, T2, T3, T4, T5, T6)] =
-      (CommutativeBoth.tupleParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6])).tupled(tf)
+      (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6])).tupled(tf)
   }
 
   implicit class CommutativeBothTuple7Ops[F[+_], T1, T2, T3, T4, T5, T6, T7](
@@ -1288,10 +1288,10 @@ trait CommutativeBothSyntax {
     def mapParN[R](
       f: (T1, T2, T3, T4, T5, T6, T7) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
-      (CommutativeBoth.mapParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7])(f)).tupled(tf)
+      (CommutativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7])(f)).tupled(tf)
 
     def tupleParN(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[(T1, T2, T3, T4, T5, T6, T7)] =
-      (CommutativeBoth.tupleParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7])).tupled(tf)
+      (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7])).tupled(tf)
   }
 
   implicit class CommutativeBothTuple8Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8](
@@ -1301,12 +1301,12 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8])(f))
+        .mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8])(f))
         .tupled(tf)
 
     def tupleParN(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[(T1, T2, T3, T4, T5, T6, T7, T8)] =
       (CommutativeBoth
-        .tupleParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8]))
+        .tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8]))
         .tupled(tf)
   }
 
@@ -1317,12 +1317,12 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8], _: F[T9])(f))
+        .mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8], _: F[T9])(f))
         .tupled(tf)
 
     def tupleParN(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] =
       (CommutativeBoth
-        .tupleParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8], _: F[T9]))
+        .tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8], _: F[T9]))
         .tupled(tf)
   }
 
@@ -1333,7 +1333,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8], _: F[T9], _: F[T10])(
+        .mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8], _: F[T9], _: F[T10])(
           f
         ))
         .tupled(tf)
@@ -1343,7 +1343,7 @@ trait CommutativeBothSyntax {
       covariant: Covariant[F]
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)] =
       (CommutativeBoth
-        .tupleParN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8], _: F[T9], _: F[T10]))
+        .tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7], _: F[T8], _: F[T9], _: F[T10]))
         .tupled(tf)
   }
 
@@ -1354,7 +1354,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1374,7 +1374,7 @@ trait CommutativeBothSyntax {
       covariant: Covariant[F]
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)] =
       (CommutativeBoth
-        .tupleParN(
+        .tupleN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1397,7 +1397,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1418,7 +1418,7 @@ trait CommutativeBothSyntax {
       covariant: Covariant[F]
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)] =
       (CommutativeBoth
-        .tupleParN(
+        .tupleN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1442,7 +1442,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1464,7 +1464,7 @@ trait CommutativeBothSyntax {
       covariant: Covariant[F]
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)] =
       (CommutativeBoth
-        .tupleParN(
+        .tupleN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1489,7 +1489,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1512,7 +1512,7 @@ trait CommutativeBothSyntax {
       covariant: Covariant[F]
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)] =
       (CommutativeBoth
-        .tupleParN(
+        .tupleN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1554,7 +1554,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1579,7 +1579,7 @@ trait CommutativeBothSyntax {
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)] =
       (
         CommutativeBoth
-          .tupleParN(
+          .tupleN(
             _: F[T1],
             _: F[T2],
             _: F[T3],
@@ -1642,7 +1642,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1668,7 +1668,7 @@ trait CommutativeBothSyntax {
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)] =
       (
         CommutativeBoth
-          .tupleParN(
+          .tupleN(
             _: F[T1],
             _: F[T2],
             _: F[T3],
@@ -1734,7 +1734,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1761,7 +1761,7 @@ trait CommutativeBothSyntax {
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)] =
       (
         CommutativeBoth
-          .tupleParN(
+          .tupleN(
             _: F[T1],
             _: F[T2],
             _: F[T3],
@@ -1830,7 +1830,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1858,7 +1858,7 @@ trait CommutativeBothSyntax {
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)] =
       (
         CommutativeBoth
-          .tupleParN(
+          .tupleN(
             _: F[T1],
             _: F[T2],
             _: F[T3],
@@ -1930,7 +1930,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -1959,7 +1959,7 @@ trait CommutativeBothSyntax {
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)] =
       (
         CommutativeBoth
-          .tupleParN(
+          .tupleN(
             _: F[T1],
             _: F[T2],
             _: F[T3],
@@ -2034,7 +2034,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -2064,7 +2064,7 @@ trait CommutativeBothSyntax {
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)] =
       (
         CommutativeBoth
-          .tupleParN(
+          .tupleN(
             _: F[T1],
             _: F[T2],
             _: F[T3],
@@ -2142,7 +2142,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -2173,7 +2173,7 @@ trait CommutativeBothSyntax {
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)] =
       (
         CommutativeBoth
-          .tupleParN(
+          .tupleN(
             _: F[T1],
             _: F[T2],
             _: F[T3],
@@ -2254,7 +2254,7 @@ trait CommutativeBothSyntax {
       f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R
     )(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth
-        .mapParN(
+        .mapN(
           _: F[T1],
           _: F[T2],
           _: F[T3],
@@ -2286,7 +2286,7 @@ trait CommutativeBothSyntax {
     ): F[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)] =
       (
         CommutativeBoth
-          .tupleParN(
+          .tupleN(
             _: F[T1],
             _: F[T2],
             _: F[T3],


### PR DESCRIPTION
In accordance with https://github.com/zio/zio-prelude/issues/372#issuecomment-744067514
(Note, that the names of the extension methods stay the same.)
