### PR TITLE
Use NonEmptyChunk in ZValidation

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Assertions.scala
+++ b/core/shared/src/main/scala/zio/prelude/Assertions.scala
@@ -16,6 +16,7 @@
 
 package zio.prelude
 
+import zio.NonEmptyChunk
 import zio.test.Assertion
 import zio.test.Assertion.Render._
 
@@ -35,7 +36,7 @@ trait Assertions {
    * Makes a new assertion that requires a validation failure satisfying a
    * specified assertion.
    */
-  def isFailureV[E](assertion: Assertion[NonEmptyMultiSet[E]]): Assertion[ZValidation[Any, E, Any]] =
+  def isFailureV[E](assertion: Assertion[NonEmptyChunk[E]]): Assertion[ZValidation[Any, E, Any]] =
     Assertion.assertionRec("isFailureV")(param(assertion))(assertion) {
       case ZValidation.Failure(_, es) => Some(es)
       case _                          => None

--- a/core/shared/src/main/scala/zio/prelude/Gens.scala
+++ b/core/shared/src/main/scala/zio/prelude/Gens.scala
@@ -80,7 +80,7 @@ object Gens {
     a: Gen[R, A]
   ): Gen[R, ZValidation[W, E, A]] =
     Gen.chunkOf(w).flatMap { w =>
-      Gen.either(nonEmptyMultiSetOf(e), a).map {
+      Gen.either(Gen.chunkOf1(e), a).map {
         case Left(e)  => Validation.Failure(w, e)
         case Right(a) => Validation.Success(w, a)
       }

--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -19,7 +19,7 @@ package zio.prelude.fx
 import zio.internal.Stack
 import zio.prelude._
 import zio.test.Assertion
-import zio.{CanFail, Chunk, ChunkBuilder, NeedsEnv}
+import zio.{CanFail, Chunk, ChunkBuilder, NeedsEnv, NonEmptyChunk}
 
 import scala.annotation.{implicitNotFound, switch}
 import scala.util.Try
@@ -732,7 +732,7 @@ sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
    */
   final def runValidation(implicit ev1: Unit <:< S1, ev2: Any <:< R): ZValidation[W, E, A] =
     runAll(()) match {
-      case (log, Left(cause))   => ZValidation.Failure(log, cause.toNonEmptyMultiSet)
+      case (log, Left(cause))   => ZValidation.Failure(log, NonEmptyChunk.fromChunk(cause.toChunk).get)
       case (log, Right((_, a))) => ZValidation.Success(log, a)
     }
 

--- a/core/shared/src/test/scala/zio/prelude/NewtypeFSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NewtypeFSpec.scala
@@ -1,5 +1,6 @@
 package zio.prelude
 
+import zio.NonEmptyChunk
 import zio.test.Assertion.anything
 import zio.test.AssertionM.Render.param
 import zio.test._
@@ -18,7 +19,7 @@ object NewtypeFSpec extends DefaultRunnableSpec {
         },
         test("invalid values") {
           val expected = "List(1, 2, 3, 4, 5) did not satisfy isShorterThan(5)"
-          assert(ShortList.make(List(1, 2, 3, 4, 5)))(isFailureV(equalTo(NonEmptyMultiSet(expected))))
+          assert(ShortList.make(List(1, 2, 3, 4, 5)))(isFailureV(equalTo(NonEmptyChunk(expected))))
         }
       ),
       suite("SubtypeSmartF")(

--- a/core/shared/src/test/scala/zio/prelude/NewtypeSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NewtypeSpec.scala
@@ -1,5 +1,6 @@
 package zio.prelude
 
+import zio.NonEmptyChunk
 import zio.prelude.newtypes._
 import zio.test.Assertion._
 import zio.test._
@@ -24,7 +25,7 @@ object NewtypeSpec extends DefaultRunnableSpec {
         },
         test("invalid values") {
           val expected = "-1 did not satisfy isGreaterThanEqualTo(0)"
-          assert(Natural.make(-1))(isFailureV(equalTo(NonEmptyMultiSet(expected))))
+          assert(Natural.make(-1))(isFailureV(equalTo(NonEmptyChunk(expected))))
         }
       ),
       suite("SubtypeSmart")(


### PR DESCRIPTION
We want to honor the guarantee from `CommutativeBoth` that:

```scala
ZVallidation.fail("foo") <&> ZValidation.fail("bar") === ZValidation.fail("bar") <&> ZValidation.fail("foo")
```

However, from the user perspective it can be helpful to be able to see the order in which errors occurred for debugging purposes.

This PR addresses that by deferring the conversion of the errors into a multiset until we actually call `equals` or `hashCode`. This approach of "lazily" honoring these guarantees is similar to what we do in other ZIO data structures such as `Cause` in ZIO and `BoolAlgebra` in ZIO Test.