### PR TITLE
Rationalize law testing -- drop redundant tests of instances

### DIFF
--- a/core/shared/src/test/scala/zio/prelude/AssociativeBothSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/AssociativeBothSpec.scala
@@ -13,11 +13,6 @@ object AssociativeBothSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("AssociativeBothSpec")(
       suite("laws")(
-        testM("chunk")(checkAllLaws(AssociativeBoth)(GenF.chunk, Gen.anyInt)),
-        testM("either")(checkAllLaws(AssociativeBoth)(GenF.either(Gen.anyInt), Gen.anyInt)),
-        testM("option")(checkAllLaws(AssociativeBoth)(GenF.option, Gen.anyInt)),
-        testM("list")(checkAllLaws(AssociativeBoth)(GenF.list, Gen.anyInt)),
-        testM("vector")(checkAllLaws(AssociativeBoth)(GenF.vector, Gen.anyInt)),
         testM("chunk . option")(checkAllLaws(AssociativeBoth)(chunkOptionGenF, Gen.anyInt))
       )
     )

--- a/core/shared/src/test/scala/zio/prelude/AssociativeEitherSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/AssociativeEitherSpec.scala
@@ -8,7 +8,6 @@ object AssociativeEitherSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("AssociativeEitherSpec")(
       suite("laws")(
-        testM("option")(checkAllLaws(AssociativeEither)(GenF.option, Gen.anyInt)),
         testM("either")(checkAllLaws(AssociativeEither)(GenF.either(Gen.anyInt), Gen.anyInt))
       )
     )

--- a/core/shared/src/test/scala/zio/prelude/AssociativeFlattenSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/AssociativeFlattenSpec.scala
@@ -8,11 +8,6 @@ object AssociativeFlattenSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("AssociativeFlattenSpec")(
       suite("laws")(
-        testM("chunk")(checkAllLaws(AssociativeFlatten)(GenF.chunk, Gen.chunkOf(Gen.anyInt))),
-        testM("either")(checkAllLaws(AssociativeFlatten)(GenFs.either(Gen.anyInt), Gen.anyInt)),
-        testM("option")(checkAllLaws(AssociativeFlatten)(GenF.option, Gen.anyInt)),
-        testM("list")(checkAllLaws(AssociativeFlatten)(GenF.list, Gen.anyInt)),
-        testM("vector")(checkAllLaws(AssociativeFlatten)(GenF.vector, Gen.anyInt)),
         testM("map")(checkAllLaws(AssociativeFlatten)(GenFs.map(Gen.anyInt), Gen.anyInt))
       )
     )

--- a/core/shared/src/test/scala/zio/prelude/AssociativeSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/AssociativeSpec.scala
@@ -1,9 +1,7 @@
 package zio.prelude
 
 import com.github.ghik.silencer.silent
-import zio.prelude.newtypes.{And, Or, Prod, Sum}
-import zio.test.laws._
-import zio.test.{testM, _}
+import zio.test._
 
 object AssociativeSpec extends DefaultRunnableSpec {
 

--- a/core/shared/src/test/scala/zio/prelude/AssociativeSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/AssociativeSpec.scala
@@ -11,29 +11,6 @@ object AssociativeSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("AssociativeSpec")(
       suite("laws")(
-        testM("char addition")(checkAllLaws(Associative)(Gen.anyChar.map(Sum(_)))),
-        testM("char multiplication")(checkAllLaws(Associative)(Gen.anyChar.map(Prod(_)))),
-        testM("string")(checkAllLaws(Associative)(Gen.anyString)),
-        testM("byte addition")(checkAllLaws(Associative)(Gen.anyByte.map(Sum(_)))),
-        testM("byte multiplication")(checkAllLaws(Associative)(Gen.anyByte.map(Prod(_)))),
-        testM("short addition")(checkAllLaws(Associative)(Gen.anyShort.map(Sum(_)))),
-        testM("short multiplication")(checkAllLaws(Associative)(Gen.anyShort.map(Prod(_)))),
-        testM("int addition")(checkAllLaws(Associative)(Gen.anyInt.map(Sum(_)))),
-        testM("int multiplication")(checkAllLaws(Associative)(Gen.anyInt.map(Prod(_)))),
-        testM("long addition")(checkAllLaws(Associative)(Gen.anyLong.map(Sum(_)))),
-        testM("long multiplication")(checkAllLaws(Associative)(Gen.anyLong.map(Prod(_)))),
-        testM("boolean disjunction")(checkAllLaws(Associative)(Gen.boolean.map(Or(_)))),
-        testM("boolean conjuction")(checkAllLaws(Associative)(Gen.boolean.map(And(_)))),
-        testM("option")(checkAllLaws(Associative)(Gen.option(Gen.anyInt.map(Sum(_))))),
-        testM("list")(checkAllLaws(Associative)(Gen.listOf(Gen.anyInt))),
-        testM("vector")(checkAllLaws(Associative)(Gen.vectorOf(Gen.anyInt))),
-        testM("map")(checkAllLaws(Associative)(Gen.mapOf(Gen.anyInt, Gen.anyInt.map(Sum(_))))),
-        testM("set")(checkAllLaws(Associative)(Gen.setOf(Gen.anyInt))),
-        testM("tuple2")(checkAllLaws(Associative)(Gen.anyInt.map(Sum(_)).zip(Gen.anyInt.map(Sum(_))))),
-        testM("tuple3")(
-          checkAllLaws(Associative)(Gen.anyInt.map(Sum(_)).zip(Gen.anyInt.map(Sum(_))).zip(Gen.anyInt.map(Sum(_))))
-        ),
-        testM("chunk")(checkAllLaws(Associative)(Gen.chunkOf(Gen.anyInt)))
       )
     )
 }

