### PR TITLE
Sketch of NewtypeSmartF and SubtypeSmartF

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -605,6 +605,10 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
     new NonEmptyTraversable[Id] {
       override def foreach1[G[+_]: AssociativeBoth: Covariant, A, B](fa: Id[A])(f: A => G[B]): G[Id[B]] =
         f(Id.unwrap(fa)).map(Id(_))
+
+      override def map[A, B](f: A => B): Id[A] => Id[B] = { id =>
+        Id(f(Id.unwrap(id)))
+      }
     }
 
   implicit val IdentityInvariant: Invariant[Identity] =

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -599,13 +599,12 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
     }
 
   /**
-   * The `Covariant` (and thus `Invariant`) instance for `Id`.
+   * The `NonEmptyTraversable` (and thus `Traversable`, `Covariant` and `Invariant`) instance for `Id`.
    */
-  implicit val IdCovariant: Covariant[Id] =
-    new Covariant[Id] {
-      def map[A, B](f: A => B): Id[A] => Id[B] = { id =>
-        Id(f(Id.unwrap(id)))
-      }
+  implicit val IdNonEmptyTraversable: NonEmptyTraversable[Id] =
+    new NonEmptyTraversable[Id] {
+      override def foreach1[G[+_]: AssociativeBoth: Covariant, A, B](fa: Id[A])(f: A => G[B]): G[Id[B]] =
+        f(Id.unwrap(fa)).map(Id(_))
     }
 
   implicit val IdentityInvariant: Invariant[Identity] =

--- a/core/shared/src/main/scala/zio/prelude/NewtypeModuleF.scala
+++ b/core/shared/src/main/scala/zio/prelude/NewtypeModuleF.scala
@@ -1,5 +1,9 @@
 package zio.prelude
 
+import zio.test.Assertion
+
+import scala.language.reflectiveCalls
+
 /**
  * The `NewtypeF` module provides functionality for creating newtypes that are
  * parameterized on some type `A`. See the documentation on `Newtype` for a
@@ -60,9 +64,19 @@ package zio.prelude
 private[prelude] sealed trait NewtypeModuleF {
   def newtypeF: NewtypeF
 
+  def newtypeSmartF(assertion: Object { def apply[A]: Assertion[A] }): NewtypeSmartF
+
   def subtypeF: SubtypeF
 
-  private type Id[+A] = A
+  def subtypeSmartF(assertion: Object { def apply[A]: Assertion[A] }): SubtypeSmartF
+
+  private[this] type Id[+A] = A
+
+  private implicit val IdTraversable: Traversable[Id] =
+    new Traversable[Id] {
+      def foreach[G[+_]: IdentityBoth: Covariant, A, B](fa: Id[A])(f: A => G[B]): G[Id[B]] =
+        f(fa)
+    }
 
   sealed trait NewtypeF {
     type Type[+A]
@@ -108,11 +122,78 @@ private[prelude] sealed trait NewtypeModuleF {
     def unwrapAll[F[_], A](value: F[Type[A]]): F[A]
   }
 
+  sealed trait NewtypeSmartF {
+    type Type[+A]
+
+    /**
+     * Converts an instance of the underlying type to an instance of the
+     * newtype.
+     */
+    protected def apply[A](value: A): Type[A] = wrap(value)
+
+    /**
+     * Attempts to convert an instance of the underlying type to an instance
+     * of the newtype, returning a `Validation` containing either a valid
+     * instance of the newtype or a string message describing why the instance
+     * was invalid.
+     */
+    def make[A](value: A): Validation[String, Type[A]] = makeAll[Id, A](value)
+
+    /**
+     * Allows pattern matching on newtype instances to convert them back to
+     * instances of the underlying type.
+     */
+    def unapply[A](value: Type[A]): Some[A] = Some(unwrap(value))
+
+    /**
+     * Converts an instance of the underlying type to an instance of the
+     * newtype.
+     */
+    protected def wrap[A](value: A): Type[A] = wrapAll[Id, A](value)
+
+    /**
+     * Converts an instance of the newtype back to an instance of the
+     * underlying type.
+     */
+    def unwrap[A](value: Type[A]): A = unwrapAll[Id, A](value)
+
+    /**
+     * Attempts to convert a collection of instances of the underlying type to
+     * a collection of instances of the newtype, returning a `Validation`
+     * containing either a collection of valid instances of the newtype or an
+     * accumulation of validation errors.
+     */
+    def makeAll[F[+_]: Traversable, A](value: F[A]): Validation[String, F[Type[A]]]
+
+    /**
+     * Converts an instance of a type parameterized on the underlying type
+     * to an instance of a type parameterized on the newtype. For example,
+     * this could be used to convert a list of instances of the underlying
+     * type to a list of instances of the newtype.
+     */
+    protected def wrapAll[F[_], A](value: F[A]): F[Type[A]]
+
+    /**
+     * Converts an instance of a type parameterized on the newtype back to an
+     * instance of a type parameterized on the underlying type. For example,
+     * this could be used to convert a list of instances of the newtype back
+     * to a list of instances of the underlying type.
+     */
+    def unwrapAll[F[_], A](value: F[Type[A]]): F[A]
+
+    private[prelude] def unsafeWrapAll[F[_], A](value: F[A]): F[Type[A]]
+  }
+
   sealed trait SubtypeF extends NewtypeF {
     type Type[+A] <: A
   }
