### PR TITLE
Implement ZPure#mapErrorCause

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -396,10 +396,10 @@ sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
     catchAll(e => fail(f(e)))
 
   /**
-    * Returns a computation with its full cause of failure mapped using the
-    * specified function. This can be users to transform errors while
-    * preserving the original structure of the `Cause`.
-    */
+   * Returns a computation with its full cause of failure mapped using the
+   * specified function. This can be users to transform errors while
+   * preserving the original structure of the `Cause`.
+   */
   final def mapErrorCause[E2](f: Cause[E] => Cause[E2]): ZPure[W, S1, S2, R, E2, A] =
     foldCauseM(cause => ZPure.halt(f(cause)), ZPure.succeed)
 

--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -396,6 +396,14 @@ sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
     catchAll(e => fail(f(e)))
 
   /**
+    * Returns a computation with its full cause of failure mapped using the
+    * specified function. This can be users to transform errors while
+    * preserving the original structure of the `Cause`.
+    */
+  final def mapErrorCause[E2](f: Cause[E] => Cause[E2]): ZPure[W, S1, S2, R, E2, A] =
+    foldCauseM(cause => ZPure.halt(f(cause)), ZPure.succeed)
+
+  /**
    * Transforms the updated state of this computation with the specified
    * function.
    */


### PR DESCRIPTION
This is a useful operator for transforming the full cause of failure that we did not have on `ZPure`.