### PR TITLE
Add ZValidation#{mapErrorAll, mapLogAll, toEitherWith}

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Equal.scala
+++ b/core/shared/src/main/scala/zio/prelude/Equal.scala
@@ -345,7 +345,7 @@ object Equal extends Lawful[Equal] {
       l.compareStrict(r)
 
     override protected def checkEqual(l: Map[A, B], r: Map[A, B]): Boolean =
-      l.size === r.size &&
+      l.size == r.size &&
         l.forall { case (key, value) => r.get(key).fold(false)(_ === value) }
   }
 

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -124,6 +124,16 @@ sealed trait ZValidation[+W, +E, +A] { self =>
     }
 
   /**
+   * Transforms all the error values of this `ZValidation` with the specified
+   * function.
+   */
+  final def mapErrorAll[E2](f: NonEmptyMultiSet[E] => NonEmptyMultiSet[E2]): ZValidation[W, E2, A] =
+    self match {
+      case Failure(w, e) => Failure(w, f(e))
+      case Success(w, a) => Success(w, a)
+    }
+
+  /**
    * Transforms the log entries of this `ZValidation` with the specified
    * function.
    */
@@ -131,6 +141,16 @@ sealed trait ZValidation[+W, +E, +A] { self =>
     self match {
       case Failure(w, e) => Failure(w.map(f), e)
       case Success(w, a) => Success(w.map(f), a)
+    }
+
+  /**
+   * Transforms all the log entries of this `ZValidation` with the specified
+   * function.
+   */
+  final def mapLogAll[W2](f: Chunk[W] => Chunk[W2]): ZValidation[W2, E, A] =
+    self match {
+      case Failure(w, e) => Failure(f(w), e)
+      case Success(w, a) => Success(f(w), a)
     }
 
   /**
@@ -241,7 +261,7 @@ object ZValidation extends LowPriorityValidationImplicits {
   /**
    * Derives an `Equal[ZValidation[W, E, A]]` given an `Equal[A]`.
    */
-  implicit def ZValidationEqual[W, E: Equal, A: Equal]: Equal[ZValidation[W, E, A]] =
+  implicit def ZValidationEqual[W, E, A: Equal]: Equal[ZValidation[W, E, A]] =
     Equal.make {
       case (Failure(_, e), Failure(_, e1)) => e == e1
       case (Success(_, a), Success(_, a1)) => a === a1
@@ -1441,8 +1461,8 @@ trait LowPriorityValidationImplicits {
     }
 
   /**
-   * Derives a `Hash[ZValidation[W, E, A]]` given a `Hash[E]` and a `Hash[A]`.
+   * Derives a `Hash[ZValidation[W, E, A]]` given a `Hash[A]`.
    */
-  implicit def ValidationHash[W, E: Hash, A: Hash]: Hash[ZValidation[W, E, A]] =
+  implicit def ValidationHash[W, E, A: Hash]: Hash[ZValidation[W, E, A]] =
     Hash[NonEmptyMultiSet[E]].eitherWith(Hash[A])(_.toEither)
 }

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -151,6 +151,12 @@ sealed trait ZValidation[+W, +E, +A] { self =>
     fold(Left(_), Right(_))
 
   /**
+   * Transforms this `ZValidation` to an `Either`, transforming the accumulated errors and discarding the log.
+   */
+  final def toEitherWith[E1 >: E, E2](f: NonEmptyMultiSet[E1] => E2): Either[E2, A] =
+    toEither.left.map(f)
+
+  /**
    * Transforms this `ZValidation` to an `Option`, discarding information about
    * the errors and log.
    */

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -173,7 +173,7 @@ sealed trait ZValidation[+W, +E, +A] { self =>
   /**
    * Transforms this `ZValidation` to an `Either`, transforming the accumulated errors and discarding the log.
    */
-  final def toEitherWith[E1 >: E, E2](f: NonEmptyMultiSet[E1] => E2): Either[E2, A] =
+  final def toEitherWith[E2](f: NonEmptyMultiSet[E] => E2): Either[E2, A] =
     toEither.left.map(f)
 
   /**


### PR DESCRIPTION
You save typing 5 characters. (And maybe get better type inference?)
