### PR TITLE
organize-imports 0.5.0

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -18,13 +18,8 @@ Disable {
 }
 
 OrganizeImports {
-  expandRelative = true
+  # Allign with IntelliJ IDEA so that they don't fight each other
   groupedImports = Merge
-  # IntelliJ IDEA's order so that they don't fight each other
-  groups = [
-    "*"
-    "re:(javax?|scala)\\."
-  ]
 }
 
 RemoveUnused {

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -244,7 +244,7 @@ object BuildHelper {
     semanticdbVersion := scalafixSemanticdb.revision, // use Scalafix compatible version
     ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value),
     ThisBuild / scalafixDependencies ++= List(
-      "com.github.liancheng" %% "organize-imports" % "0.4.4",
+      "com.github.liancheng" %% "organize-imports" % "0.5.0",
       "com.github.vovapolu"  %% "scaluzzi"         % "0.1.16"
     ),
     parallelExecution in Test := true,


### PR DESCRIPTION
organize-imports 0.5.0 uses IntelliJ's import order
https://github.com/liancheng/scalafix-organize-imports/releases/tag/v0.5.0