### PR TITLE
sbt: remove unused PGP variables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,6 @@ inThisBuild(
         "john@degoes.net",
         url("http://degoes.net")
       )
-    ),
-    pgpPassphrase := sys.env.get("PGP_PASSWORD").map(_.toArray),
-    pgpPublicRing := file("/tmp/public.asc"),
-    pgpSecretRing := file("/tmp/secret.asc"),
-    scmInfo := Some(
-      ScmInfo(url("https://github.com/zio/zio-prelude/"), "scm:git:git@github.com:zio/zio-prelude.git")
     )
   )
 )


### PR DESCRIPTION
I know you guys have more sbt configuration changes on your hands than you ever wished for, but at the next chance, I think we can clean this.

`pgpPassphrase`, `PGP_PASSWORD` is not necessary, because use sbt-ci-release ([the variables we use with it are `PGP_PASSPHRASE` and `PGP_SECRET`](https://github.com/olafurpg/sbt-ci-release#secrets)).

`scmInfo` is populated by sbt-git (a transitive dependency of sbt-ci-release).

@mijicd @softinio 