### PR TITLE
Add Variants For Running ZPure Values

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Assertions.scala
+++ b/core/shared/src/main/scala/zio/prelude/Assertions.scala
@@ -21,7 +21,7 @@ trait Assertions {
    */
   def isFailureV[E](assertion: Assertion[E]): Assertion[Validation[E, Any]] =
     Assertion.assertionRec("isFailureV")(param(assertion))(assertion) { validation =>
-      validation.runEither(()) match {
+      validation.either.run match {
         case Left(e) => Some(e)
         case _       => None
       }
@@ -61,8 +61,8 @@ trait Assertions {
    */
   def isSuccessV[A](assertion: Assertion[A]): Assertion[Validation[Any, A]] =
     Assertion.assertionRec("isSuccessV")(param(assertion))(assertion) { validation =>
-      validation.runEither(()) match {
-        case Right(a) => Some(a._2)
+      validation.either.run match {
+        case Right(a) => Some(a)
         case _        => None
       }
     }

--- a/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
@@ -1,10 +1,10 @@
 package zio.prelude.fx
 
-import zio.{Chunk, CanFail}
 import zio.prelude._
 import zio.random.Random
-import zio.test.Assertion.{ equalTo => _, _ }
+import zio.test.Assertion.{equalTo => _, _}
 import zio.test._
+import zio.{CanFail, Chunk}
 
 import java.util.NoSuchElementException
 import scala.util.Try
@@ -225,7 +225,9 @@ object ZPureSpec extends DefaultRunnableSpec {
             },
             test("failure") {
               val f = (s: Int) => if (s == 3) Left("error") else Right((s + 1, (s + 1) / 10))
-              assert(ZPure.modifyEither(f).repeatUntilState(_ == 10).getState.either.runResult(0))(isLeft(equalTo("error")))
+              assert(ZPure.modifyEither(f).repeatUntilState(_ == 10).getState.either.runResult(0))(
+                isLeft(equalTo("error"))
+              )
             }
           ),
           suite("repeatUntilStateEquals")(
@@ -239,7 +241,9 @@ object ZPureSpec extends DefaultRunnableSpec {
             },
             test("failure") {
               val f = (s: Int) => if (s == 3) Left("error") else Right((s + 1, (s + 1) / 10))
-              assert(ZPure.modifyEither(f).repeatUntilStateEquals(10).getState.either.runResult(0))(isLeft(equalTo("error")))
+              assert(ZPure.modifyEither(f).repeatUntilStateEquals(10).getState.either.runResult(0))(
+                isLeft(equalTo("error"))
+              )
             }
           ),
           suite("repeatWhile")(
@@ -277,7 +281,9 @@ object ZPureSpec extends DefaultRunnableSpec {
             },
             test("failure") {
               val f = (s: Int) => if (s == 3) Left("error") else Right((s + 1, (s + 1) / 10))
-              assert(ZPure.modifyEither(f).repeatWhileState(_ < 10).getState.either.runResult(0))(isLeft(equalTo("error")))
+              assert(ZPure.modifyEither(f).repeatWhileState(_ < 10).getState.either.runResult(0))(
+                isLeft(equalTo("error"))
+              )
             }
           ),
           testM("run") {
@@ -378,7 +384,9 @@ object ZPureSpec extends DefaultRunnableSpec {
           suite("none")(
             testM("success") {
               check(genInt) { s =>
-                assert(ZPure.succeed[Int, Option[Int]](None).none.getState.either.runResult(s))(isRight(equalTo((s, ()))))
+                assert(ZPure.succeed[Int, Option[Int]](None).none.getState.either.runResult(s))(
+                  isRight(equalTo((s, ())))
+                )
               }
             },
             testM("failure") {
@@ -401,7 +409,8 @@ object ZPureSpec extends DefaultRunnableSpec {
           },
           testM("orElseOptional (None case)") {
             check(genInt, genString) { (s1, e) =>
-              val errorOrUpdate = ZPure.fail(Option.empty[String]).orElseOptional(ZPure.fail(Some(e))).getState.either.runResult(s1)
+              val errorOrUpdate =
+                ZPure.fail(Option.empty[String]).orElseOptional(ZPure.fail(Some(e))).getState.either.runResult(s1)
               assert(errorOrUpdate)(isLeft(equalTo(Option(e))))
             }
           },
@@ -828,7 +837,9 @@ object ZPureSpec extends DefaultRunnableSpec {
               assert(ZPure.modifyEither((_: Int) => Right((1, "success"))).run(0))(equalTo((1, "success")))
             },
             test("failure") {
-              assert(ZPure.modifyEither((_: Int) => Left("error")).getState.either.runResult(0))(isLeft(equalTo("error")))
+              assert(ZPure.modifyEither((_: Int) => Left("error")).getState.either.runResult(0))(
+                isLeft(equalTo("error"))
+              )
             }
           )
         ),


### PR DESCRIPTION
With the addition of the `W` type parameter to `ZPure` we have a little bit of an issue with a combinatorial explosion of different ways to run `ZPure` values:

- Do you want the log, the result, or both?
- Do you want the state, the result, or both?
- Do you want the first error, the full cause, or to require that errors were already handled?
- Do you want to provide an input state or require that no input state is provided?

To address this, this PR adds a set of more composable operators to improve ergonomics of simple use cases as well as allow flexibility for any combination of these choices the user wants.

The fundamental operator is `runAll`, which requires an initial state and returns the full result of the computation including the log and either all errors that occurred or the final result and updated state. It is expected that users will rarely if ever need to call this but it is available if necessary and provides maximum flexibility.

There are then a set of convenience operators for common cases included `run`, `runEither`, `runState`, and `runResult` to allow users working with more monomorphic versions of `ZPure` without having to interact with additional type parameters.

Finally, there are a set of operators, some of which already existed, to allow flexibility in what is returned:

- `sandbox` / `unsandbox` to expose or submerge the cause of failure
- `either` / `absolve` to surface errors into the value channel or submerge them
- `getState` / `provideState` to surface the output state into the value channel or provide the input state

With these the user has full flexibility in a composable way of what they want returned.