### PR TITLE
Work around bad type inference of our extension methods

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Associative.scala
+++ b/core/shared/src/main/scala/zio/prelude/Associative.scala
@@ -1336,13 +1336,13 @@ trait AssociativeSyntax extends PlatformSpecificAssociativeSyntax {
     /**
      * A symbolic alias for `combine`.
      */
-    def <>(r: => A)(implicit associative: Associative[A]): A =
+    def <>[A1 >: A](r: => A1)(implicit associative: Associative[A1]): A1 =
       associative.combine(l, r)
 
     /**
      * Associatively combines this value with the specified value
      */
-    def combine(r: => A)(implicit associative: Associative[A]): A =
+    def combine[A1 >: A](r: => A1)(implicit associative: Associative[A1]): A1 =
       associative.combine(l, r)
 
     /**

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1341,13 +1341,13 @@ trait AssociativeBothSyntax {
     /**
      * A symbolic alias for `zipLeft`.
      */
-    def <*[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[A] =
+    def <*[F1[+x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[A] =
       zipLeft(fb)
 
     /**
      * A symbolic alias for `zipRight`.
      */
-    def *>[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[B] =
+    def *>[F1[+x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[B] =
       zipRight(fb)
 
     /**
@@ -1360,21 +1360,21 @@ trait AssociativeBothSyntax {
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]`, keeping only the left value.
      */
-    def zipLeft[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[A] =
+    def zipLeft[F1[+x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[A] =
       zipWith(fb)((a, _) => a)
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]`, keeping only the right value.
      */
-    def zipRight[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[B] =
+    def zipRight[F1[+x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[B] =
       zipWith(fb)((_, b) => b)
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]` and then maps the result with the specified function.
      */
-    def zipWith[F1[x] >: F[x], B, C](fb: => F1[B])(
+    def zipWith[F1[+x] >: F[x], B, C](fb: => F1[B])(
       f: (A, B) => C
     )(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[C] =
       both.both(fa, fb).map(f.tupled)
@@ -1389,7 +1389,7 @@ trait AssociativeBothSyntax {
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]` and then contramaps the result with the specified function.
      */
-    def bothWith[F1[x] >: F[x], B, C](
+    def bothWith[F1[-x] >: F[x], B, C](
       fb: => F1[B]
     )(f: C => (A, B))(implicit both: AssociativeBoth[F1], contravariant: Contravariant[F1]): F1[C] =
       both.both(fa, fb).contramap(f)

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1322,14 +1322,14 @@ trait AssociativeBothSyntax {
     /**
      * A symbolic alias for `zip`.
      */
-    def <*>[B](fb: => F[B])(implicit both: AssociativeBoth[F]): F[(A, B)] =
+    def <*>[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1]): F1[(A, B)] =
       zip(fb)
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]`.
      */
-    def zip[B](fb: => F[B])(implicit both: AssociativeBoth[F]): F[(A, B)] =
+    def zip[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1]): F1[(A, B)] =
       both.both(fa, fb)
   }
 
@@ -1341,13 +1341,13 @@ trait AssociativeBothSyntax {
     /**
      * A symbolic alias for `zipLeft`.
      */
-    def <*[B](fb: => F[B])(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[A] =
+    def <*[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[A] =
       zipLeft(fb)
 
     /**
      * A symbolic alias for `zipRight`.
      */
-    def *>[B](fb: => F[B])(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[B] =
+    def *>[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[B] =
       zipRight(fb)
 
     /**
@@ -1360,21 +1360,23 @@ trait AssociativeBothSyntax {
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]`, keeping only the left value.
      */
-    def zipLeft[B](fb: => F[B])(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[A] =
+    def zipLeft[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[A] =
       zipWith(fb)((a, _) => a)
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]`, keeping only the right value.
      */
-    def zipRight[B](fb: => F[B])(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[B] =
+    def zipRight[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[B] =
       zipWith(fb)((_, b) => b)
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]` and then maps the result with the specified function.
      */
-    def zipWith[B, C](fb: => F[B])(f: (A, B) => C)(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[C] =
+    def zipWith[F1[x] >: F[x], B, C](fb: => F1[B])(
+      f: (A, B) => C
+    )(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[C] =
       both.both(fa, fb).map(f.tupled)
   }
 
@@ -1387,9 +1389,9 @@ trait AssociativeBothSyntax {
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]` and then contramaps the result with the specified function.
      */
-    def bothWith[B, C](
-      fb: => F[B]
-    )(f: C => (A, B))(implicit both: AssociativeBoth[F], contravariant: Contravariant[F]): F[C] =
+    def bothWith[F1[x] >: F[x], B, C](
+      fb: => F1[B]
+    )(f: C => (A, B))(implicit both: AssociativeBoth[F1], contravariant: Contravariant[F1]): F1[C] =
       both.both(fa, fb).contramap(f)
   }
 

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1322,14 +1322,14 @@ trait AssociativeBothSyntax {
     /**
      * A symbolic alias for `zip`.
      */
-    def <*>[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1]): F1[(A, B)] =
+    def <*>[B](fb: => F[B])(implicit both: AssociativeBoth[F]): F[(A, B)] =
       zip(fb)
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]`.
      */
-    def zip[F1[x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1]): F1[(A, B)] =
+    def zip[B](fb: => F[B])(implicit both: AssociativeBoth[F]): F[(A, B)] =
       both.both(fa, fb)
   }
 
@@ -1341,13 +1341,13 @@ trait AssociativeBothSyntax {
     /**
      * A symbolic alias for `zipLeft`.
      */
-    def <*[F1[+x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[A] =
+    def <*[B](fb: => F[B])(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[A] =
       zipLeft(fb)
 
     /**
      * A symbolic alias for `zipRight`.
      */
-    def *>[F1[+x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[B] =
+    def *>[B](fb: => F[B])(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[B] =
       zipRight(fb)
 
     /**
@@ -1360,23 +1360,21 @@ trait AssociativeBothSyntax {
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]`, keeping only the left value.
      */
-    def zipLeft[F1[+x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[A] =
+    def zipLeft[B](fb: => F[B])(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[A] =
       zipWith(fb)((a, _) => a)
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]`, keeping only the right value.
      */
-    def zipRight[F1[+x] >: F[x], B](fb: => F1[B])(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[B] =
+    def zipRight[B](fb: => F[B])(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[B] =
       zipWith(fb)((_, b) => b)
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]` and then maps the result with the specified function.
      */
-    def zipWith[F1[+x] >: F[x], B, C](fb: => F1[B])(
-      f: (A, B) => C
-    )(implicit both: AssociativeBoth[F1], covariant: Covariant[F1]): F1[C] =
+    def zipWith[B, C](fb: => F[B])(f: (A, B) => C)(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[C] =
       both.both(fa, fb).map(f.tupled)
   }
 
@@ -1389,9 +1387,9 @@ trait AssociativeBothSyntax {
      * Combines two values of types `F[A]` and `F[B]` to produce an
      * `F[(A, B)]` and then contramaps the result with the specified function.
      */
-    def bothWith[F1[-x] >: F[x], B, C](
-      fb: => F1[B]
-    )(f: C => (A, B))(implicit both: AssociativeBoth[F1], contravariant: Contravariant[F1]): F1[C] =
+    def bothWith[B, C](
+      fb: => F[B]
+    )(f: C => (A, B))(implicit both: AssociativeBoth[F], contravariant: Contravariant[F]): F[C] =
       both.both(fa, fb).contramap(f)
   }
 

--- a/core/shared/src/main/scala/zio/prelude/Inverse.scala
+++ b/core/shared/src/main/scala/zio/prelude/Inverse.scala
@@ -915,13 +915,13 @@ trait InverseSyntax {
     /**
      * A symbolic alias for `inverse`.
      */
-    def ~~(r: => A)(implicit inverse: Inverse[A]): A =
+    def ~~[A1 >: A](r: => A1)(implicit inverse: Inverse[A1]): A1 =
       inverse.inverse(l, r)
 
     /**
      * Inverses this value with the specified value
      */
-    def inverse(r: => A)(implicit inverse: Inverse[A]): A =
+    def inverse[A1 >: A](r: => A1)(implicit inverse: Inverse[A1]): A1 =
       inverse.inverse(l, r)
 
     /**


### PR DESCRIPTION
current master would fail with this
```scala
  val x: Either[Int, String] = Either.cond(test = true, "x", 1)
  val y: Right[Int, String]  = Right("y")

  val _ = x <> y // OK
  val _ = y <> x // doesn't work, but will be fixed
  val _ = x <*> y // OK
  val _ = y <*> x // doesn't work, and won't be fixed, see below
```

## Scala 2.11 and 2.12 and Higher kinds

While Scala 2.13 works fine with `F1[x] >: F[x]`, 2.11 and 2.12 don't like it. If I expand `fa.zipWith(fb)(_ zip _)` in `AssociativeBoth.compose`, I get
```scala
        AssociativeBothCovariantOps[F, G[A]](fa).zipWith[F, G[B], G[(A, B)]](fb)({ case (ga, gb) =>
          AssociativeBothOps[G, A](ga).zip[G, B](gb)
        })
```
For 2.12, the compiler complains
```
type arguments [G,B] do not conform to method zip's type parameter bounds [F1[x] >: G[x],B]
           AssociativeBothOps[G, A](ga).zip[G, B](gb)
                                           ^
```
Seems like we'll have to do this fix only for `*` kind types :crying_cat_face: 