--- a/core/shared/src/test/scala/zio/prelude/CommutativeBothSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/CommutativeBothSpec.scala
@@ -9,8 +9,8 @@ object CommutativeBothSpec extends DefaultRunnableSpec {
     suite("CommutativeBothSpec")(
       suite("laws")(
         testM("chunk")(checkAllLaws(CommutativeBoth)(GenF.chunk, Gen.chunkOf(Gen.anyInt))),
-        testM("option")(checkAllLaws(CommutativeBoth)(GenF.option, Gen.anyInt)),
         testM("list")(checkAllLaws(CommutativeBoth)(GenF.list, Gen.anyInt)),
+        testM("option")(checkAllLaws(CommutativeBoth)(GenF.option, Gen.anyInt)),
         testM("vector")(checkAllLaws(CommutativeBoth)(GenF.vector, Gen.vectorOf(Gen.anyInt)))
       )
     )

--- a/core/shared/src/test/scala/zio/prelude/CommutativeSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/CommutativeSpec.scala
@@ -12,22 +12,22 @@ object CommutativeSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("CommutativeSpec")(
       suite("laws")(
-        testM("char")(checkAllLaws(Commutative)(Gen.anyChar.map(Sum(_)))),
-        testM("char")(checkAllLaws(Commutative)(Gen.anyChar.map(Prod(_)))),
+        testM("boolean conjuction")(checkAllLaws(Commutative)(Gen.boolean.map(And(_)))),
+        testM("boolean disjunction")(checkAllLaws(Commutative)(Gen.boolean.map(Or(_)))),
         testM("byte addition")(checkAllLaws(Commutative)(Gen.anyByte.map(Sum(_)))),
         testM("byte multiplication")(checkAllLaws(Commutative)(Gen.anyByte.map(Prod(_)))),
-        testM("short addition")(checkAllLaws(Commutative)(Gen.anyShort.map(Sum(_)))),
-        testM("short multiplication")(checkAllLaws(Commutative)(Gen.anyShort.map(Prod(_)))),
+        testM("char addition")(checkAllLaws(Commutative)(Gen.anyChar.map(Sum(_)))),
+        testM("char multiplication")(checkAllLaws(Commutative)(Gen.anyChar.map(Prod(_)))),
+        testM("either")(checkAllLaws(Commutative)(Gen.either(anySumInt, anySumInt))),
         testM("int addition")(checkAllLaws(Commutative)(anySumInt)),
         testM("int multiplication")(checkAllLaws(Commutative)(Gen.anyInt.map(Prod(_)))),
         testM("long addition")(checkAllLaws(Commutative)(Gen.anyLong.map(Sum(_)))),
         testM("long multiplication")(checkAllLaws(Commutative)(Gen.anyLong.map(Prod(_)))),
-        testM("boolean disjunction")(checkAllLaws(Commutative)(Gen.boolean.map(Or(_)))),
-        testM("boolean conjuction")(checkAllLaws(Commutative)(Gen.boolean.map(And(_)))),
-        testM("option")(checkAllLaws(Commutative)(Gen.option(anySumInt))),
-        testM("either")(checkAllLaws(Commutative)(Gen.either(anySumInt, anySumInt))),
-        testM("set")(checkAllLaws(Commutative)(Gen.setOf(anySumInt))),
         testM("map")(checkAllLaws(Commutative)(Gen.mapOf(anySumInt, anySumInt))),
+        testM("option")(checkAllLaws(Commutative)(Gen.option(anySumInt))),
+        testM("set")(checkAllLaws(Commutative)(Gen.setOf(anySumInt))),
+        testM("short addition")(checkAllLaws(Commutative)(Gen.anyShort.map(Sum(_)))),
+        testM("short multiplication")(checkAllLaws(Commutative)(Gen.anyShort.map(Prod(_)))),
         testM("tuple2")(checkAllLaws(Commutative)(anySumInt.zip(anySumInt))),
         testM("tuple3")(
           checkAllLaws(Commutative)(anySumInt.zip(anySumInt).zip(anySumInt).map { case ((x, y), z) => (x, y, z) })

--- a/core/shared/src/test/scala/zio/prelude/CovariantSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/CovariantSpec.scala
@@ -13,18 +13,10 @@ object CovariantSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("CovariantSpec")(
       suite("laws")(
-        testM("option")(checkAllLaws(Covariant)(GenF.option, Gen.anyInt)),
-        testM("list")(checkAllLaws(Covariant)(GenF.list, Gen.anyInt)),
-        testM("vector")(checkAllLaws(Covariant)(GenF.vector, Gen.anyInt)),
-        testM("map")(checkAllLaws(Covariant)(GenFs.map(Gen.anyInt), Gen.anyInt)),
-        testM("either")(checkAllLaws(Covariant)(GenFs.either(Gen.anyInt), Gen.anyInt)),
-        testM("tuple2")(checkAllLaws(Covariant)(GenFs.tuple2(Gen.anyInt), Gen.anyInt)),
-        testM("tuple3")(checkAllLaws(Covariant)(GenFs.tuple3(Gen.anyInt, Gen.anyInt), Gen.anyInt)),
         testM("cause")(checkAllLaws(Covariant)(GenFs.cause, Gen.anyInt)),
-        testM("chunk")(checkAllLaws(Covariant)(GenF.chunk, Gen.anyInt)),
         testM("exit")(checkAllLaws(Covariant)(GenFs.exit(Gen.causes(Gen.anyInt, Gen.throwable)), Gen.anyInt)),
-        testM("nonEmptyChunk")(checkAllLaws(Covariant)(GenFs.nonEmptyChunk, Gen.anyInt)),
-        testM("chunk . option")(checkAllLaws(Covariant)(chunkOptionGenF, Gen.anyInt))
+        testM("tuple2")(checkAllLaws(Covariant)(GenFs.tuple2(Gen.anyInt), Gen.anyInt)),
+        testM("tuple3")(checkAllLaws(Covariant)(GenFs.tuple3(Gen.anyInt, Gen.anyInt), Gen.anyInt))
       )
     )
 }

--- a/core/shared/src/test/scala/zio/prelude/EqualSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/EqualSpec.scala
@@ -9,24 +9,7 @@ object EqualSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("EqualSpec")(
       suite("laws")(
-        testM("unit")(checkAllLaws(Equal)(Gen.unit)),
-        testM("boolean")(checkAllLaws(Equal)(Gen.boolean)),
-        testM("byte")(checkAllLaws(Equal)(Gen.anyByte)),
-        testM("char")(checkAllLaws(Equal)(Gen.anyChar)),
-        testM("string")(checkAllLaws(Equal)(Gen.anyString)),
-        testM("int")(checkAllLaws(Equal)(Gen.anyInt)),
-        testM("long")(checkAllLaws(Equal)(Gen.anyLong)),
-        testM("float")(checkAllLaws(Equal)(Gen.anyFloat)),
-        testM("double")(checkAllLaws(Equal)(Gen.anyDouble)),
-        testM("option")(checkAllLaws(Equal)(Gen.option(Gen.anyInt))),
-        testM("either")(checkAllLaws(Equal)(Gen.either(Gen.anyInt, Gen.anyInt))),
-        testM("tuple2")(checkAllLaws(Equal)(Gen.anyInt.zip(Gen.anyInt))),
-        testM("tuple3")(checkAllLaws(Equal)(Gen.anyInt.zip(Gen.anyInt).zip(Gen.anyInt))),
-        testM("list")(checkAllLaws(Equal)(Gen.listOf(Gen.anyInt))),
-        testM("vector")(checkAllLaws(Equal)(Gen.vectorOf(Gen.anyInt))),
-        testM("map")(checkAllLaws(Equal)(Gen.mapOf(Gen.anyInt, Gen.anyInt))),
-        testM("set")(checkAllLaws(Equal)(Gen.setOf(Gen.anyInt))),
-        testM("chunk")(checkAllLaws(Equal)(Gen.chunkOf(Gen.anyInt))), {
+        {
           implicit val ThrowableEqual: Equal[Throwable] = Equal.ThrowableHash
           testM("throwable")(checkAllLaws(Equal)(Gen.throwable))
         },

--- a/core/shared/src/test/scala/zio/prelude/EquivalenceSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/EquivalenceSpec.scala
@@ -9,11 +9,31 @@ object EquivalenceSpec extends DefaultRunnableSpec {
   val genAny: Gen[Any, Any] =
     Gen.unit
 
-  val genNothing: Gen[Any, Nothing]     =
+  val genNothing: Gen[Any, Nothing] =
     Gen(ZStream.empty)
+
   def spec: ZSpec[Environment, Failure] =
     suite("EquivalenceSpec")(
       suite("laws")(
+        testM("either") {
+          implicit val equivalence = Equivalence.either[Int, Int, Int]
+          val left                 = Gen.either(Gen.anyInt, Gen.either(Gen.anyInt, Gen.anyInt))
+          val right                = Gen.either(Gen.either(Gen.anyInt, Gen.anyInt), Gen.anyInt)
+          checkAllLaws(Equivalence)(left, right)
+        },
+        testM("eitherFlip") {
+          implicit val equivalence = Equivalence.eitherFlip[Int, Int]
+          val left                 = Gen.either(Gen.anyInt, Gen.anyInt)
+          val right                = Gen.either(Gen.anyInt, Gen.anyInt)
+          checkAllLaws(Equivalence)(left, right)
+        },
+        testM("eitherNothing") {
+          implicit val equal       = Equal.EitherEqual[Int, Nothing](Equal.IntHashOrd, Equal.NothingHashOrd)
+          implicit val equivalence = Equivalence.eitherNothing[Int]
+          val left                 = Gen.either(Gen.anyInt, genNothing)
+          val right                = Gen.anyInt
+          checkAllLaws(Equivalence)(left, right)
+        },
         testM("identity") {
           implicit val equivalence = Equivalence.identity[Int]
           val left                 = Gen.anyInt
@@ -36,25 +56,6 @@ object EquivalenceSpec extends DefaultRunnableSpec {
           implicit val equal       = Equal.AnyHashOrd
           implicit val equivalence = Equivalence.tupleAny[Int]
           val left                 = Gen.anyInt <*> genAny
-          val right                = Gen.anyInt
-          checkAllLaws(Equivalence)(left, right)
-        },
-        testM("either") {
-          implicit val equivalence = Equivalence.either[Int, Int, Int]
-          val left                 = Gen.either(Gen.anyInt, Gen.either(Gen.anyInt, Gen.anyInt))
-          val right                = Gen.either(Gen.either(Gen.anyInt, Gen.anyInt), Gen.anyInt)
-          checkAllLaws(Equivalence)(left, right)
-        },
-        testM("eitherFlip") {
-          implicit val equivalence = Equivalence.eitherFlip[Int, Int]
-          val left                 = Gen.either(Gen.anyInt, Gen.anyInt)
-          val right                = Gen.either(Gen.anyInt, Gen.anyInt)
-          checkAllLaws(Equivalence)(left, right)
-        },
-        testM("eitherNothing") {
-          implicit val equal       = Equal.EitherEqual[Int, Nothing](Equal.IntHashOrd, Equal.NothingHashOrd)
-          implicit val equivalence = Equivalence.eitherNothing[Int]
-          val left                 = Gen.either(Gen.anyInt, genNothing)
           val right                = Gen.anyInt
           checkAllLaws(Equivalence)(left, right)
         }

--- a/core/shared/src/test/scala/zio/prelude/HashSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/HashSpec.scala
@@ -12,24 +12,24 @@ object HashSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("HashSpec")(
       suite("laws")(
-        testM("unit")(checkAllLaws(Hash)(Gen.unit)),
         testM("boolean")(checkAllLaws(Hash)(Gen.boolean)),
         testM("byte")(checkAllLaws(Hash)(Gen.anyByte)),
         testM("char")(checkAllLaws(Hash)(Gen.anyChar)),
-        testM("string")(checkAllLaws(Hash)(Gen.anyString)),
-        testM("int")(checkAllLaws(Hash)(Gen.anyInt)),
-        testM("long")(checkAllLaws(Hash)(Gen.anyLong)),
-        testM("float")(checkAllLaws(Hash)(Gen.anyFloat)),
+        testM("chunk")(checkAllLaws(Hash)(Gen.chunkOf(Gen.anyInt))),
         testM("double")(checkAllLaws(Hash)(Gen.anyDouble)),
+        testM("either")(checkAllLaws(Hash)(Gen.either(Gen.anyInt, Gen.anyInt))),
+        testM("float")(checkAllLaws(Hash)(Gen.anyFloat)),
+        testM("int")(checkAllLaws(Hash)(Gen.anyInt)),
+        testM("list")(checkAllLaws(Hash)(Gen.listOf(Gen.anyInt))),
+        testM("long")(checkAllLaws(Hash)(Gen.anyLong)),
+        testM("map")(checkAllLaws(Hash)(Gen.mapOf(Gen.anyInt, Gen.anyInt))),
         testM("option")(checkAllLaws(Hash)(Gen.option(Gen.anyInt))),
+        testM("set")(checkAllLaws(Hash)(Gen.setOf(Gen.anyInt))),
+        testM("string")(checkAllLaws(Hash)(Gen.anyString)),
         testM("tuple2")(checkAllLaws(Hash)(Gen.anyInt.zip(Gen.anyInt))),
         testM("tuple3")(checkAllLaws(Hash)(Gen.anyInt.zip(Gen.anyInt).zip(Gen.anyInt))),
-        testM("either")(checkAllLaws(Hash)(Gen.either(Gen.anyInt, Gen.anyInt))),
-        testM("list")(checkAllLaws(Hash)(Gen.listOf(Gen.anyInt))),
-        testM("vector")(checkAllLaws(Hash)(Gen.vectorOf(Gen.anyInt))),
-        testM("set")(checkAllLaws(Hash)(Gen.setOf(Gen.anyInt))),
-        testM("map")(checkAllLaws(Hash)(Gen.mapOf(Gen.anyInt, Gen.anyInt))),
-        testM("chunk")(checkAllLaws(Hash)(Gen.chunkOf(Gen.anyInt)))
+        testM("unit")(checkAllLaws(Hash)(Gen.unit)),
+        testM("vector")(checkAllLaws(Hash)(Gen.vectorOf(Gen.anyInt)))
       ),
       suite("ScalaHashCode consistency")(
         testM("unit")(scalaHashCodeConsistency(Gen.unit)),

--- a/core/shared/src/test/scala/zio/prelude/IdempotentSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/IdempotentSpec.scala
@@ -31,17 +31,17 @@ object IdempotentSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("IdempotentSpec")(
       suite("laws")(
-        testM("boolean disjunction")(checkAllLaws(Idempotent)(Gen.boolean.map(Or(_)))),
         testM("boolean conjuction")(checkAllLaws(Idempotent)(Gen.boolean.map(And(_)))),
-        testM("option")(checkAllLaws(Idempotent)(Gen.option(anyMaxInt))),
-        testM("set")(checkAllLaws(Idempotent)(Gen.setOf(Gen.anyInt))),
+        testM("boolean disjunction")(checkAllLaws(Idempotent)(Gen.boolean.map(Or(_)))),
         testM("map")(checkAllLaws(Idempotent)(Gen.mapOf(anyMaxInt, anyMaxInt))),
+        testM("option")(checkAllLaws(Idempotent)(Gen.option(anyMaxInt))),
+        testM("ordering")(checkAllLaws(Idempotent)(anyOrdering)),
+        testM("partial ordering")(checkAllLaws(Idempotent)(anyPartialOrdering)),
+        testM("set")(checkAllLaws(Idempotent)(Gen.setOf(Gen.anyInt))),
         testM("tuple2")(checkAllLaws(Idempotent)(anyMaxInt.zip(anyMaxInt))),
         testM("tuple3")(
           checkAllLaws(Idempotent)(anyMaxInt.zip(anyMaxInt).zip(anyMaxInt).map { case ((x, y), z) => (x, y, z) })
-        ),
-        testM("partial ordering")(checkAllLaws(Idempotent)(anyPartialOrdering)),
-        testM("ordering")(checkAllLaws(Idempotent)(anyOrdering))
+        )
       ),
       test("Idempotent.reduceIdempotent") {
 

--- a/core/shared/src/test/scala/zio/prelude/IdentityFlattenSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/IdentityFlattenSpec.scala
@@ -10,8 +10,8 @@ object IdentityFlattenSpec extends DefaultRunnableSpec {
       suite("laws")(
         testM("chunk")(checkAllLaws(IdentityFlatten)(GenF.chunk, Gen.chunkOf(Gen.anyInt))),
         testM("either")(checkAllLaws(IdentityFlatten)(GenFs.either(Gen.anyInt), Gen.anyInt)),
-        testM("option")(checkAllLaws(IdentityFlatten)(GenF.option, Gen.anyInt)),
         testM("list")(checkAllLaws(IdentityFlatten)(GenF.list, Gen.anyInt)),
+        testM("option")(checkAllLaws(IdentityFlatten)(GenF.option, Gen.anyInt)),
         testM("vector")(checkAllLaws(IdentityFlatten)(GenF.vector, Gen.anyInt))
       )
     )

--- a/core/shared/src/test/scala/zio/prelude/IdentitySpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/IdentitySpec.scala
@@ -11,44 +11,30 @@ object IdentitySpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("IdentitySpec")(
       suite("laws")(
-        testM("char addition")(checkAllLaws(Identity)(Gen.anyChar.map(Sum(_)))),
-        testM("char max")(checkAllLaws(Identity)(Gen.anyChar.map(Max(_)))),
-        testM("char min")(checkAllLaws(Identity)(Gen.anyChar.map(Min(_)))),
-        testM("char multiplication")(checkAllLaws(Identity)(Gen.anyChar.map(Prod(_)))),
-        testM("string")(checkAllLaws(Identity)(Gen.anyString)),
-        testM("byte addition")(checkAllLaws(Identity)(Gen.anyByte.map(Sum(_)))),
+        testM("boolean conjuction")(checkAllLaws(Identity)(Gen.boolean.map(And(_)))),
+        testM("boolean disjunction")(checkAllLaws(Identity)(Gen.boolean.map(Or(_)))),
         testM("byte max")(checkAllLaws(Identity)(Gen.anyByte.map(Max(_)))),
         testM("byte min")(checkAllLaws(Identity)(Gen.anyByte.map(Min(_)))),
         testM("byte multiplication")(checkAllLaws(Identity)(Gen.anyByte.map(Prod(_)))),
-        testM("short addition")(checkAllLaws(Identity)(Gen.anyShort.map(Sum(_)))),
-        testM("short max")(checkAllLaws(Identity)(Gen.anyShort.map(Max(_)))),
-        testM("short min")(checkAllLaws(Identity)(Gen.anyShort.map(Min(_)))),
-        testM("short multiplication")(checkAllLaws(Identity)(Gen.anyShort.map(Prod(_)))),
-        testM("int addition")(checkAllLaws(Identity)(Gen.anyInt.map(Sum(_)))),
+        testM("char max")(checkAllLaws(Identity)(Gen.anyChar.map(Max(_)))),
+        testM("char min")(checkAllLaws(Identity)(Gen.anyChar.map(Min(_)))),
+        testM("char multiplication")(checkAllLaws(Identity)(Gen.anyChar.map(Prod(_)))),
+        testM("either")(checkAllLaws(Identity)(Gen.either(Gen.anyInt.map(Sum(_)), Gen.anyInt.map(Sum(_))))),
+        testM("chunk")(checkAllLaws(Identity)(Gen.chunkOf(Gen.anyInt))),
         testM("int max")(checkAllLaws(Identity)(Gen.anyInt.map(Max(_)))),
         testM("int min")(checkAllLaws(Identity)(Gen.anyInt.map(Min(_)))),
         testM("int multiplication")(checkAllLaws(Identity)(Gen.anyInt.map(Prod(_)))),
-        testM("long addition")(checkAllLaws(Identity)(Gen.anyLong.map(Sum(_)))),
+        testM("list")(checkAllLaws(Identity)(Gen.listOf(Gen.anyInt))),
         testM("long max")(checkAllLaws(Identity)(Gen.anyLong.map(Max(_)))),
         testM("long min")(checkAllLaws(Identity)(Gen.anyLong.map(Min(_)))),
         testM("long multiplication")(checkAllLaws(Identity)(Gen.anyLong.map(Prod(_)))),
-        testM("boolean disjunction")(checkAllLaws(Identity)(Gen.boolean.map(Or(_)))),
-        testM("boolean conjuction")(checkAllLaws(Identity)(Gen.boolean.map(And(_)))),
-        testM("option")(checkAllLaws(Identity)(Gen.option(Gen.anyInt.map(Sum(_))))),
-        testM("either")(checkAllLaws(Identity)(Gen.either(Gen.anyInt.map(Sum(_)), Gen.anyInt.map(Sum(_))))),
-        testM("list")(checkAllLaws(Identity)(Gen.listOf(Gen.anyInt))),
-        testM("vector")(checkAllLaws(Identity)(Gen.vectorOf(Gen.anyInt))),
         testM("map")(checkAllLaws(Identity)(Gen.mapOf(Gen.anyInt, Gen.anyInt.map(Sum(_))))),
-        testM("set")(checkAllLaws(Identity)(Gen.setOf(Gen.anyInt))),
-        testM("tuple2")(checkAllLaws(Identity)(Gen.anyInt.map(Sum(_)).zip(Gen.anyInt.map(Sum(_))))),
-        testM("tuple3")(
-          checkAllLaws(Identity)(
-            Gen.anyInt.map(Sum(_)).zip(Gen.anyInt.map(Sum(_))).zip(Gen.anyInt.map(Sum(_))).map { case ((a, b), c) =>
-              (a, b, c)
-            }
-          )
-        ),
-        testM("chunk")(checkAllLaws(Identity)(Gen.chunkOf(Gen.anyInt)))
+        testM("option")(checkAllLaws(Identity)(Gen.option(Gen.anyInt.map(Sum(_))))),
+        testM("short max")(checkAllLaws(Identity)(Gen.anyShort.map(Max(_)))),
+        testM("short min")(checkAllLaws(Identity)(Gen.anyShort.map(Min(_)))),
+        testM("short multiplication")(checkAllLaws(Identity)(Gen.anyShort.map(Prod(_)))),
+        testM("string")(checkAllLaws(Identity)(Gen.anyString)),
+        testM("vector")(checkAllLaws(Identity)(Gen.vectorOf(Gen.anyInt)))
       )
     )
 }

--- a/core/shared/src/test/scala/zio/prelude/InverseSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/InverseSpec.scala
@@ -8,12 +8,12 @@ object InverseSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("InverseSpec")(
       suite("laws")(
-        testM("char addition")(checkAllLaws(Inverse)(Gen.anyChar.map(Sum(_)))),
         testM("byte addition")(checkAllLaws(Inverse)(Gen.anyByte.map(Sum(_)))),
-        testM("short addition")(checkAllLaws(Inverse)(Gen.anyShort.map(Sum(_)))),
+        testM("char addition")(checkAllLaws(Inverse)(Gen.anyChar.map(Sum(_)))),
         testM("int addition")(checkAllLaws(Inverse)(Gen.anyInt.map(Sum(_)))),
         testM("long addition")(checkAllLaws(Inverse)(Gen.anyLong.map(Sum(_)))),
         testM("set")(checkAllLaws(Inverse)(Gen.setOf(Gen.anyInt))),
+        testM("short addition")(checkAllLaws(Inverse)(Gen.anyShort.map(Sum(_)))),
         testM("tuple2")(checkAllLaws(Inverse)(Gen.anyInt.map(Sum(_)).zip(Gen.anyInt.map(Sum(_))))),
         testM("tuple3")(
           checkAllLaws(Inverse)(Gen.anyInt.map(Sum(_)).zip(Gen.anyInt.map(Sum(_))).zip(Gen.anyInt.map(Sum(_))).map {

--- a/core/shared/src/test/scala/zio/prelude/NonEmptyListSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NonEmptyListSpec.scala
@@ -43,10 +43,7 @@ object NonEmptyListSpec extends DefaultRunnableSpec {
     suite("NonEmptyListSpec")(
       suite("laws")(
         testM("associative")(checkAllLaws(Associative)(genNonEmptyList)),
-        testM("associativeBoth")(checkAllLaws(AssociativeBoth)(GenFs.nonEmptyList, Gen.anyInt)),
         testM("commutativeBoth")(checkAllLaws(CommutativeBoth)(GenFs.nonEmptyList, Gen.anyInt)),
-        testM("covariant")(checkAllLaws(Covariant)(GenFs.nonEmptyList, Gen.anyInt)),
-        testM("equal")(checkAllLaws(Equal)(genNonEmptyList)),
         testM("hash")(checkAllLaws(Hash)(genNonEmptyList)),
         testM("identityBoth")(checkAllLaws(IdentityBoth)(GenFs.nonEmptyList, Gen.anyInt)),
         testM("identityFlatten")(checkAllLaws(IdentityFlatten)(GenFs.nonEmptyList, Gen.anyInt)),

--- a/core/shared/src/test/scala/zio/prelude/NonEmptyTraversableSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NonEmptyTraversableSpec.scala
@@ -20,7 +20,7 @@ object NonEmptyTraversableSpec extends DefaultRunnableSpec {
 
   def spec: ZSpec[Environment, Failure] =
     suite("NonEmptyTraversableSpec")(
-      suite("instances")(
+      suite("laws")(
         testM("nonEmptyChunk")(checkAllLaws(NonEmptyTraversable)(GenFs.nonEmptyChunk, Gen.anyInt))
       ),
       suite("combinators")(

--- a/core/shared/src/test/scala/zio/prelude/OrdSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/OrdSpec.scala
@@ -41,22 +41,22 @@ object OrdSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("OrdSpec")(
       suite("laws")(
-        testM("unit")(checkAllLaws(Ord)(Gen.unit)),
         testM("boolean")(checkAllLaws(Ord)(Gen.boolean)),
         testM("byte")(checkAllLaws(Ord)(Gen.anyByte)),
         testM("char")(checkAllLaws(Ord)(Gen.anyChar)),
-        testM("string")(checkAllLaws(Ord)(Gen.anyString)),
-        testM("int")(checkAllLaws(Ord)(Gen.anyInt)),
-        testM("long")(checkAllLaws(Ord)(Gen.anyLong)),
-        testM("float")(checkAllLaws(Ord)(Gen.anyFloat)),
+        testM("chunk")(checkAllLaws(Ord)(Gen.chunkOf(Gen.anyInt))),
         testM("double")(checkAllLaws(Ord)(Gen.anyDouble)),
-        testM("option")(checkAllLaws(Ord)(Gen.option(Gen.anyInt))),
         testM("either")(checkAllLaws(Ord)(Gen.either(Gen.anyInt, Gen.anyInt))),
+        testM("float")(checkAllLaws(Ord)(Gen.anyFloat)),
+        testM("int")(checkAllLaws(Ord)(Gen.anyInt)),
+        testM("list")(checkAllLaws(Ord)(Gen.listOf(Gen.anyInt))),
+        testM("long")(checkAllLaws(Ord)(Gen.anyLong)),
+        testM("option")(checkAllLaws(Ord)(Gen.option(Gen.anyInt))),
+        testM("string")(checkAllLaws(Ord)(Gen.anyString)),
         testM("tuple2")(checkAllLaws(Ord)(Gen.anyInt.zip(Gen.anyInt))),
         testM("tuple3")(checkAllLaws(Ord)(Gen.anyInt.zip(Gen.anyInt).zip(Gen.anyInt))),
-        testM("list")(checkAllLaws(Ord)(Gen.listOf(Gen.anyInt))),
-        testM("vector")(checkAllLaws(Ord)(Gen.vectorOf(Gen.anyInt))),
-        testM("chunk")(checkAllLaws(Ord)(Gen.chunkOf(Gen.anyInt)))
+        testM("unit")(checkAllLaws(Ord)(Gen.unit)),
+        testM("vector")(checkAllLaws(Ord)(Gen.vectorOf(Gen.anyInt)))
       ),
       suite("ScalaOrdering consistency")(
         testM("unit")(scalaOrderingConsistency(Gen.unit)),

--- a/core/shared/src/test/scala/zio/prelude/PartialOrdSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/PartialOrdSpec.scala
@@ -8,26 +8,8 @@ object PartialOrdSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("OrdSpec")(
       suite("laws")(
-        testM("unit")(checkAllLaws(PartialOrd)(Gen.unit)),
-        testM("boolean")(checkAllLaws(PartialOrd)(Gen.boolean)),
-        testM("byte")(checkAllLaws(PartialOrd)(Gen.anyByte)),
-        testM("char")(checkAllLaws(PartialOrd)(Gen.anyChar)),
-        testM("string")(checkAllLaws(PartialOrd)(Gen.anyString)),
-        testM("int")(checkAllLaws(PartialOrd)(Gen.anyInt)),
-        testM("long")(checkAllLaws(PartialOrd)(Gen.anyLong)),
-        testM("float")(checkAllLaws(PartialOrd)(Gen.anyFloat)),
-        testM("double")(checkAllLaws(PartialOrd)(Gen.anyDouble)),
-        testM("option")(checkAllLaws(PartialOrd)(Gen.option(Gen.anyInt))),
-        testM("either")(checkAllLaws(PartialOrd)(Gen.either(Gen.anyInt, Gen.anyInt))),
-        testM("tuple2")(checkAllLaws(PartialOrd)(Gen.anyInt.zip(Gen.anyInt))),
-        testM("tuple3")(
-          checkAllLaws(PartialOrd)(Gen.anyInt.zip(Gen.anyInt).zip(Gen.anyInt).map { case ((x, y), z) => (x, y, z) })
-        ),
-        testM("set")(checkAllLaws(PartialOrd)(Gen.setOf(Gen.anyInt))),
-        testM("list")(checkAllLaws(PartialOrd)(Gen.listOf(Gen.anyInt))),
-        testM("vector")(checkAllLaws(PartialOrd)(Gen.vectorOf(Gen.anyInt))),
-        testM("chunk")(checkAllLaws(PartialOrd)(Gen.chunkOf(Gen.anyInt))),
-        testM("map")(checkAllLaws(PartialOrd)(Gen.mapOf(Gen.anyInt, Gen.anyInt)))
+        testM("map")(checkAllLaws(PartialOrd)(Gen.mapOf(Gen.anyInt, Gen.anyInt))),
+        testM("set")(checkAllLaws(PartialOrd)(Gen.setOf(Gen.anyInt)))
       ),
       test("map compareSoft") {
         assert(Map.empty[Int, Int] compareSoft Map.empty[Int, Int])(equalTo(Ordering.Equals)) &&

--- a/core/shared/src/test/scala/zio/prelude/TraversableSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/TraversableSpec.scala
@@ -37,14 +37,14 @@ object TraversableSpec extends DefaultRunnableSpec {
 
   def spec: ZSpec[Environment, Failure] =
     suite("TraversableSpec")(
-      suite("instances")(
+      suite("laws")(
         testM("chunk")(checkAllLaws(Traversable)(GenF.chunk, Gen.anyInt)),
+        testM("chunk . option")(checkAllLaws(Traversable)(chunkOptionGenF, Gen.anyInt)),
         testM("either")(checkAllLaws(Traversable)(GenFs.either(Gen.anyInt), Gen.anyInt)),
         testM("list")(checkAllLaws(Traversable)(GenF.list, Gen.anyInt)),
         testM("map")(checkAllLaws(Traversable)(GenFs.map(Gen.anyInt), Gen.anyInt)),
         testM("option")(checkAllLaws(Traversable)(GenF.option, Gen.anyInt)),
-        testM("vector")(checkAllLaws(Traversable)(GenF.vector, Gen.anyInt)),
-        testM("chunk . option")(checkAllLaws(Traversable)(chunkOptionGenF, Gen.anyInt))
+        testM("vector")(checkAllLaws(Traversable)(GenF.vector, Gen.anyInt))
       ),
       suite("combinators")(
         testM("contains") {

--- a/core/shared/src/test/scala/zio/prelude/ValidationSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ValidationSpec.scala
@@ -22,10 +22,8 @@ object ValidationSpec extends DefaultRunnableSpec {
   def spec: ZSpec[Environment, Failure] =
     suite("ValidationSpec")(
       suite("laws")(
-        testM("associativeBoth")(checkAllLaws(AssociativeBoth)(genFValidation, Gen.anyInt)),
         testM("commutativeBoth")(checkAllLaws(CommutativeBoth)(genFValidation, Gen.anyInt)),
         testM("covariant")(checkAllLaws(Covariant)(genFValidation, Gen.anyInt)),
-        testM("equal")(checkAllLaws(Equal)(genValidation)),
         testM("failureCovariant")(
           checkAllLaws[
             CovariantDeriveEqual,

--- a/core/shared/src/test/scala/zio/prelude/ZNonEmptySetSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ZNonEmptySetSpec.scala
@@ -49,7 +49,6 @@ object ZNonEmptySetSpec extends DefaultRunnableSpec {
             IntHashOrd
           )
         ),
-        testM("equal")(checkAllLaws(Equal)(genZNonEmptySet(Gen.anyInt, Gen.anyInt))),
         testM("hash")(checkAllLaws(Hash)(genZNonEmptySet(Gen.anyInt, Gen.anyInt))),
         testM("intersect commutative")(
           checkAllLaws(Commutative)(genZNonEmptySet(Gen.anyInt, Gen.anyInt).map(_.transform(Min(_))))

--- a/core/shared/src/test/scala/zio/prelude/ZSetSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ZSetSpec.scala
@@ -48,7 +48,6 @@ object ZSetSpec extends DefaultRunnableSpec {
             IntHashOrd
           )
         ),
-        testM("equal")(checkAllLaws(Equal)(genZSet(Gen.anyInt, Gen.anyInt))),
         testM("hash")(checkAllLaws(Hash)(genZSet(Gen.anyInt, Gen.anyInt))),
         testM("intersect commutative")(
           checkAllLaws(Commutative)(genZSet(Gen.anyInt, Gen.anyInt).map(_.transform(Min(_))))


### PR DESCRIPTION
Law tests are also now alphabetically sorted
