### PR TITLE
fromPredicate* arguments switched for better type inference

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -995,13 +995,13 @@ object ZPure extends ZPureLowPriorityImplicits with ZPureArities {
   /**
    * Constructs a `Validation` from a predicate, failing with None.
    */
-  def fromPredicate[A](f: A => Boolean)(value: A): Validation[None.type, A] =
-    fromPredicateWith(None)(f)(value)
+  def fromPredicate[A](value: A)(f: A => Boolean): Validation[None.type, A] =
+    fromPredicateWith(None)(value)(f)
 
   /**
    * Constructs a `Validation` from a predicate, failing with the error provided.
    */
-  def fromPredicateWith[E, A](error: E)(f: A => Boolean)(value: A): Validation[E, A] =
+  def fromPredicateWith[E, A](error: E)(value: A)(f: A => Boolean): Validation[E, A] =
     if (f(value)) Validation.succeed(value)
     else Validation.fail(error)
 


### PR DESCRIPTION
Now I need to write
```scala
ZValidation.fromPredicateWith(s"ttl [$ttl] must be less than 30 days")((x: FiniteDuration) => x < 30.days)(ttl)
```

but I want to write
```scala
ZValidation.fromPredicateWith(s"ttl [$ttl] must be less than 30 days")(ttl)(_ < 30.days)
```