+
+  sealed trait SubtypeSmartF extends NewtypeSmartF {
+    type Type[+A] <: A
+  }
 }
-private[prelude] object NewtypeModuleF       {
+
+private[prelude] object NewtypeModuleF {
   val instance: NewtypeModuleF =
     new NewtypeModuleF {
       def newtypeF: NewtypeF =
@@ -124,6 +205,22 @@ private[prelude] object NewtypeModuleF       {
           def unwrapAll[F[_], A](value: F[A]): F[A] = value
         }
 
+      def newtypeSmartF(assertion: Object { def apply[A]: Assertion[A] }): NewtypeSmartF =
+        new NewtypeSmartF {
+          type Type[+A] = A
+
+          def makeAll[F[+_]: Traversable, A](value: F[A]): Validation[String, F[Type[A]]] =
+            Traversable[F].foreach[({ type lambda[+A] = Validation[String, A] })#lambda, A, A](value)(
+              Validation.fromAssert(_)(assertion.apply)
+            )
+
+          protected def wrapAll[F[_], A](value: F[A]): F[A] = value
+
+          def unwrapAll[F[_], A](value: F[A]): F[A] = value
+
+          private[prelude] def unsafeWrapAll[F[_], A](value: F[A]): F[A] = value
+        }
+
       def subtypeF: SubtypeF =
         new SubtypeF {
           type Type[+A] = A
@@ -132,9 +229,26 @@ private[prelude] object NewtypeModuleF       {
 
           def unwrapAll[F[_], A](value: F[A]): F[A] = value
         }
+
+      def subtypeSmartF(assertion: Object { def apply[A]: Assertion[A] }): SubtypeSmartF =
+        new SubtypeSmartF {
+          type Type[+A] = A
+
+          def makeAll[F[+_]: Traversable, A](value: F[A]): Validation[String, F[Type[A]]] =
+            Traversable[F].foreach[({ type lambda[+A] = Validation[String, A] })#lambda, A, A](value)(
+              Validation.fromAssert(_)(assertion.apply)
+            )
+
+          protected def wrapAll[F[_], A](value: F[A]): F[A] = value
+
+          def unwrapAll[F[_], A](value: F[A]): F[A] = value
+
+          private[prelude] def unsafeWrapAll[F[_], A](value: F[A]): F[A] = value
+        }
     }
 }
-trait NewtypeFExports                        {
+
+trait NewtypeFExports {
   import NewtypeModuleF._
 
   /**
@@ -161,6 +275,36 @@ trait NewtypeFExports                        {
   }
 
   /**
+   * The class of objects corresponding to newtypes with smart constructors
+   * where not all instances of the underlying type are valid instances of the
+   * newtype. Users should implement an object that extends this class to
+   * create their own newtypes, specifying `A` as the underlying type to wrap
+   * and an assertion that valid instances of the underlying type should
+   * satisfy.
+   *
+   * {{{
+   * TODO
+   * object Natural extends NewtypeSmart[Int](isGreaterThanEqualTo(0))
+   * type Natural = Natural.Type
+   * }}}
+   */
+  abstract class NewtypeSmartF(assertion: Object { def apply[A]: Assertion[A] }) extends instance.NewtypeSmartF {
+    val newtypeF: instance.NewtypeSmartF = instance.newtypeSmartF(assertion)
+
+    type Type[+A] = newtypeF.Type[A]
+
+    def makeAll[F[+_]: Traversable, A](value: F[A]): Validation[String, F[Type[A]]] =
+      newtypeF.makeAll(value)
+
+    protected def wrapAll[F[_], A](value: F[A]): F[Type[A]] = unsafeWrapAll(value)
+
+    def unwrapAll[F[_], A](value: F[Type[A]]): F[A] = newtypeF.unwrapAll(value.asInstanceOf[F[newtypeF.Type[A]]])
+
+    private[prelude] def unsafeWrapAll[F[_], A](value: F[A]): F[Type[A]] =
+      newtypeF.unsafeWrapAll(value)
+  }
+
+  /**
    * The class of objects corresponding to parameterized subtypes. Users should
    * implement an object that extends this class to create their own
    * parameterized subtypes
@@ -181,5 +325,35 @@ trait NewtypeFExports                        {
 
     def unwrapAll[F[_], A](value: F[Type[A]]): F[A] =
       subtypeF.unwrapAll(value)
+  }
+
+  /**
+   * The class of objects corresponding to subtypes with smart constructors
+   * where not all instances of the underlying type are valid instances of the
+   * subtype. Users should implement an object that extends this class to
+   * create their own subtypes, specifying `A` as the underlying type to wrap
+   * and an assertion that valid instances of the underlying type should
+   * satisfy.
+   *
+   * {{{
+   * TODO
+   * object Natural extends SubtypeSmart[Int](isGreaterThanEqualTo(0))
+   * type Natural = Natural.Type
+   * }}}
+   */
+  abstract class SubtypeSmartF(assertion: Object { def apply[A]: Assertion[A] }) extends instance.SubtypeSmartF {
+    val subtypeF: instance.SubtypeSmartF = instance.subtypeSmartF(assertion)
+
+    type Type[+A] = subtypeF.Type[A]
+
+    def makeAll[F[+_]: Traversable, A](value: F[A]): Validation[String, F[Type[A]]] =
+      subtypeF.makeAll(value)
+
+    protected def wrapAll[F[_], A](value: F[A]): F[Type[A]] = unsafeWrapAll(value)
+
+    def unwrapAll[F[_], A](value: F[Type[A]]): F[A] = subtypeF.unwrapAll(value.asInstanceOf[F[subtypeF.Type[A]]])
+
+    private[prelude] def unsafeWrapAll[F[_], A](value: F[A]): F[Type[A]] =
+      subtypeF.unsafeWrapAll(value)
   }
 }

--- a/core/shared/src/test/scala/zio/prelude/NewtypeFSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NewtypeFSpec.scala
@@ -23,13 +23,13 @@ object NewtypeFSpec extends DefaultRunnableSpec {
       ),
       suite("SubtypeSmartF")(
         test("subtypes values") {
-          assert(ShortList.list1234 ++ List(5, 6))(equalTo(List(1, 2, 3, 4) ++ List(5, 6)))
+          assert((ShortList.list1234: List[Int]) ++ List(5, 6))(equalTo(List(1, 2, 3, 4) ++ List(5, 6)))
         }
       )
     )
 
   object ShortList extends SubtypeSmartF[List](isShorterThan(5)) {
-    val list1234: Type[Int] = ShortList[Int](List(1, 2, 3, 4))
+    val list1234: ShortList[Int] = ShortList[Int](List(1, 2, 3, 4))
   }
   type ShortList[x] = ShortList.Type[x]
 

--- a/core/shared/src/test/scala/zio/prelude/NewtypeFSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NewtypeFSpec.scala
@@ -29,7 +29,7 @@ object NewtypeFSpec extends DefaultRunnableSpec {
     )
 
   object ShortList extends SubtypeSmartF[List](isShorterThan(5)) {
-    val list1234 = ShortList[Int](List(1, 2, 3, 4))
+    val list1234: Type[Int] = ShortList[Int](List(1, 2, 3, 4))
   }
   type ShortList[x] = ShortList.Type[x]
 

--- a/core/shared/src/test/scala/zio/prelude/NewtypeFSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NewtypeFSpec.scala
@@ -1,0 +1,36 @@
+package zio.prelude
+
+import zio.test.Assertion.anything
+import zio.test.AssertionM.Render.param
+import zio.test.{Assertion, DefaultRunnableSpec, ZSpec, assert, suite, test}
+
+object NewtypeFSpec extends DefaultRunnableSpec {
+
+  def isShorterThan(length: Int): AssertionK[List] = new AssertionK[List] {
+    def apply[x]: Assertion[List[x]] = Assertion.assertion("isShorterThan")(param(length))(_.length < length)
+  }
+
+  def spec: ZSpec[Environment, Failure] =
+    suite("NewtypeFSpec")(
+      suite("NewtypeSmartF")(
+        test("valid values") {
+          assert(ShortList.make(List(1, 2, 3, 4)))(isSuccessV(anything))
+        },
+        test("invalid values") {
+          val expected = NonEmptyMultiSet("List(1, 2, 3, 4, 5) did not satisfy isShorterThan(5)")
+          assert(ShortList.make(List(1, 2, 3, 4, 5)))(isFailureV(equalTo(expected)))
+        }
+      ),
+      suite("SubtypeSmartF")(
+        test("subtypes values") {
+          assert(ShortList.list1234 ++ List(5, 6))(equalTo(List(1, 2, 3, 4) ++ List(5, 6)))
+        }
+      )
+    )
+
+  object ShortList extends SubtypeSmartF[List](isShorterThan(5)) {
+    val list1234 = ShortList[Int](List(1, 2, 3, 4))
+  }
+  type ShortList[x] = ShortList.Type[x]
+
+}


### PR DESCRIPTION
fixes https://github.com/zio/zio-prelude/issues/483

Is this what you had in mind, @jdegoes ?

On a second thought, shouldn't these be called rather `NewtypeSmartK` and `SubtypeSmartK`?
