### PR TITLE
Bring back `Validation.fromPredicate`

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -945,13 +945,13 @@ object ZPure extends ZPureLowPriorityImplicits with ZPureArities {
   /**
    * Constructs a `Validation` from a predicate, failing with None.
    */
-  def fromPredicate[A](value: A)(f: A => Boolean): Validation[None.type, A] =
-    fromPredicateWith(None, value)(f)
+  def fromPredicate[A](f: A => Boolean)(value: A): Validation[None.type, A] =
+    fromPredicateWith(None)(f)(value)
 
   /**
    * Constructs a `Validation` from a predicate, failing with the error provided.
    */
-  def fromPredicateWith[E, A](error: E, value: A)(f: A => Boolean): Validation[E, A] =
+  def fromPredicateWith[E, A](error: E)(f: A => Boolean)(value: A): Validation[E, A] =
     if (f(value)) Validation.succeed(value)
     else Validation.fail(error)
 

--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -943,6 +943,19 @@ object ZPure extends ZPureLowPriorityImplicits with ZPureArities {
     }
 
   /**
+   * Constructs a `Validation` from a predicate, failing with None.
+   */
+  def fromPredicate[A](value: A)(f: A => Boolean): Validation[None.type, A] =
+    fromPredicateWith(None, value)(f)
+
+  /**
+   * Constructs a `Validation` from a predicate, failing with the error provided.
+   */
+  def fromPredicateWith[E, A](error: E, value: A)(f: A => Boolean): Validation[E, A] =
+    if (f(value)) Validation.succeed(value)
+    else Validation.fail(error)
+
+  /**
    * Constructs a computation from a `scala.util.Try`.
    */
   def fromTry[S, A](t: Try[A]): ZPure[Nothing, S, S, Any, Throwable, A] =


### PR DESCRIPTION
@adamgfraser Do you think I should avoid the term `Validation` and rename it?

closes https://github.com/zio/zio-prelude/issues/536