### PR TITLE
Rename name collisions

### DIFF
--- a/benchmarks/src/main/scala/zio/prelude/StateBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/prelude/StateBenchmarks.scala
@@ -116,7 +116,7 @@ class StateBenchmarks {
   @Benchmark
   def zioEffectfulTraversal(): Int =
     State
-      .foreach(list) { el =>
+      .forEach(list) { el =>
         State.get[Int].flatMap(s => State.set(s + el))
       }
       .runState(0)

--- a/core/shared/src/main/scala-2.11-2.12/zio/prelude/InvariantVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.11-2.12/zio/prelude/InvariantVersionSpecific.scala
@@ -5,11 +5,11 @@ import scala.collection.generic.CanBuildFrom
 trait InvariantVersionSpecific {
 
   /**
-   * Derives a `Traverable[F]` from an `Iterable[F]`.
+   * Derives a `ForEach[F]` from an `Iterable[F]`.
    */
-  implicit def IterableTraversable[F[+a] <: Iterable[a]](implicit derive: DeriveCanBuildFrom[F]): Traversable[F] =
-    new Traversable[F] {
-      def foreach[G[+_]: IdentityBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+  implicit def IterableForEach[F[+a] <: Iterable[a]](implicit derive: DeriveCanBuildFrom[F]): ForEach[F] =
+    new ForEach[F] {
+      def forEach[G[+_]: IdentityBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
         fa.foldLeft(derive.derive[B](fa).succeed)((bs, a) => bs.zipWith(f(a))(_ += _)).map(_.result())
     }
 

--- a/core/shared/src/main/scala-2.13+/zio/prelude/InvariantVersionSpecific.scala
+++ b/core/shared/src/main/scala-2.13+/zio/prelude/InvariantVersionSpecific.scala
@@ -5,11 +5,11 @@ import scala.collection.BuildFrom
 trait InvariantVersionSpecific {
 
   /**
-   * Derives a `Traverable[F]` from an `Iterable[F]`.
+   * Derives a `ForEach[F]` from an `Iterable[F]`.
    */
-  implicit def IterableTraversable[F[+a] <: Iterable[a]](implicit derive: DeriveBuildFrom[F]): Traversable[F] =
-    new Traversable[F] {
-      def foreach[G[+_]: IdentityBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+  implicit def IterableForEach[F[+a] <: Iterable[a]](implicit derive: DeriveBuildFrom[F]): ForEach[F] =
+    new ForEach[F] {
+      def forEach[G[+_]: IdentityBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
         fa.foldLeft(derive.derive[B].newBuilder(fa).succeed)((bs, a) => bs.zipWith(f(a))(_ += _)).map(_.result())
     }
 

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -66,11 +66,11 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
     }
 
   /**
-   * The `Traversable` (and thus `Covariant` and `Invariant`) for `Chunk`.
+   * The `ForEach` (and thus `Covariant` and `Invariant`) for `Chunk`.
    */
-  implicit val ChunkTraversable: Traversable[Chunk] =
-    new Traversable[Chunk] {
-      def foreach[G[+_]: IdentityBoth: Covariant, A, B](chunk: Chunk[A])(f: A => G[B]): G[Chunk[B]] =
+  implicit val ChunkForEach: ForEach[Chunk] =
+    new ForEach[Chunk] {
+      def forEach[G[+_]: IdentityBoth: Covariant, A, B](chunk: Chunk[A])(f: A => G[B]): G[Chunk[B]] =
         chunk.foldLeft(ChunkBuilder.make[B]().succeed)((builder, a) => builder.zipWith(f(a))(_ += _)).map(_.result())
     }
 
@@ -90,12 +90,12 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
     Bicovariant.EitherBicovariant.deriveFailureCovariant
 
   /**
-   * The `Traversable` (and thus `Covariant` and `Invariant`) for `Either`.
+   * The `ForEach` (and thus `Covariant` and `Invariant`) for `Either`.
    */
-  implicit def EitherTraversable[E]: Traversable[({ type lambda[+a] = Either[E, a] })#lambda] with Bicovariant[Either] =
-    new Traversable[({ type lambda[+a] = Either[E, a] })#lambda] with Bicovariant[Either] {
+  implicit def EitherForEach[E]: ForEach[({ type lambda[+a] = Either[E, a] })#lambda] with Bicovariant[Either] =
+    new ForEach[({ type lambda[+a] = Either[E, a] })#lambda] with Bicovariant[Either] {
 
-      def foreach[G[+_]: IdentityBoth: Covariant, A, B](either: Either[E, A])(f: A => G[B]): G[Either[E, B]] =
+      def forEach[G[+_]: IdentityBoth: Covariant, A, B](either: Either[E, A])(f: A => G[B]): G[Either[E, B]] =
         either.fold(Left(_).succeed, f(_).map(Right(_)))
 
       override def bimap[A, B, AA, BB](f: A => AA, g: B => BB): Either[A, B] => Either[AA, BB] = {
@@ -599,11 +599,11 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
     }
 
   /**
-   * The `NonEmptyTraversable` (and thus `Traversable`, `Covariant` and `Invariant`) instance for `Id`.
+   * The `NonEmptyForEach` (and thus `ForEach`, `Covariant` and `Invariant`) instance for `Id`.
    */
-  implicit val IdNonEmptyTraversable: NonEmptyTraversable[Id] =
-    new NonEmptyTraversable[Id] {
-      override def foreach1[G[+_]: AssociativeBoth: Covariant, A, B](fa: Id[A])(f: A => G[B]): G[Id[B]] =
+  implicit val IdNonEmptyForEach: NonEmptyForEach[Id] =
+    new NonEmptyForEach[Id] {
+      override def forEach1[G[+_]: AssociativeBoth: Covariant, A, B](fa: Id[A])(f: A => G[B]): G[Id[B]] =
         f(Id.unwrap(fa)).map(Id(_))
 
       override def map[A, B](f: A => B): Id[A] => Id[B] = { id =>
@@ -640,32 +640,32 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
     }
 
   /**
-   * The `Traversable` (and thus `Covariant` and `Invariant`) instance for `List`.
+   * The `ForEach` (and thus `Covariant` and `Invariant`) instance for `List`.
    */
-  implicit val ListTraversable: Traversable[List] =
-    new Traversable[List] {
-      def foreach[G[+_]: IdentityBoth: Covariant, A, B](list: List[A])(f: A => G[B]): G[List[B]] =
+  implicit val ListForEach: ForEach[List] =
+    new ForEach[List] {
+      def forEach[G[+_]: IdentityBoth: Covariant, A, B](list: List[A])(f: A => G[B]): G[List[B]] =
         list.foldRight[G[List[B]]](Nil.succeed)((a, bs) => f(a).zipWith(bs)(_ :: _))
       override def map[A, B](f: A => B): List[A] => List[B]                                      = _.map(f)
     }
 
   /**
-   * The `Traversable` (and thus `Covariant` and `Invariant`) instance for `Map`.
+   * The `ForEach` (and thus `Covariant` and `Invariant`) instance for `Map`.
    */
-  implicit def MapTraversable[K]: Traversable[({ type lambda[+v] = Map[K, v] })#lambda] =
-    new Traversable[({ type lambda[+v] = Map[K, v] })#lambda] {
-      def foreach[G[+_]: IdentityBoth: Covariant, V, V2](map: Map[K, V])(f: V => G[V2]): G[Map[K, V2]] =
+  implicit def MapForEach[K]: ForEach[({ type lambda[+v] = Map[K, v] })#lambda] =
+    new ForEach[({ type lambda[+v] = Map[K, v] })#lambda] {
+      def forEach[G[+_]: IdentityBoth: Covariant, V, V2](map: Map[K, V])(f: V => G[V2]): G[Map[K, V2]] =
         map.foldLeft[G[Map[K, V2]]](Map.empty.succeed) { case (map, (k, v)) =>
           map.zipWith(f(v))((map, v2) => map + (k -> v2))
         }
     }
 
   /**
-   * The `NonEmptyTraversable` (and thus `Traversable`, `Covariant` and `Invariant`) instance for `NonEmptyChunk`.
+   * The `NonEmptyForEach` (and thus `ForEach`, `Covariant` and `Invariant`) instance for `NonEmptyChunk`.
    */
-  implicit val NonEmptyChunkNonEmptyTraversable: NonEmptyTraversable[NonEmptyChunk] =
-    new NonEmptyTraversable[NonEmptyChunk] {
-      def foreach1[F[+_]: AssociativeBoth: Covariant, A, B](
+  implicit val NonEmptyChunkNonEmptyForEach: NonEmptyForEach[NonEmptyChunk] =
+    new NonEmptyForEach[NonEmptyChunk] {
+      def forEach1[F[+_]: AssociativeBoth: Covariant, A, B](
         nonEmptyChunk: NonEmptyChunk[A]
       )(f: A => F[B]): F[NonEmptyChunk[B]] =
         nonEmptyChunk
@@ -674,11 +674,11 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
     }
 
   /**
-   * The `Traversable` (and thus `Covariant` and `Invariant`) instance for `Option`.
+   * The `ForEach` (and thus `Covariant` and `Invariant`) instance for `Option`.
    */
-  implicit val OptionTraversable: Traversable[Option] =
-    new Traversable[Option] {
-      def foreach[G[+_]: IdentityBoth: Covariant, A, B](option: Option[A])(f: A => G[B]): G[Option[B]] =
+  implicit val OptionForEach: ForEach[Option] =
+    new ForEach[Option] {
+      def forEach[G[+_]: IdentityBoth: Covariant, A, B](option: Option[A])(f: A => G[B]): G[Option[B]] =
         option.fold[G[Option[B]]](Option.empty.succeed)(a => f(a).map(Some(_)))
     }
 
@@ -1275,11 +1275,11 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
     }
 
   /**
-   * The `Traversable` (and thus `Covariant` and `Invariant`) instance for `Vector`.
+   * The `ForEach` (and thus `Covariant` and `Invariant`) instance for `Vector`.
    */
-  implicit val VectorTraversable: Traversable[Vector] =
-    new Traversable[Vector] {
-      def foreach[G[+_]: IdentityBoth: Covariant, A, B](vector: Vector[A])(f: A => G[B]): G[Vector[B]] =
+  implicit val VectorForEach: ForEach[Vector] =
+    new ForEach[Vector] {
+      def forEach[G[+_]: IdentityBoth: Covariant, A, B](vector: Vector[A])(f: A => G[B]): G[Vector[B]] =
         vector.foldLeft[G[Vector[B]]](Vector.empty.succeed)((bs, a) => bs.zipWith(f(a))(_ :+ _))
     }
 

--- a/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -12,7 +12,7 @@ import scala.util.hashing.MurmurHash3
  * A `NonEmptyList[A]` is a list of one or more values of type A. Unlike a
  * `List`, a `NonEmptyList` is guaranteed to contain at least one element.
  * This additional structure allows some operations to be defined on
- * `NonEmptyList` that are not safe on `List`, such as `head` and `reduce`.
+ * `NonEmptyList` that are not safe on `List`, such as `head` and `reduceAll`.
  *
  * For interoperability with Scala's collection library an implicit conversion
  * is provided from `NonEmptyList` to the `::` case of `List`. Operations that
@@ -171,7 +171,7 @@ sealed trait NonEmptyList[+A] { self =>
    * Transforms each element of this `NonEmptyList` with the specified
    * effectual function.
    */
-  final def foreach[F[+_]: AssociativeBoth: Covariant, B](f: A => F[B]): F[NonEmptyList[B]] =
+  final def forEach[F[+_]: AssociativeBoth: Covariant, B](f: A => F[B]): F[NonEmptyList[B]] =
     reduceMapRight(f(_).map(single))((a, fas) => f(a).zipWith(fas)(cons))
 
   /**
@@ -285,7 +285,7 @@ sealed trait NonEmptyList[+A] { self =>
   /**
    * Reduces the elements of this `NonEmptyList` from left to right using the
    * function `map` to transform the first value to the type `B` and then the
-   * function `reduce` to combine the `B` value with each other `A` value.
+   * function `reduceAll` to combine the `B` value with each other `A` value.
    */
   final def reduceMapLeft[B](map: A => B)(reduce: (B, A) => B): B =
     self match {
@@ -296,7 +296,7 @@ sealed trait NonEmptyList[+A] { self =>
   /**
    * Reduces the elements of this `NonEmptyList` from right to left using the
    * function `map` to transform the first value to the type `B` and then the
-   * function `reduce` to combine the `B` value with each other `A` value.
+   * function `reduceAll` to combine the `B` value with each other `A` value.
    */
   final def reduceMapRight[B](map: A => B)(reduce: (A, B) => B): B =
     self.reverse.reduceMapLeft(map)((b, a) => reduce(a, b))
@@ -493,12 +493,12 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
     }
 
   /**
-   * The `NonEmptyTraversable` instance for `NonEmptyList`.
+   * The `NonEmptyForEach` instance for `NonEmptyList`.
    */
-  implicit val NonEmptyListNonEmptyTraversable: NonEmptyTraversable[NonEmptyList] =
-    new NonEmptyTraversable[NonEmptyList] {
-      def foreach1[F[+_]: AssociativeBoth: Covariant, A, B](fa: NonEmptyList[A])(f: A => F[B]): F[NonEmptyList[B]] =
-        fa.foreach(f)
+  implicit val NonEmptyListNonEmptyForEach: NonEmptyForEach[NonEmptyList] =
+    new NonEmptyForEach[NonEmptyList] {
+      def forEach1[F[+_]: AssociativeBoth: Covariant, A, B](fa: NonEmptyList[A])(f: A => F[B]): F[NonEmptyList[B]] =
+        fa.forEach(f)
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/ParSeq.scala
+++ b/core/shared/src/main/scala/zio/prelude/ParSeq.scala
@@ -112,7 +112,7 @@ sealed trait ParSeq[+Z <: Unit, +A] { self =>
    * collection of events, collecting them back into a single collection of
    * events.
    */
-  final def foreach[F[+_]: IdentityBoth: Covariant, B](f: A => F[B]): F[ParSeq[Z, B]] =
+  final def forEach[F[+_]: IdentityBoth: Covariant, B](f: A => F[B]): F[ParSeq[Z, B]] =
     fold[F[ParSeq[Unit, B]]](ParSeq.empty.succeed, a => f(a).map(ParSeq.single))(
       _.zipWith(_)(_ ++ _),
       _.zipWith(_)(_ && _)
@@ -312,12 +312,12 @@ object ParSeq {
     }
 
   /**
-   * The `NonEmptyTraversable` instance for `ParSeq.
+   * The `NonEmptyForEach` instance for `ParSeq.
    */
-  implicit def parSeqTraversable[Z <: Unit]: Traversable[({ type lambda[+a] = ParSeq[Z, a] })#lambda] =
-    new Traversable[({ type lambda[+a] = ParSeq[Z, a] })#lambda] {
-      def foreach[F[+_]: IdentityBoth: Covariant, A, B](fa: ParSeq[Z, A])(f: A => F[B]): F[ParSeq[Z, B]] =
-        fa.foreach(f)
+  implicit def parSeqForEach[Z <: Unit]: ForEach[({ type lambda[+a] = ParSeq[Z, a] })#lambda] =
+    new ForEach[({ type lambda[+a] = ParSeq[Z, a] })#lambda] {
+      def forEach[F[+_]: IdentityBoth: Covariant, A, B](fa: ParSeq[Z, A])(f: A => F[B]): F[ParSeq[Z, B]] =
+        fa.forEach(f)
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
+++ b/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
@@ -183,33 +183,33 @@ object DeriveEqualIdentityEitherInvariant {
     }
 }
 
-trait DeriveEqualNonEmptyTraversable[F[+_]] extends DeriveEqualTraversable[F] with NonEmptyTraversable[F]
+trait DeriveEqualNonEmptyForEach[F[+_]] extends DeriveEqualForEach[F] with NonEmptyForEach[F]
 
-object DeriveEqualNonEmptyTraversable {
+object DeriveEqualNonEmptyForEach {
   implicit def derive[F[+_]](implicit
     deriveEqual0: DeriveEqual[F],
-    nonEmptyTraversable0: NonEmptyTraversable[F]
-  ): DeriveEqualNonEmptyTraversable[F] =
-    new DeriveEqualNonEmptyTraversable[F] {
+    nonEmptyForEach0: NonEmptyForEach[F]
+  ): DeriveEqualNonEmptyForEach[F] =
+    new DeriveEqualNonEmptyForEach[F] {
       def derive[A: Equal]: Equal[F[A]]                                                      =
         deriveEqual0.derive
-      def foreach1[G[+_]: AssociativeBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
-        nonEmptyTraversable0.foreach1(fa)(f)
+      def forEach1[G[+_]: AssociativeBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+        nonEmptyForEach0.forEach1(fa)(f)
     }
 }
 
-trait DeriveEqualTraversable[F[+_]] extends CovariantDeriveEqual[F] with Traversable[F]
+trait DeriveEqualForEach[F[+_]] extends CovariantDeriveEqual[F] with ForEach[F]
 
-object DeriveEqualTraversable {
+object DeriveEqualForEach {
   implicit def derive[F[+_]](implicit
     deriveEqual0: DeriveEqual[F],
-    traversable0: Traversable[F]
-  ): DeriveEqualTraversable[F] =
-    new DeriveEqualTraversable[F] {
+    forEach0: ForEach[F]
+  ): DeriveEqualForEach[F] =
+    new DeriveEqualForEach[F] {
       def derive[A: Equal]: Equal[F[A]]                                                  =
         deriveEqual0.derive
-      def foreach[G[+_]: IdentityBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
-        traversable0.foreach(fa)(f)
+      def forEach[G[+_]: IdentityBoth: Covariant, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+        forEach0.forEach(fa)(f)
     }
 }
 

--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -840,10 +840,10 @@ object ZPure {
    * passes the updated state from each computation to the next and collects
    * the results.
    */
-  def collectAll[F[+_]: Traversable, W, S, R, E, A](fa: F[ZPure[W, S, S, R, E, A]]): ZPure[W, S, S, R, E, F[A]] =
-    Traversable[F].flip[({ type lambda[+A] = ZPure[W, S, S, R, E, A] })#lambda, A](fa)
+  def collectAll[F[+_]: ForEach, W, S, R, E, A](fa: F[ZPure[W, S, S, R, E, A]]): ZPure[W, S, S, R, E, F[A]] =
+    ForEach[F].flip[({ type lambda[+A] = ZPure[W, S, S, R, E, A] })#lambda, A](fa)
 
-  def environment[S, R]: ZPure[Nothing, S, S, R, Nothing, R]                                                    =
+  def environment[S, R]: ZPure[Nothing, S, S, R, Nothing, R]                                                =
     access(r => r)
 
   def fail[E](e: E): ZPure[Nothing, Any, Nothing, Any, E, Nothing] =
@@ -914,10 +914,10 @@ object ZPure {
    * into a single computation that passes the updated state from each
    * computation to the next and collects the results.
    */
-  def foreach[F[+_]: Traversable, W, S, R, E, A, B](fa: F[A])(
+  def forEach[F[+_]: ForEach, W, S, R, E, A, B](fa: F[A])(
     f: A => ZPure[W, S, S, R, E, B]
   ): ZPure[W, S, S, R, E, F[B]]                     =
-    Traversable[F].foreach[({ type lambda[+A] = ZPure[W, S, S, R, E, A] })#lambda, A, B](fa)(f)
+    ForEach[F].forEach[({ type lambda[+A] = ZPure[W, S, S, R, E, A] })#lambda, A, B](fa)(f)
 
   /**
    * Constructs a computation that returns the initial state unchanged.

--- a/core/shared/src/main/scala/zio/prelude/package.scala
+++ b/core/shared/src/main/scala/zio/prelude/package.scala
@@ -27,10 +27,10 @@ package object prelude
     with NewtypeExports
     with NewtypeFExports
     with NonEmptySetSyntax
-    with NonEmptyTraversableSyntax
+    with NonEmptyForEachSyntax
     with OrdSyntax
     with PartialOrdSyntax
-    with TraversableSyntax
+    with ForEachSyntax
     with ZivariantSyntax {
 
   type <=>[A, B] = Equivalence[A, B]

--- a/core/shared/src/test/scala/zio/prelude/ForEachSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ForEachSpec.scala
@@ -5,7 +5,7 @@ import zio.test._
 import zio.test.laws._
 import zio.{Chunk, NonEmptyChunk, Ref}
 
-object TraversableSpec extends DefaultRunnableSpec {
+object ForEachSpec extends DefaultRunnableSpec {
   import Fixtures._
 
   val genBoolean: Gen[Random, Boolean] =
@@ -32,52 +32,52 @@ object TraversableSpec extends DefaultRunnableSpec {
   val genIntIntFunction2: Gen[Random, (Int, Int) => (Int, Int)] =
     Gen.function2(genInt <*> genInt)
 
-  implicit val chunkOptionTraversable: Traversable[ChunkOption] =
-    Traversable[Chunk].compose[Option]
+  implicit val chunkOptionForEach: ForEach[ChunkOption] =
+    ForEach[Chunk].compose[Option]
 
   def spec: ZSpec[Environment, Failure] =
-    suite("TraversableSpec")(
+    suite("ForEachSpec")(
       suite("laws")(
-        testM("chunk")(checkAllLaws(Traversable)(GenF.chunk, Gen.anyInt)),
-        testM("chunk . option")(checkAllLaws(Traversable)(chunkOptionGenF, Gen.anyInt)),
-        testM("either")(checkAllLaws(Traversable)(GenFs.either(Gen.anyInt), Gen.anyInt)),
-        testM("list")(checkAllLaws(Traversable)(GenF.list, Gen.anyInt)),
-        testM("map")(checkAllLaws(Traversable)(GenFs.map(Gen.anyInt), Gen.anyInt)),
-        testM("option")(checkAllLaws(Traversable)(GenF.option, Gen.anyInt)),
-        testM("vector")(checkAllLaws(Traversable)(GenF.vector, Gen.anyInt))
+        testM("chunk")(checkAllLaws(ForEach)(GenF.chunk, Gen.anyInt)),
+        testM("chunk . option")(checkAllLaws(ForEach)(chunkOptionGenF, Gen.anyInt)),
+        testM("either")(checkAllLaws(ForEach)(GenFs.either(Gen.anyInt), Gen.anyInt)),
+        testM("list")(checkAllLaws(ForEach)(GenF.list, Gen.anyInt)),
+        testM("map")(checkAllLaws(ForEach)(GenFs.map(Gen.anyInt), Gen.anyInt)),
+        testM("option")(checkAllLaws(ForEach)(GenF.option, Gen.anyInt)),
+        testM("vector")(checkAllLaws(ForEach)(GenF.vector, Gen.anyInt))
       ),
       suite("combinators")(
         testM("contains") {
           check(genList, genInt) { (as, a) =>
-            val actual   = Traversable[List].contains(as)(a)
+            val actual   = ForEach[List].contains(as)(a)
             val expected = as.contains(a)
             assert(actual)(equalTo(expected))
           }
         },
         testM("count") {
           check(genList, genBooleanFunction) { (as, f) =>
-            val actual   = Traversable[List].count(as)(f)
+            val actual   = ForEach[List].count(as)(f)
             val expected = as.count(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("exists") {
           check(genList, genBooleanFunction) { (as, f) =>
-            val actual   = Traversable[List].exists(as)(f)
+            val actual   = ForEach[List].exists(as)(f)
             val expected = as.exists(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("find") {
           check(genList, genBooleanFunction) { (as, f) =>
-            val actual   = Traversable[List].find(as)(f)
+            val actual   = ForEach[List].find(as)(f)
             val expected = as.find(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("foldLeft") {
           check(genList, genInt, genIntFunction2) { (as, s, f) =>
-            val actual   = Traversable[List].foldLeft(as)(s)(f)
+            val actual   = ForEach[List].foldLeft(as)(s)(f)
             val expected = as.foldLeft(s)(f)
             assert(actual)(equalTo(expected))
           }
@@ -93,7 +93,7 @@ object TraversableSpec extends DefaultRunnableSpec {
         },
         testM("foldRight") {
           check(genList, genInt, genIntFunction2) { (as, s, f) =>
-            val actual   = Traversable[List].foldRight(as)(s)(f)
+            val actual   = ForEach[List].foldRight(as)(s)(f)
             val expected = as.foldRight(s)(f)
             assert(actual)(equalTo(expected))
           }
@@ -109,14 +109,14 @@ object TraversableSpec extends DefaultRunnableSpec {
         },
         testM("forall") {
           check(genList, genBooleanFunction) { (as, f) =>
-            val actual   = Traversable[List].forall(as)(f)
+            val actual   = ForEach[List].forall(as)(f)
             val expected = as.forall(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("groupBy") {
           check(genList, genIntFunction) { (as, f) =>
-            val actual   = Traversable[List].groupBy(as)(f)
+            val actual   = ForEach[List].groupBy(as)(f)
             val expected = as
               .groupBy(f)
               .toList
@@ -128,7 +128,7 @@ object TraversableSpec extends DefaultRunnableSpec {
         testM("groupByM") {
           check(genList, genIntFunction) { (as, f) =>
             // Dotty can't infer Function1Covariant: 'Required: zio.prelude.Covariant[[R] =>> Int => R]'
-            val actual   = Traversable[List].groupByM(as)(f.map(Option(_))(Invariant.Function1Covariant))
+            val actual   = ForEach[List].groupByM(as)(f.map(Option(_))(Invariant.Function1Covariant))
             val expected = Option(
               as.groupBy(f)
                 .toList
@@ -140,98 +140,98 @@ object TraversableSpec extends DefaultRunnableSpec {
         },
         testM("isEmpty") {
           check(genList) { (as) =>
-            val actual   = Traversable[List].isEmpty(as)
+            val actual   = ForEach[List].isEmpty(as)
             val expected = as.isEmpty
             assert(actual)(equalTo(expected))
           }
         },
         testM("map") {
           check(genList, genIntFunction) { (as, f) =>
-            val actual   = Traversable[List].map(f)(as)
+            val actual   = ForEach[List].map(f)(as)
             val expected = as.map(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("mapAccum") {
           check(genChunk, genInt, genIntIntFunction2) { (as, s, f) =>
-            val actual   = Traversable[Chunk].mapAccum(as)(s)(f)
+            val actual   = ForEach[Chunk].mapAccum(as)(s)(f)
             val expected = as.mapAccum(s)(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("maxOption") {
           check(genList) { (as) =>
-            val actual   = Traversable[List].maxOption(as)
+            val actual   = ForEach[List].maxOption(as)
             val expected = as.maxOption
             assert(actual)(equalTo(expected))
           }
         },
         testM("maxByOption") {
           check(genList, genIntFunction) { (as, f) =>
-            val actual   = Traversable[List].maxByOption(as)(f)
+            val actual   = ForEach[List].maxByOption(as)(f)
             val expected = as.maxByOption(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("minOption") {
           check(genList) { (as) =>
-            val actual   = Traversable[List].minOption(as)
+            val actual   = ForEach[List].minOption(as)
             val expected = as.minOption
             assert(actual)(equalTo(expected))
           }
         },
         testM("minByOption") {
           check(genList, genIntFunction) { (as, f) =>
-            val actual   = Traversable[List].minByOption(as)(f)
+            val actual   = ForEach[List].minByOption(as)(f)
             val expected = as.minByOption(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("nonEmpty") {
           check(genList) { (as) =>
-            val actual   = Traversable[List].nonEmpty(as)
+            val actual   = ForEach[List].nonEmpty(as)
             val expected = as.nonEmpty
             assert(actual)(equalTo(expected))
           }
         },
         testM("product") {
           check(genList) { (as) =>
-            val actual   = Traversable[List].product(as)
+            val actual   = ForEach[List].product(as)
             val expected = as.product
             assert(actual)(equalTo(expected))
           }
         },
         testM("reduceOption") {
           check(genList, genIntFunction2) { (as, f) =>
-            val actual   = Traversable[List].reduceOption(as)(f)
+            val actual   = ForEach[List].reduceOption(as)(f)
             val expected = as.reduceOption(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("reverse") {
           check(genList) { (as) =>
-            val actual   = Traversable[List].reverse(as)
+            val actual   = ForEach[List].reverse(as)
             val expected = as.reverse
             assert(actual)(equalTo(expected))
           }
         },
         testM("size") {
           check(genList) { (as) =>
-            val actual   = Traversable[List].size(as)
+            val actual   = ForEach[List].size(as)
             val expected = as.size
             assert(actual)(equalTo(expected))
           }
         },
         testM("sum") {
           check(genList) { (as) =>
-            val actual   = Traversable[List].sum(as)
+            val actual   = ForEach[List].sum(as)
             val expected = as.sum
             assert(actual)(equalTo(expected))
           }
         },
         testM("zipWithIndex") {
           check(genList) { (as) =>
-            val actual   = Traversable[List].zipWithIndex(as)
+            val actual   = ForEach[List].zipWithIndex(as)
             val expected = as.zipWithIndex
             assert(actual)(equalTo(expected))
           }
@@ -240,12 +240,12 @@ object TraversableSpec extends DefaultRunnableSpec {
       test("zipWithIndex is stacks safe") {
         val as       = (1 to 100000).toList
         val expected = as.zipWithIndex
-        val actual   = Invariant.ListTraversable.zipWithIndex(as)
+        val actual   = Invariant.ListForEach.zipWithIndex(as)
         assert(actual)(equalTo(expected))
       },
-      testM("Traversable can be derived from Iterable") {
+      testM("ForEach can be derived from Iterable") {
         check(genList, genInt, genIntFunction2) { (as, s, f) =>
-          val actual   = Traversable[Seq].foldLeft(as)(s)(f)
+          val actual   = ForEach[Seq].foldLeft(as)(s)(f)
           val expected = as.foldLeft(s)(f)
           assert(actual)(equalTo(expected))
         }

--- a/core/shared/src/test/scala/zio/prelude/NonEmptyForEachSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NonEmptyForEachSpec.scala
@@ -4,7 +4,7 @@ import zio.random.Random
 import zio.test._
 import zio.test.laws._
 
-object NonEmptyTraversableSpec extends DefaultRunnableSpec {
+object NonEmptyForEachSpec extends DefaultRunnableSpec {
 
   val genInt: Gen[Random, Int] =
     Gen.anyInt
@@ -19,49 +19,49 @@ object NonEmptyTraversableSpec extends DefaultRunnableSpec {
     Gen.function2(genInt)
 
   def spec: ZSpec[Environment, Failure] =
-    suite("NonEmptyTraversableSpec")(
+    suite("NonEmptyForEachSpec")(
       suite("laws")(
-        testM("nonEmptyChunk")(checkAllLaws(NonEmptyTraversable)(GenFs.nonEmptyChunk, Gen.anyInt))
+        testM("nonEmptyChunk")(checkAllLaws(NonEmptyForEach)(GenFs.nonEmptyChunk, Gen.anyInt))
       ),
       suite("combinators")(
         testM("max") {
           check(genNonEmptyList) { (as) =>
-            val actual   = NonEmptyTraversable[NonEmptyList].max(as)
+            val actual   = NonEmptyForEach[NonEmptyList].max(as)
             val expected = as.max
             assert(actual)(equalTo(expected))
           }
         },
         testM("maxBy") {
           check(genNonEmptyList, genIntFunction) { (as, f) =>
-            val actual   = NonEmptyTraversable[NonEmptyList].maxBy(as)(f)
+            val actual   = NonEmptyForEach[NonEmptyList].maxBy(as)(f)
             val expected = as.maxBy(f)
             assert(actual)(equalTo(expected))
           }
         },
         testM("min") {
           check(genNonEmptyList) { (as) =>
-            val actual   = NonEmptyTraversable[NonEmptyList].min(as)
+            val actual   = NonEmptyForEach[NonEmptyList].min(as)
             val expected = as.min
             assert(actual)(equalTo(expected))
           }
         },
         testM("minBy") {
           check(genNonEmptyList, genIntFunction) { (as, f) =>
-            val actual   = NonEmptyTraversable[NonEmptyList].minBy(as)(f)
+            val actual   = NonEmptyForEach[NonEmptyList].minBy(as)(f)
             val expected = as.minBy(f)
             assert(actual)(equalTo(expected))
           }
         },
-        testM("reduce") {
+        testM("reduceAll") {
           check(genNonEmptyList, genIntFunction2) { (as, f) =>
-            val actual   = NonEmptyTraversable[NonEmptyList].reduce(as)(f)
+            val actual   = NonEmptyForEach[NonEmptyList].reduceAll(as)(f)
             val expected = as.reduce(Associative.make(f))
             assert(actual)(equalTo(expected))
           }
         },
         testM("toNonEmptyChunk") {
           check(genNonEmptyList) { (as) =>
-            val actual   = NonEmptyTraversable[NonEmptyList].toNonEmptyChunk(as)
+            val actual   = NonEmptyForEach[NonEmptyList].toNonEmptyChunk(as)
             val expected = as.toNonEmptyChunk
             assert(actual)(equalTo(expected))
           }

--- a/core/shared/src/test/scala/zio/prelude/NonEmptyListSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NonEmptyListSpec.scala
@@ -47,7 +47,7 @@ object NonEmptyListSpec extends DefaultRunnableSpec {
         testM("hash")(checkAllLaws(Hash)(genNonEmptyList)),
         testM("identityBoth")(checkAllLaws(IdentityBoth)(GenFs.nonEmptyList, Gen.anyInt)),
         testM("identityFlatten")(checkAllLaws(IdentityFlatten)(GenFs.nonEmptyList, Gen.anyInt)),
-        testM("nonEmptyTraversable")(checkAllLaws(NonEmptyTraversable)(GenFs.nonEmptyList, Gen.anyInt)),
+        testM("nonEmptyForEach")(checkAllLaws(NonEmptyForEach)(GenFs.nonEmptyList, Gen.anyInt)),
         testM("ord")(checkAllLaws(Ord)(genNonEmptyList))
       ),
       suite("methods")(

--- a/core/shared/src/test/scala/zio/prelude/ParSeqSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ParSeqSpec.scala
@@ -41,8 +41,8 @@ object ParSeqSpec extends DefaultRunnableSpec {
         testM("identityFlatten") {
           checkAllLaws(IdentityFlatten)(GenFs.parSeq(Gen.unit), Gen.anyInt)
         },
-        testM("traversable") {
-          checkAllLaws(Traversable)(GenFs.parSeq(Gen.unit), Gen.anyInt)
+        testM("forEach") {
+          checkAllLaws(ForEach)(GenFs.parSeq(Gen.unit), Gen.anyInt)
         }
       ),
       suite("both")(


### PR DESCRIPTION
closes #312 as well as a collision for `reduce` in NonEmptyTraversable.

I left untouched anything that didn't collide, including `foreach1` and `foreach_`. Perhaps we want to change these as well for internal consistency? 

UPDATE: As discussed below, I've actually undone this ^^^ and instead added `reduce0` and `foreach0` to _only_ the implicit classes.