### PR TITLE
Implement ZSet#forEach

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Associative.scala
+++ b/core/shared/src/main/scala/zio/prelude/Associative.scala
@@ -492,7 +492,7 @@ object Associative extends AssociativeLowPriority with Lawful[AssociativeEqual] 
   implicit val NaturalProdCommutativeIdentity: Commutative[Prod[Natural]] with Identity[Prod[Natural]] =
     new Commutative[Prod[Natural]] with Identity[Prod[Natural]] {
       def combine(l: => Prod[Natural], r: => Prod[Natural]): Prod[Natural] = Prod(Natural.times(l, r))
-      val identity: Prod[Natural]                                  = Prod(Natural.one)
+      val identity: Prod[Natural]                                          = Prod(Natural.one)
     }
 
   /**
@@ -501,7 +501,7 @@ object Associative extends AssociativeLowPriority with Lawful[AssociativeEqual] 
   implicit val NaturalSumCommutativeInverse: Commutative[Sum[Natural]] with Inverse[Sum[Natural]] =
     new Commutative[Sum[Natural]] with Inverse[Sum[Natural]] {
       def combine(l: => Sum[Natural], r: => Sum[Natural]): Sum[Natural] = Sum(Natural.plus(l, r))
-      val identity: Sum[Natural]                                  = Sum(Natural.zero)
+      val identity: Sum[Natural]                                        = Sum(Natural.zero)
       def inverse(l: => Sum[Natural], r: => Sum[Natural]): Sum[Natural] = Sum(Natural.minus(l, r))
     }
 
@@ -1327,7 +1327,7 @@ object Associative extends AssociativeLowPriority with Lawful[AssociativeEqual] 
 
 trait AssociativeLowPriority {
 
- /**
+  /**
    * The `Commutative` and `Identity` instance for the product of `Int` values.
    */
   implicit val IntProdCommutativeIdentity: Commutative[Prod[Int]] with Identity[Prod[Int]] =

--- a/core/shared/src/main/scala/zio/prelude/Associative.scala
+++ b/core/shared/src/main/scala/zio/prelude/Associative.scala
@@ -17,7 +17,7 @@
 package zio.prelude
 
 import zio.prelude.coherent.AssociativeEqual
-import zio.prelude.newtypes.{And, First, Last, Max, Min, Or, Prod, Sum}
+import zio.prelude.newtypes.{And, First, Last, Max, Min, Natural, Or, Prod, Sum}
 import zio.test.TestResult
 import zio.test.laws.{Lawful, Laws}
 import zio.{Chunk, NonEmptyChunk}
@@ -68,7 +68,7 @@ trait Associative[A] {
   }
 }
 
-object Associative extends Lawful[AssociativeEqual] {
+object Associative extends AssociativeLowPriority with Lawful[AssociativeEqual] {
 
   /**
    * The associativity law states that for some binary operator `*`, for all
@@ -410,25 +410,6 @@ object Associative extends Lawful[AssociativeEqual] {
     }
 
   /**
-   * The `Commutative` and `Identity` instance for the product of `Int` values.
-   */
-  implicit val IntProdCommutativeIdentity: Commutative[Prod[Int]] with Identity[Prod[Int]] =
-    new Commutative[Prod[Int]] with Identity[Prod[Int]] {
-      def combine(l: => Prod[Int], r: => Prod[Int]): Prod[Int] = Prod(l * r)
-      val identity: Prod[Int]                                  = Prod(1)
-    }
-
-  /**
-   * The `Commutative` and `Inverse` instance for the sum of `Int` values.
-   */
-  implicit val IntSumCommutativeInverse: Commutative[Sum[Int]] with Inverse[Sum[Int]] =
-    new Commutative[Sum[Int]] with Inverse[Sum[Int]] {
-      def combine(l: => Sum[Int], r: => Sum[Int]): Sum[Int] = Sum(l + r)
-      val identity: Sum[Int]                                = Sum(0)
-      def inverse(l: => Sum[Int], r: => Sum[Int]): Sum[Int] = Sum(l - r)
-    }
-
-  /**
    * The `Associative` instance for the last of `A` values.
    */
   implicit def LastAssociative[A]: Associative[Last[A]] =
@@ -504,6 +485,25 @@ object Associative extends Lawful[AssociativeEqual] {
    */
   implicit def MinCommutative[A: Ord]: Commutative[Min[A]] =
     Commutative.make((l: Min[A], r: Min[A]) => if (l <= r) l else r)
+
+  /**
+   * The `Commutative` and `Identity` instance for the product of `Natural` values.
+   */
+  implicit val NaturalProdCommutativeIdentity: Commutative[Prod[Natural]] with Identity[Prod[Natural]] =
+    new Commutative[Prod[Natural]] with Identity[Prod[Natural]] {
+      def combine(l: => Prod[Natural], r: => Prod[Natural]): Prod[Natural] = Prod(Natural.times(l, r))
+      val identity: Prod[Natural]                                  = Prod(Natural.one)
+    }
+
+  /**
+   * The `Commutative` and `Inverse` instance for the sum of `Narutal` values.
+   */
+  implicit val NaturalSumCommutativeInverse: Commutative[Sum[Natural]] with Inverse[Sum[Natural]] =
+    new Commutative[Sum[Natural]] with Inverse[Sum[Natural]] {
+      def combine(l: => Sum[Natural], r: => Sum[Natural]): Sum[Natural] = Sum(Natural.plus(l, r))
+      val identity: Sum[Natural]                                  = Sum(Natural.zero)
+      def inverse(l: => Sum[Natural], r: => Sum[Natural]): Sum[Natural] = Sum(Natural.minus(l, r))
+    }
 
   /**
    * The `Associative` instance for the concatenation of `NonEmptyChunk[A]`
@@ -1323,6 +1323,28 @@ object Associative extends Lawful[AssociativeEqual] {
    */
   implicit def VectorIdentity[A]: Identity[Vector[A]] =
     Identity.make(Vector.empty, _ ++ _)
+}
+
+trait AssociativeLowPriority {
+
+ /**
+   * The `Commutative` and `Identity` instance for the product of `Int` values.
+   */
+  implicit val IntProdCommutativeIdentity: Commutative[Prod[Int]] with Identity[Prod[Int]] =
+    new Commutative[Prod[Int]] with Identity[Prod[Int]] {
+      def combine(l: => Prod[Int], r: => Prod[Int]): Prod[Int] = Prod(l * r)
+      val identity: Prod[Int]                                  = Prod(1)
+    }
+
+  /**
+   * The `Commutative` and `Inverse` instance for the sum of `Int` values.
+   */
+  implicit val IntSumCommutativeInverse: Commutative[Sum[Int]] with Inverse[Sum[Int]] =
+    new Commutative[Sum[Int]] with Inverse[Sum[Int]] {
+      def combine(l: => Sum[Int], r: => Sum[Int]): Sum[Int] = Sum(l + r)
+      val identity: Sum[Int]                                = Sum(0)
+      def inverse(l: => Sum[Int], r: => Sum[Int]): Sum[Int] = Sum(l - r)
+    }
 }
 
 trait AssociativeSyntax {

--- a/core/shared/src/main/scala/zio/prelude/Associative.scala
+++ b/core/shared/src/main/scala/zio/prelude/Associative.scala
@@ -78,7 +78,7 @@ object Associative extends Lawful[AssociativeEqual] {
    * (a1 * a2) * a3 === a1 * (a2 * a3)
    * }}}
    */
-  val associativityLaw: Laws[AssociativeEqual] =
+  lazy val associativityLaw: Laws[AssociativeEqual] =
     new Laws.Law3[AssociativeEqual]("associativityLaw") {
       def apply[A: AssociativeEqual](a1: A, a2: A, a3: A): TestResult =
         (a1 <> (a2 <> a3)) <-> ((a1 <> a2) <> a3)
@@ -87,7 +87,7 @@ object Associative extends Lawful[AssociativeEqual] {
   /**
    * The set of all laws that instances of `Associative` must satisfy.
    */
-  val laws: Laws[AssociativeEqual] =
+  lazy val laws: Laws[AssociativeEqual] =
     associativityLaw
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -53,7 +53,7 @@ object AssociativeBoth extends LawfulF.Invariant[AssociativeBothDeriveEqualInvar
    * For all `fa`, `fb`, and `fc`, `both(fa, both(fb, fc))` is equivalent
    * to `both(both(fa, fb), fc)`.
    */
-  val associativityLaw: LawsF.Invariant[AssociativeBothDeriveEqualInvariant, Equal] =
+  lazy val associativityLaw: LawsF.Invariant[AssociativeBothDeriveEqualInvariant, Equal] =
     new LawsF.Invariant.Law3[AssociativeBothDeriveEqualInvariant, Equal]("associativityLaw") {
       def apply[F[_]: AssociativeBothDeriveEqualInvariant, A: Equal, B: Equal, C: Equal](
         fa: F[A],
@@ -70,7 +70,7 @@ object AssociativeBoth extends LawfulF.Invariant[AssociativeBothDeriveEqualInvar
   /**
    * The set of law laws that instances of `AssociativeBoth` must satisfy.
    */
-  val laws: LawsF.Invariant[AssociativeBothDeriveEqualInvariant, Equal] =
+  lazy val laws: LawsF.Invariant[AssociativeBothDeriveEqualInvariant, Equal] =
     associativityLaw
 
   def fromCovariantAssociativeFlatten[F[+_]](implicit

--- a/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
@@ -47,7 +47,7 @@ object AssociativeEither extends LawfulF.Invariant[AssociativeEitherDeriveEqualI
    * For all `fa`, `fb`, and `fc`, `either(fa, either(fb, fc))` is
    * equivalent to `either(either(fa, fb), fc)`.
    */
-  val associativityLaw: LawsF.Invariant[AssociativeEitherDeriveEqualInvariant, Equal] =
+  lazy val associativityLaw: LawsF.Invariant[AssociativeEitherDeriveEqualInvariant, Equal] =
     new LawsF.Invariant.Law3[AssociativeEitherDeriveEqualInvariant, Equal]("associativityLaw") {
       def apply[F[_]: AssociativeEitherDeriveEqualInvariant, A: Equal, B: Equal, C: Equal](
         fa: F[A],
@@ -65,7 +65,7 @@ object AssociativeEither extends LawfulF.Invariant[AssociativeEitherDeriveEqualI
    * The set of law laws that instances of `AssociativeEither` must
    * satisfy.
    */
-  val laws: LawsF.Invariant[AssociativeEitherDeriveEqualInvariant, Equal] =
+  lazy val laws: LawsF.Invariant[AssociativeEitherDeriveEqualInvariant, Equal] =
     associativityLaw
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/AssociativeFlatten.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeFlatten.scala
@@ -49,7 +49,7 @@ object AssociativeFlatten extends LawfulF.Covariant[AssociativeFlattenCovariantD
    * For all `fffa`, `flatten(flatten(fffa))` is equivalent to
    * `flatten(fffa.map(flatten))`.
    */
-  val associativityLaw: LawsF.Covariant[AssociativeFlattenCovariantDeriveEqual, Equal] =
+  lazy val associativityLaw: LawsF.Covariant[AssociativeFlattenCovariantDeriveEqual, Equal] =
     new LawsF.Covariant.FlattenLaw[AssociativeFlattenCovariantDeriveEqual, Equal]("associativityLaw") {
       def apply[F[+_]: AssociativeFlattenCovariantDeriveEqual, A: Equal](fffa: F[F[F[A]]]): TestResult =
         fffa.flatten.flatten <-> fffa.map(_.flatten).flatten
@@ -58,7 +58,7 @@ object AssociativeFlatten extends LawfulF.Covariant[AssociativeFlattenCovariantD
   /**
    * The set of all laws that instances of `AssociativeFlatten` must satisfy.
    */
-  val laws: LawsF.Covariant[AssociativeFlattenCovariantDeriveEqual, Equal] =
+  lazy val laws: LawsF.Covariant[AssociativeFlattenCovariantDeriveEqual, Equal] =
     associativityLaw
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Commutative.scala
+++ b/core/shared/src/main/scala/zio/prelude/Commutative.scala
@@ -54,7 +54,7 @@ object Commutative extends Lawful[CommutativeEqual] {
    * a1 * a2 === a2 * a1
    * }}}
    */
-  val commutativeLaw: Laws[CommutativeEqual] =
+  lazy val commutativeLaw: Laws[CommutativeEqual] =
     new Laws.Law2[CommutativeEqual]("commutativeLaw") {
       def apply[A: CommutativeEqual](a1: A, a2: A): TestResult =
         (a1 <> a2) <-> (a2 <> a1)
@@ -63,7 +63,7 @@ object Commutative extends Lawful[CommutativeEqual] {
   /**
    * The set of all laws that instances of `Commutative` must satisfy.
    */
-  val laws: Laws[CommutativeEqual] =
+  lazy val laws: Laws[CommutativeEqual] =
     commutativeLaw + Associative.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -37,7 +37,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * For all `fa` and `fb`, `both(fa, fb)` is equivalent to `both(fb, fa)`.
    */
-  val commutativeLaw: LawsF.Invariant[CommutativeBothDeriveEqualInvariant, Equal] =
+  lazy val commutativeLaw: LawsF.Invariant[CommutativeBothDeriveEqualInvariant, Equal] =
     new LawsF.Invariant.Law2[CommutativeBothDeriveEqualInvariant, Equal]("commutativeLaw") {
       def apply[F[_]: CommutativeBothDeriveEqualInvariant, A: Equal, B: Equal](fa: F[A], fb: F[B]): TestResult = {
         val left  = fa.zipPar(fb)
@@ -50,7 +50,7 @@ object CommutativeBoth extends LawfulF.Invariant[CommutativeBothDeriveEqualInvar
   /**
    * The set of law laws that instances of `CommutativeBoth` must satisfy.
    */
-  val laws: LawsF.Invariant[CommutativeBothDeriveEqualInvariant, Equal] =
+  lazy val laws: LawsF.Invariant[CommutativeBothDeriveEqualInvariant, Equal] =
     commutativeLaw + AssociativeBoth.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
@@ -37,7 +37,7 @@ object CommutativeEither extends LawfulF.Invariant[CommutativeEitherDeriveEqualI
   /**
    * For all `fa` and `fb`, `either(fa, fb)` is equivalent to `either(fb, fa)`.
    */
-  val commutativeLaw: LawsF.Invariant[CommutativeEitherDeriveEqualInvariant, Equal] =
+  lazy val commutativeLaw: LawsF.Invariant[CommutativeEitherDeriveEqualInvariant, Equal] =
     new LawsF.Invariant.Law2[CommutativeEitherDeriveEqualInvariant, Equal]("commutativeLaw") {
       def apply[F[_]: CommutativeEitherDeriveEqualInvariant, A: Equal, B: Equal](fa: F[A], fb: F[B]): TestResult = {
         val left  = fa.orElseEitherPar(fb)
@@ -50,7 +50,7 @@ object CommutativeEither extends LawfulF.Invariant[CommutativeEitherDeriveEqualI
   /**
    * The set of law laws that instances of `CommutativeEither` must satisfy.
    */
-  val laws: LawsF.Invariant[CommutativeEitherDeriveEqualInvariant, Equal] =
+  lazy val laws: LawsF.Invariant[CommutativeEitherDeriveEqualInvariant, Equal] =
     commutativeLaw + AssociativeEither.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Contravariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Contravariant.scala
@@ -81,7 +81,7 @@ object Contravariant extends LawfulF.Contravariant[ContravariantDeriveEqual, Equ
   /**
    * Contramapping with the identity function must not change the structure.
    */
-  val identityLaw: LawsF.Contravariant[ContravariantDeriveEqual, Equal] =
+  lazy val identityLaw: LawsF.Contravariant[ContravariantDeriveEqual, Equal] =
     new LawsF.Contravariant.Law1[ContravariantDeriveEqual, Equal]("identityLaw") {
       def apply[F[-_]: ContravariantDeriveEqual, A: Equal](fa: F[A]): TestResult =
         fa.contramap(identity[A]) <-> fa
@@ -91,7 +91,7 @@ object Contravariant extends LawfulF.Contravariant[ContravariantDeriveEqual, Equ
    * Contramapping by `f` followed by `g` must be the same as contramapping
    * with the composition of `f` and `g`.
    */
-  val compositionLaw: LawsF.Contravariant[ContravariantDeriveEqual, Equal] =
+  lazy val compositionLaw: LawsF.Contravariant[ContravariantDeriveEqual, Equal] =
     new LawsF.Contravariant.ComposeLaw[ContravariantDeriveEqual, Equal]("compositionLaw") {
       def apply[F[-_]: ContravariantDeriveEqual, A: Equal, B: Equal, C: Equal](
         fa: F[A],
@@ -107,7 +107,7 @@ object Contravariant extends LawfulF.Contravariant[ContravariantDeriveEqual, Equ
   /**
    * The set of all laws that instances of `Contravariant` must satisfy.
    */
-  val laws: LawsF.Contravariant[ContravariantDeriveEqual, Equal] =
+  lazy val laws: LawsF.Contravariant[ContravariantDeriveEqual, Equal] =
     identityLaw + compositionLaw
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Covariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Covariant.scala
@@ -83,7 +83,7 @@ object Covariant extends LawfulF.Covariant[CovariantDeriveEqual, Equal] {
   /**
    * Mapping with the identity function must be an identity function.
    */
-  val identityLaw: LawsF.Covariant[CovariantDeriveEqual, Equal] =
+  lazy val identityLaw: LawsF.Covariant[CovariantDeriveEqual, Equal] =
     new LawsF.Covariant.Law1[CovariantDeriveEqual, Equal]("identityLaw") {
       def apply[F[+_]: CovariantDeriveEqual, A: Equal](fa: F[A]): TestResult =
         fa.map(identity) <-> fa
@@ -93,7 +93,7 @@ object Covariant extends LawfulF.Covariant[CovariantDeriveEqual, Equal] {
    * Mapping by `f` followed by `g` must be the same as mapping with the
    * composition of `f` and `g`.
    */
-  val compositionLaw: LawsF.Covariant[CovariantDeriveEqual, Equal] =
+  lazy val compositionLaw: LawsF.Covariant[CovariantDeriveEqual, Equal] =
     new LawsF.Covariant.ComposeLaw[CovariantDeriveEqual, Equal]("compositionLaw") {
       def apply[F[+_]: CovariantDeriveEqual, A: Equal, B: Equal, C: Equal](fa: F[A], f: A => B, g: B => C): TestResult =
         fa.map(f).map(g) <-> fa.map(f andThen g)
@@ -102,7 +102,7 @@ object Covariant extends LawfulF.Covariant[CovariantDeriveEqual, Equal] {
   /**
    * The set of all laws that instances of `Covariant` must satisfy.
    */
-  val laws: LawsF.Covariant[CovariantDeriveEqual, Equal] =
+  lazy val laws: LawsF.Covariant[CovariantDeriveEqual, Equal] =
     identityLaw + compositionLaw
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Equal.scala
+++ b/core/shared/src/main/scala/zio/prelude/Equal.scala
@@ -110,7 +110,7 @@ object Equal extends Lawful[Equal] {
   /**
    * For all values `a1`, `a1` is equal to `a1`.
    */
-  val reflexiveLaw: Laws.Law1[Equal] =
+  lazy val reflexiveLaw: Laws.Law1[Equal] =
     new Laws.Law1[Equal]("reflexiveLaw") {
       def apply[A: Equal](a1: A): TestResult =
         a1 <-> a1
@@ -120,7 +120,7 @@ object Equal extends Lawful[Equal] {
    * For all values `a1` and `a2`, if `a1` is equal to `a2` then `a2` is equal
    * to `a1`.
    */
-  val symmetryLaw: Laws.Law2[Equal] =
+  lazy val symmetryLaw: Laws.Law2[Equal] =
     new Laws.Law2[Equal]("symmetryLaw") {
       def apply[A: Equal](a1: A, a2: A): TestResult =
         (a1 <-> a2) ==> (a2 <-> a1)
@@ -130,7 +130,7 @@ object Equal extends Lawful[Equal] {
    * For all values `a1`, `a2`, and `a3`, if `a1` is equal to `a2` and `a2` is
    * equal `a3`, then `a1` is equal to `a3`.
    */
-  val transitivityLaw: Laws.Law3[Equal] =
+  lazy val transitivityLaw: Laws.Law3[Equal] =
     new Laws.Law3[Equal]("transitivityLaw") {
       def apply[A: Equal](a1: A, a2: A, a3: A): TestResult =
         ((a1 <-> a2) && (a2 <-> a3)) ==> (a1 <-> a3)
@@ -139,7 +139,7 @@ object Equal extends Lawful[Equal] {
   /**
    * The set of all laws that instances of `Equal` must satisfy.
    */
-  val laws: Laws[Equal] =
+  lazy val laws: Laws[Equal] =
     reflexiveLaw + symmetryLaw + transitivityLaw
 
   def fromScala[A](implicit equiv: sm.Equiv[A]): Equal[A] = equiv.equiv(_, _)

--- a/core/shared/src/main/scala/zio/prelude/Equivalence.scala
+++ b/core/shared/src/main/scala/zio/prelude/Equivalence.scala
@@ -62,19 +62,19 @@ final case class Equivalence[A, B](to: A => B, from: B => A) { self =>
 
 object Equivalence extends Lawful2[Equivalence, Equal, Equal] {
 
-  val leftIdentity: Laws2[Equivalence, Equal, AnyF] =
+  lazy val leftIdentity: Laws2[Equivalence, Equal, AnyF] =
     new Laws2.Law1Left[Equivalence, Equal, AnyF]("leftIdentity") {
       def apply[A: Equal, B: AnyF](a: A)(implicit equivalence: Equivalence[A, B]): TestResult =
         equivalence.from(equivalence.to(a)) <-> a
     }
 
-  val rightIdentity: Laws2[Equivalence, AnyF, Equal] =
+  lazy val rightIdentity: Laws2[Equivalence, AnyF, Equal] =
     new Laws2.Law1Right[Equivalence, AnyF, Equal]("rightIdentity") {
       def apply[A: AnyF, B: Equal](b: B)(implicit equivalence: Equivalence[A, B]): TestResult =
         equivalence.to(equivalence.from(b)) <-> b
     }
 
-  val laws: Laws2[Equivalence, Equal, Equal] =
+  lazy val laws: Laws2[Equivalence, Equal, Equal] =
     leftIdentity + rightIdentity
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/ForEach.scala
+++ b/core/shared/src/main/scala/zio/prelude/ForEach.scala
@@ -311,7 +311,7 @@ object ForEach extends LawfulF.Covariant[DeriveEqualForEach, Equal] {
   /**
    * The set of all laws that instances of `ForEach` must satisfy.
    */
-  val laws: LawsF.Covariant[DeriveEqualForEach, Equal] =
+  lazy val laws: LawsF.Covariant[DeriveEqualForEach, Equal] =
     Covariant.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Gens.scala
+++ b/core/shared/src/main/scala/zio/prelude/Gens.scala
@@ -17,6 +17,7 @@
 package zio.prelude
 
 import zio.prelude.fx.Cause
+import zio.prelude.newtypes.Natural
 import zio.random.Random
 import zio.test._
 
@@ -24,6 +25,19 @@ import zio.test._
  * Provides generators for data types from _ZIO Prelude_.
  */
 object Gens {
+
+  /**
+   * A generator of natural numbers. Shrinks toward '0'.
+   */
+  val anyNatural: Gen[Random, Natural] =
+    natural(Natural.zero, Natural.unsafeMake(Int.MaxValue))
+
+  /**
+   * A generator of natural numbers inside the specified range: [start, end].
+   * The shrinker will shrink toward the lower end of the range ("smallest").
+   */
+  def natural(min: Natural, max: Natural): Gen[Random, Natural] =
+    Gen.int(min, max).map(Natural.unsafeMake)
 
   def parSeq[R <: Random with Sized, Z <: Unit, A](z: Gen[R, Z], a: Gen[R, A]): Gen[R, ParSeq[Z, A]] = {
     val failure = a.map(Cause.single)
@@ -63,7 +77,7 @@ object Gens {
    * A generator of `NonEmptyMultiSet` values.
    */
   def nonEmptyMultiSetOf[R <: Random with Sized, A](a: Gen[R, A]): Gen[R, NonEmptyMultiSet[A]] =
-    Gen.mapOf1(a, Gen.size).map(NonEmptyMultiSet.fromMapOption(_).get)
+    Gen.mapOf1(a, Gen.size.map(Natural.unsafeMake)).map(NonEmptyMultiSet.fromMapOption(_).get)
 
   /**
    * A generator of state transition functions.

--- a/core/shared/src/main/scala/zio/prelude/Hash.scala
+++ b/core/shared/src/main/scala/zio/prelude/Hash.scala
@@ -105,7 +105,7 @@ object Hash extends Lawful[Hash] {
    * For all values `a1` and `a2`, if `a1` is equal to `a2` then the hash of
    * `a1` is equal to the hash of `a2`.
    */
-  val consistencyLaw: Laws[Hash] =
+  lazy val consistencyLaw: Laws[Hash] =
     new Laws.Law2[Hash]("consistencyLaw") {
       def apply[A](a1: A, a2: A)(implicit caps: Hash[A]): TestResult =
         (a1 <-> a2) ==> (Hash[A].hash(a1) <-> Hash[A].hash(a2))
@@ -114,7 +114,7 @@ object Hash extends Lawful[Hash] {
   /**
    * The set of all laws that instances of `Hash` must satisfy.
    */
-  val laws: Laws[Hash] =
+  lazy val laws: Laws[Hash] =
     consistencyLaw + Equal.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Idempotent.scala
+++ b/core/shared/src/main/scala/zio/prelude/Idempotent.scala
@@ -61,7 +61,7 @@ object Idempotent extends Lawful[EqualIdempotent] {
    * a * a === a
    * }}}
    */
-  val idempotentLaw: Laws[EqualIdempotent] =
+  lazy val idempotentLaw: Laws[EqualIdempotent] =
     new Laws.Law1[EqualIdempotent]("idempotentLaw") {
       def apply[A: EqualIdempotent](a: A): TestResult =
         (a <> a) <-> a
@@ -70,7 +70,7 @@ object Idempotent extends Lawful[EqualIdempotent] {
   /**
    * The set of all laws that instances of `Idempotent` must satisfy.
    */
-  val laws: Laws[EqualIdempotent] =
+  lazy val laws: Laws[EqualIdempotent] =
     idempotentLaw + Associative.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Identity.scala
+++ b/core/shared/src/main/scala/zio/prelude/Identity.scala
@@ -55,7 +55,7 @@ object Identity extends Lawful[EqualIdentity] {
    * identity * a === a
    * }}}
    */
-  val leftIdentityLaw: Laws[EqualIdentity] =
+  lazy val leftIdentityLaw: Laws[EqualIdentity] =
     new Laws.Law1[EqualIdentity]("leftIdentityLaw") {
       def apply[A](a: A)(implicit I: EqualIdentity[A]): TestResult =
         (I.identity <> a) <-> a
@@ -69,7 +69,7 @@ object Identity extends Lawful[EqualIdentity] {
    * a * identity === a
    * }}}
    */
-  val rightIdentityLaw: Laws[EqualIdentity] =
+  lazy val rightIdentityLaw: Laws[EqualIdentity] =
     new Laws.Law1[EqualIdentity]("rightIdentityLaw") {
       def apply[A](a: A)(implicit I: EqualIdentity[A]): TestResult =
         (a <> I.identity) <-> a
@@ -78,7 +78,7 @@ object Identity extends Lawful[EqualIdentity] {
   /**
    * The set of all laws that instances of `Identity` must satisfy.
    */
-  val laws: Laws[EqualIdentity] =
+  lazy val laws: Laws[EqualIdentity] =
     leftIdentityLaw + rightIdentityLaw + Associative.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/IdentityBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/IdentityBoth.scala
@@ -44,7 +44,7 @@ object IdentityBoth extends LawfulF.Invariant[DeriveEqualIdentityBothInvariant, 
   /**
    * For all `fa`, `both(identity, fa)` is equivalent to `fa`.
    */
-  val leftIdentityLaw: LawsF.Invariant[DeriveEqualIdentityBothInvariant, Equal] =
+  lazy val leftIdentityLaw: LawsF.Invariant[DeriveEqualIdentityBothInvariant, Equal] =
     new LawsF.Invariant.Law1[DeriveEqualIdentityBothInvariant, Equal]("leftIdentityLaw") {
       def apply[F[_]: DeriveEqualIdentityBothInvariant, A: Equal](fa: F[A]): TestResult = {
         val left  = IdentityBoth[F].both(IdentityBoth[F].any, fa)
@@ -57,7 +57,7 @@ object IdentityBoth extends LawfulF.Invariant[DeriveEqualIdentityBothInvariant, 
   /**
    * For all `fa`, `both(fa, identity)` is equivalent to `fa`.
    */
-  val rightIdentityLaw: LawsF.Invariant[DeriveEqualIdentityBothInvariant, Equal] =
+  lazy val rightIdentityLaw: LawsF.Invariant[DeriveEqualIdentityBothInvariant, Equal] =
     new LawsF.Invariant.Law1[DeriveEqualIdentityBothInvariant, Equal]("rightIdentityLaw") {
       def apply[F[_]: DeriveEqualIdentityBothInvariant, A: Equal](fa: F[A]): TestResult = {
         val left  = IdentityBoth[F].both(fa, IdentityBoth[F].any)
@@ -70,7 +70,7 @@ object IdentityBoth extends LawfulF.Invariant[DeriveEqualIdentityBothInvariant, 
   /**
    * The set of law laws that instances of `IdentityBoth` must satisfy.
    */
-  val laws: LawsF.Invariant[DeriveEqualIdentityBothInvariant, Equal] =
+  lazy val laws: LawsF.Invariant[DeriveEqualIdentityBothInvariant, Equal] =
     leftIdentityLaw + rightIdentityLaw + AssociativeBoth.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -1791,3 +1791,14 @@ trait LowPriorityInvariantImplicits {
   implicit def ZSTMZivariantContravariant[E, A]: Contravariant[({ type lambda[-x] = ZSTM[x, E, A] })#lambda] =
     Zivariant.ZSTMZivariant.deriveContravariant
 }
+
+trait InvariantSyntax {
+
+  /**
+   * Provides infix syntax for mapping over invariant values.
+   */
+  implicit class InvariantOps[F[_], A](private val self: F[A]) {
+    def invmap[B](f: A <=> B)(implicit F: Invariant[F]): F[B] =
+      F.invmap(f).to(self)
+  }
+}

--- a/core/shared/src/main/scala/zio/prelude/Inverse.scala
+++ b/core/shared/src/main/scala/zio/prelude/Inverse.scala
@@ -64,7 +64,7 @@ object Inverse extends Lawful[EqualInverse] {
    * a * a === identity
    * }}}
    */
-  val inverseLaw: Laws[EqualInverse] =
+  lazy val inverseLaw: Laws[EqualInverse] =
     new Laws.Law1[EqualInverse]("rightInverseLaw") {
       def apply[A](a: A)(implicit I: EqualInverse[A]): TestResult =
         I.inverse(a, a) <-> I.identity
@@ -73,7 +73,7 @@ object Inverse extends Lawful[EqualInverse] {
   /**
    * The set of all laws that instances of `Inverse` must satisfy.
    */
-  val laws: Laws[EqualInverse] =
+  lazy val laws: Laws[EqualInverse] =
     inverseLaw + Identity.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/NonEmptyForEach.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyForEach.scala
@@ -162,7 +162,7 @@ object NonEmptyForEach extends LawfulF.Covariant[DeriveEqualNonEmptyForEach, Equ
   /**
    * The set of all laws that instances of `NonEmptyForEach` must satisfy.
    */
-  val laws: LawsF.Covariant[DeriveEqualNonEmptyForEach, Equal] =
+  lazy val laws: LawsF.Covariant[DeriveEqualNonEmptyForEach, Equal] =
     ForEach.laws
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Ord.scala
+++ b/core/shared/src/main/scala/zio/prelude/Ord.scala
@@ -128,7 +128,7 @@ object Ord extends Lawful[Ord] {
    * For all values `a1` and `a2`, `a1` is less than or equal to `a2` or `a2`
    * is less than or equal to `a1`.
    */
-  val connexityLaw1: Laws[Ord] =
+  lazy val connexityLaw1: Laws[Ord] =
     new Laws.Law2[Ord]("connexityLaw1") {
       def apply[A: Ord](a1: A, a2: A): TestResult =
         (a1 lessOrEqual a2) || (a2 lessOrEqual a1)
@@ -138,7 +138,7 @@ object Ord extends Lawful[Ord] {
    * For all values `a1` and `a2`, `a1` is greater than or equal to `a2` or
    * `a2` is greater than or equal to `a1`.
    */
-  val connexityLaw2: Laws[Ord] =
+  lazy val connexityLaw2: Laws[Ord] =
     new Laws.Law2[Ord]("connexityLaw2") {
       def apply[A: Ord](a1: A, a2: A): TestResult =
         (a1 greaterOrEqual a2) || (a2 greaterOrEqual a1)
@@ -148,7 +148,7 @@ object Ord extends Lawful[Ord] {
    * For all values `a1` and `a2`, `a1` is less than or equal to `a2` if and
    * only if `a2` is greater than or equal to `a1`.
    */
-  val complementLaw: Laws[Ord] =
+  lazy val complementLaw: Laws[Ord] =
     new Laws.Law2[Ord]("complementLaw") {
       def apply[A: Ord](a1: A, a2: A): TestResult =
         (a1 lessOrEqual a2) <==> (a2 greaterOrEqual a1)
@@ -157,7 +157,7 @@ object Ord extends Lawful[Ord] {
   /**
    * The set of all laws that instances of `Ord` must satisfy.
    */
-  val laws: Laws[Ord] =
+  lazy val laws: Laws[Ord] =
     connexityLaw1 +
       connexityLaw2 +
       complementLaw +

--- a/core/shared/src/main/scala/zio/prelude/PartialOrd.scala
+++ b/core/shared/src/main/scala/zio/prelude/PartialOrd.scala
@@ -114,7 +114,7 @@ object PartialOrd extends Lawful[PartialOrd] {
    * For all values `a1`, `a2`, and `a3`, if `a1` is less than `a2` and `a2` is
    * less than `a3` then `a1` is less than `a3`.
    */
-  val transitivityLaw1: Laws[PartialOrd] =
+  lazy val transitivityLaw1: Laws[PartialOrd] =
     new Laws.Law3[PartialOrd]("transitivityLaw1") {
       def apply[A: PartialOrd](a1: A, a2: A, a3: A): TestResult =
         ((a1 less a2) && (a2 less a3)) ==> (a1 less a3)
@@ -124,7 +124,7 @@ object PartialOrd extends Lawful[PartialOrd] {
    * For all values `a1`, `a2`, and `a3`, if `a1` is greater than `a2` and `a2`
    * is greater than `a3` then `a1` is greater than `a3`.
    */
-  val transitivityLaw2: Laws[PartialOrd] =
+  lazy val transitivityLaw2: Laws[PartialOrd] =
     new Laws.Law3[PartialOrd]("transitivityLaw2") {
       def apply[A: PartialOrd](a1: A, a2: A, a3: A): TestResult =
         ((a1 greater a2) && (a2 greater a3)) ==> (a1 greater a3)
@@ -134,7 +134,7 @@ object PartialOrd extends Lawful[PartialOrd] {
    * For all values `a1` and `a2`, if `a1` is less than or equal to `a2` and
    * `a2` is less than or equal to `a1` then `a1` is equal to `a2`.
    */
-  val antisymmetryLaw1: Laws[PartialOrd] =
+  lazy val antisymmetryLaw1: Laws[PartialOrd] =
     new Laws.Law2[PartialOrd]("antisymmetryLaw1") {
       def apply[A: PartialOrd](a1: A, a2: A): TestResult =
         ((a1 lessOrEqual a2) && (a2 lessOrEqual a1)) ==> (a1 isEqualTo a2)
@@ -144,7 +144,7 @@ object PartialOrd extends Lawful[PartialOrd] {
    * For all values `a1` and `a2`, if `a1` is greater than or equal to `a2` and
    * `a2` is greater than or equal to `a1` then `a1` is equal to `a2`.
    */
-  val antisymmetryLaw2: Laws[PartialOrd] =
+  lazy val antisymmetryLaw2: Laws[PartialOrd] =
     new Laws.Law2[PartialOrd]("antisymmetryLaw2") {
       def apply[A: PartialOrd](a1: A, a2: A): TestResult =
         ((a1 greaterOrEqual a2) && (a2 greaterOrEqual a1)) ==> (a1 isEqualTo a2)
@@ -153,7 +153,7 @@ object PartialOrd extends Lawful[PartialOrd] {
   /**
    * For all values `a1` and `a2`, iff `a1 =??= a2` is `Ordering.Equals` then `a1 === a2`.
    */
-  val eqConsistencyLaw: Laws[PartialOrd] =
+  lazy val eqConsistencyLaw: Laws[PartialOrd] =
     new Laws.Law2[PartialOrd]("eqConsistencyLaw") {
       def apply[A: PartialOrd](a1: A, a2: A): TestResult =
         ((a1 =??= a2) isEqualTo Ordering.Equals) <==> ((a1 === a2) isEqualTo true)
@@ -162,7 +162,7 @@ object PartialOrd extends Lawful[PartialOrd] {
   /**
    * The set of all laws that instances of `PartialOrd` must satisfy.
    */
-  val laws: Laws[PartialOrd] =
+  lazy val laws: Laws[PartialOrd] =
     transitivityLaw1 +
       transitivityLaw2 +
       antisymmetryLaw1 +

--- a/core/shared/src/main/scala/zio/prelude/ZNonEmptySet.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZNonEmptySet.scala
@@ -241,13 +241,15 @@ object ZNonEmptySet extends LowPriorityZNonEmptySetImplicits {
    * Derives an `Equal[ZNonEmptySet[A, B]]` given an `Equal[B]`. Due to the
    * limitations of Scala's `Map`, this uses object equality on the keys.
    */
-  implicit def ZNonEmptySetEqual[A, B: Equal]: Equal[ZNonEmptySet[A, B]] =
+  implicit def ZNonEmptySetEqual[A, B: Equal](implicit ev: Identity[Sum[B]]): Equal[ZNonEmptySet[A, B]] =
     Equal[ZSet[A, B]].contramap(_.toZSet)
 
   /**
    * The `EqualF` instance for `ZNonEmptySet`.
    */
-  implicit def ZNonEmptySetDeriveEqual[B: Equal]: DeriveEqual[({ type lambda[+x] = ZNonEmptySet[x, B] })#lambda] =
+  implicit def ZNonEmptySetDeriveEqual[B: Equal](implicit
+    ev: Identity[Sum[B]]
+  ): DeriveEqual[({ type lambda[+x] = ZNonEmptySet[x, B] })#lambda] =
     new DeriveEqual[({ type lambda[+x] = ZNonEmptySet[x, B] })#lambda] {
       def derive[A: Equal]: Equal[ZNonEmptySet[A, B]] =
         ZNonEmptySetEqual
@@ -289,7 +291,7 @@ object ZNonEmptySet extends LowPriorityZNonEmptySetImplicits {
    * Derives a `Hash[ZNonEmptySet[A, B]]` given a `Hash[B]`. Due to the
    * limitations of Scala's `Map`, this uses object equality on the keys.
    */
-  implicit def ZNonEmptySetHash[A, B: Hash]: Hash[ZNonEmptySet[A, B]] =
+  implicit def ZNonEmptySetHash[A, B: Hash](implicit ev: Identity[Sum[B]]): Hash[ZNonEmptySet[A, B]] =
     Hash[ZSet[A, B]].contramap(_.zset)
 
   /**
@@ -306,7 +308,7 @@ trait LowPriorityZNonEmptySetImplicits {
    * Derives a `PartialOrd[ZNonEmptySet[A, B]]` given a `PartialOrd[B]`.
    * Due to the limitations of Scala's `Map`, this uses object equality on the keys.
    */
-  implicit def ZNonEmptySetPartialOrd[A, B: PartialOrd]: PartialOrd[ZNonEmptySet[A, B]] =
+  implicit def ZNonEmptySetPartialOrd[A, B: PartialOrd](implicit ev: Identity[Sum[B]]): PartialOrd[ZNonEmptySet[A, B]] =
     PartialOrd[ZSet[A, B]].contramap(_.toZSet)
 
 }

--- a/core/shared/src/main/scala/zio/prelude/ZSet.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZSet.scala
@@ -16,8 +16,9 @@
 
 package zio.prelude
 
-import zio.prelude.newtypes.{Max, Min, Prod, Sum}
+import zio.prelude.newtypes.{Max, Min, Natural, Prod, Sum}
 
+import scala.annotation.tailrec
 import scala.annotation.unchecked.uncheckedVariance
 import scala.collection.immutable.HashMap
 
@@ -121,6 +122,23 @@ final class ZSet[+A, +B] private (private val map: HashMap[A @uncheckedVariance,
     map.foldLeft[ZSet[C, B1]](ZSet.empty) { case (set, (a, b)) =>
       set <> f(a).transform(b1 => ev2.combine(Prod(b), Prod(b1)))
     }
+
+  def forEach[G[+_]: IdentityBoth: Covariant, C](f: A => G[C])(implicit ev: B <:< Natural): G[MultiSet[C]] = {
+
+    @tailrec
+    def loop(g: G[HashMap[C, Natural]], a: A, n: Int): G[HashMap[C, Natural]] =
+      if (n <= 0) g
+      else {
+        val updated = g.zipWith(f(a)) { (map, c) =>
+          map.get(c).fold(map.updated(c, Natural.one))(n => map.updated(c, Natural.successor(n)))
+        }
+        loop(updated, a, n - 1)
+      }
+
+    map
+      .foldLeft[G[HashMap[C, Natural]]](HashMap.empty.succeed) { case (g, (a, b)) => loop(g, a, ev(b)) }
+      .map(new ZSet(_))
+  }
 
   /**
    * Returns the hash code of this set.
@@ -234,15 +252,17 @@ object ZSet extends LowPriorityZSetImplicits {
    * times a value occurs in the set will be an integer representing how many
    * times the value occurred in the specified `Iterable`.
    */
-  def fromIterable[A](iterable: Iterable[A]): ZSet[A, Int] =
-    new ZSet(iterable.foldLeft(HashMap.empty[A, Int])((map, a) => map + (a -> map.get(a).fold(1)(_ + 1))))
+  def fromIterable[A](iterable: Iterable[A]): MultiSet[A] =
+    new ZSet(iterable.foldLeft(HashMap.empty[A, Natural]) { (map, a) =>
+      map + (a -> map.get(a).fold(Natural.one)(Natural.successor))
+    })
 
   /**
    * Constructs a set from the specified `Set`. The measure of how many times
    * a value occurs in the set will be a boolean representing whether a value
    * occurs at all.
    */
-  def fromSet[A](set: Set[A]): ZSet[A, Boolean]            =
+  def fromSet[A](set: Set[A]): ZSet[A, Boolean] =
     new ZSet(set.foldLeft(HashMap.empty[A, Boolean])((map, a) => map + (a -> true)))
 
   /**
@@ -250,13 +270,22 @@ object ZSet extends LowPriorityZSetImplicits {
    * the `Map` and the measure of how many times a value occurs will be the
    * keys value.
    */
-  def fromMap[A, B](map: Map[A, B]): ZSet[A, B]            =
+  def fromMap[A, B](map: Map[A, B]): ZSet[A, B] =
     new ZSet(
       map match {
         case map: HashMap[A, B] => map
         case _                  => map.foldLeft(HashMap.empty[A, B])(_ + _)
       }
     )
+
+  /**
+   * The `ForEach` instance for `MultiSet`.
+   */
+  implicit lazy val MultiSetForEach: ForEach[MultiSet] =
+    new ForEach[MultiSet] {
+      def forEach[G[+_]: IdentityBoth: Covariant, A, B](fa: MultiSet[A])(f: A => G[B]): G[MultiSet[B]] =
+        fa.forEach(f)
+    }
 
   /**
    * Derives a `Commutative[ZSet[A, B]]` given a `Commutative[B]`.
@@ -280,13 +309,15 @@ object ZSet extends LowPriorityZSetImplicits {
    * Derives an `Equal[ZSet[A, B]]` given an `Equal[B]`. Due to the
    * limitations of Scala's `Map`, this uses object equality on the keys.
    */
-  implicit def ZSetEqual[A, B: Equal]: Equal[ZSet[A, B]] =
-    Equal[HashMap[A, B]].contramap(_.map)
+  implicit def ZSetEqual[A, B](implicit ev1: Equal[B], ev: Identity[Sum[B]]): Equal[ZSet[A, B]] =
+    Equal[HashMap[A, B]].contramap(_.map.filterNot(_._2 === ev.identity))
 
   /**
    * The `EqualF` instance for `ZSet`.
    */
-  implicit def ZSetDeriveEqual[B: Equal]: DeriveEqual[({ type lambda[+x] = ZSet[x, B] })#lambda] =
+  implicit def ZSetDeriveEqual[B: Equal](implicit
+    ev: Identity[Sum[B]]
+  ): DeriveEqual[({ type lambda[+x] = ZSet[x, B] })#lambda] =
     new DeriveEqual[({ type lambda[+x] = ZSet[x, B] })#lambda] {
       def derive[A: Equal]: Equal[ZSet[A, B]] =
         ZSetEqual
@@ -347,8 +378,8 @@ object ZSet extends LowPriorityZSetImplicits {
    * Derives a `Hash[ZSet[A, B]]` given a `Hash[B]`. Due to the
    * limitations of Scala's `Map`, this uses object equality on the keys.
    */
-  implicit def ZSetHash[A, B: Hash]: Hash[ZSet[A, B]] =
-    Hash[HashMap[A, B]].contramap(_.map)
+  implicit def ZSetHash[A, B: Hash](implicit ev: Identity[Sum[B]]): Hash[ZSet[A, B]] =
+    Hash[HashMap[A, B]].contramap(_.map.filterNot(_._2 === ev.identity))
 
 }
 
@@ -358,7 +389,10 @@ trait LowPriorityZSetImplicits {
    * Derives a `PartialOrd[ZSet[A, B]]` given a `PartialOrd[B]`.
    * Due to the limitations of Scala's `Map`, this uses object equality on the keys.
    */
-  implicit def ZSetPartialOrd[A, B: PartialOrd]: PartialOrd[ZSet[A, B]] =
-    PartialOrd.makeFrom((l, r) => l.toMap.compareSoft(r.toMap), ZSet.ZSetEqual)
+  implicit def ZSetPartialOrd[A, B: PartialOrd](implicit ev: Identity[Sum[B]]): PartialOrd[ZSet[A, B]] =
+    PartialOrd.makeFrom(
+      (l, r) => l.toMap.filterNot(_._2 === ev.identity).compareSoft(r.toMap.filterNot(_._2 === ev.identity)),
+      ZSet.ZSetEqual
+    )
 
 }

--- a/core/shared/src/main/scala/zio/prelude/newtypes/package.scala
+++ b/core/shared/src/main/scala/zio/prelude/newtypes/package.scala
@@ -119,35 +119,20 @@ package object newtypes {
     def successor(n: Natural): Natural =
       Natural(n + 1)
 
-    /**
-     * The `Commutative` and `Identity` instance for the product of `Natural` values.
-     */
-    implicit val NaturalProdCommutativeIdentity: Commutative[Prod[Natural]] with Identity[Prod[Natural]] =
-      new Commutative[Prod[Natural]] with Identity[Prod[Natural]] {
-        def combine(x: => Prod[Natural], y: => Prod[Natural]): Prod[Natural] = {
-          val product = x * y
-          if (x == 0 || product / x != y) Prod(Natural(Int.MaxValue)) else Prod(Natural(product))
-        }
-        val identity: Prod[Natural] =
-          Prod(one)
-      }
+    def times(x: Natural, y: Natural): Natural = {
+      val product = x * y
+      if (x == 0 || product / x != y) Natural(Int.MaxValue) else Natural(product)
+    }
 
-    /**
-     * The `Commutative` and `Inverse` instance for the sum of `Narutal` values.
-     */
-    implicit val NaturalSumCommutativeInverse: Commutative[Sum[Natural]] with Inverse[Sum[Natural]] =
-      new Commutative[Sum[Natural]] with Inverse[Sum[Natural]] {
-        def combine(x: => Sum[Natural], y: => Sum[Natural]): Sum[Natural] = {
-          val sum = x + y
-          if (sum < 0) Sum(Natural(Int.MaxValue)) else Sum(Natural(sum))
-        }
-        val identity: Sum[Natural] =
-          Sum(zero)
-        def inverse(x: => Sum[Natural], y: => Sum[Natural]): Sum[Natural] = {
-          val difference = x - y
-          if (difference < 0) Sum(zero) else Sum(Natural(difference))
-        }
-      }
+    def plus(x: Natural, y: Natural): Natural = {
+      val sum = x + y
+      if (sum < 0) Natural(Int.MaxValue) else Natural(sum)
+    }
+
+    def minus(x: Natural, y: Natural): Natural = {
+      val difference = x - y
+      if (difference < 0) zero else Natural(difference)
+    }
 
     private[prelude] def unsafeMake(n: Int): Natural =
       Natural(n)

--- a/core/shared/src/main/scala/zio/prelude/newtypes/package.scala
+++ b/core/shared/src/main/scala/zio/prelude/newtypes/package.scala
@@ -80,7 +80,7 @@ package object newtypes {
    */
   type Min[A] = Min.Type[A]
 
-  object Max extends SubtypeF
+  object Max extends SubtypeF {}
 
   /**
    * A newtype representing taking the max of two elements.
@@ -107,4 +107,51 @@ package object newtypes {
   object FailureOut extends NewtypeF
 
   type FailureOut[+A] = FailureOut.Type[A]
+
+  object Natural extends SubtypeSmart[Int](isGreaterThanEqualTo(0)) {
+
+    val one: Natural =
+      Natural(1)
+
+    val zero: Natural =
+      Natural(0)
+
+    def successor(n: Natural): Natural =
+      Natural(n + 1)
+
+    /**
+     * The `Commutative` and `Identity` instance for the product of `Natural` values.
+     */
+    implicit val NaturalProdCommutativeIdentity: Commutative[Prod[Natural]] with Identity[Prod[Natural]] =
+      new Commutative[Prod[Natural]] with Identity[Prod[Natural]] {
+        def combine(x: => Prod[Natural], y: => Prod[Natural]): Prod[Natural] = {
+          val product = x * y
+          if (x == 0 || product / x != y) Prod(Natural(Int.MaxValue)) else Prod(Natural(product))
+        }
+        val identity: Prod[Natural] =
+          Prod(one)
+      }
+
+    /**
+     * The `Commutative` and `Inverse` instance for the sum of `Narutal` values.
+     */
+    implicit val NaturalSumCommutativeInverse: Commutative[Sum[Natural]] with Inverse[Sum[Natural]] =
+      new Commutative[Sum[Natural]] with Inverse[Sum[Natural]] {
+        def combine(x: => Sum[Natural], y: => Sum[Natural]): Sum[Natural] = {
+          val sum = x + y
+          if (sum < 0) Sum(Natural(Int.MaxValue)) else Sum(Natural(sum))
+        }
+        val identity: Sum[Natural] =
+          Sum(zero)
+        def inverse(x: => Sum[Natural], y: => Sum[Natural]): Sum[Natural] = {
+          val difference = x - y
+          if (difference < 0) Sum(zero) else Sum(Natural(difference))
+        }
+      }
+
+    private[prelude] def unsafeMake(n: Int): Natural =
+      Natural(n)
+  }
+
+  type Natural = Natural.Type
 }

--- a/core/shared/src/main/scala/zio/prelude/package.scala
+++ b/core/shared/src/main/scala/zio/prelude/package.scala
@@ -17,6 +17,7 @@
 package zio
 
 import com.github.ghik.silencer.silent
+import zio.prelude.newtypes.Natural
 import zio.test.{TestResult, assert}
 
 package object prelude
@@ -40,6 +41,7 @@ package object prelude
     with IdentitySyntax
     with IdentityBothSyntax
     with IdentityEitherSyntax
+    with InvariantSyntax
     with InverseSyntax
     with NewtypeExports
     with NewtypeFExports
@@ -75,9 +77,9 @@ package object prelude
   type Validation[+E, +A] = ZValidation[Nothing, E, A]
   val Validation: ZValidation.type = ZValidation
 
-  type MultiSet[+A] = ZSet[A, Int]
+  type MultiSet[+A] = ZSet[A, Natural]
   val MultiSet: ZSet.type = ZSet
-  type NonEmptyMultiSet[+A] = ZNonEmptySet[A, Int]
+  type NonEmptyMultiSet[+A] = ZNonEmptySet[A, Natural]
   val NonEmptyMultiSet: ZNonEmptySet.type = ZNonEmptySet
 
   type DeriveAssociative[F[_]] = Derive[F, Associative]

--- a/core/shared/src/test/scala/zio/prelude/NaturalSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/NaturalSpec.scala
@@ -1,0 +1,19 @@
+package zio.prelude
+
+import zio.prelude.newtypes.{Prod, Sum}
+import zio.test._
+import zio.test.laws._
+
+object NaturalSpec extends DefaultRunnableSpec {
+
+  def spec: ZSpec[Environment, Failure] =
+    suite("NaturalSpec")(
+      suite("laws")(
+        testM("product commutative")(checkAllLaws(Commutative)(Gens.anyNatural.map(Prod(_)))),
+        testM("product identity")(checkAllLaws(Identity)(Gens.anyNatural.map(Prod(_)))),
+        testM("sum commutative")(checkAllLaws(Commutative)(Gens.anyNatural.map(Sum(_)))),
+        testM("sum inverse")(checkAllLaws(Inverse)(Gens.anyNatural.map(Sum(_))))
+      )
+    )
+
+}

--- a/core/shared/src/test/scala/zio/prelude/ZNonEmptySetSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ZNonEmptySetSpec.scala
@@ -26,6 +26,9 @@ object ZNonEmptySetSpec extends DefaultRunnableSpec {
   val smallInts: Gen[Random with Sized, Chunk[Int]] =
     Gen.chunkOf(Gen.int(-10, 10))
 
+  implicit def SumIdentity[A: Identity]: Identity[Sum[A]] =
+    Identity[A].invmap(Equivalence(Sum.wrap, Sum.unwrap))
+
   def spec: ZSpec[Environment, Failure] =
     suite("ZNonEmptySetSpec")(
       suite("laws")(
@@ -44,7 +47,7 @@ object ZNonEmptySetSpec extends DefaultRunnableSpec {
             // Scala 2.11 doesn't seem to be able to infer the type parameter for CovariantDeriveEqual.derive
             CovariantDeriveEqual.derive[({ type lambda[+x] = ZNonEmptySet[x, Int] })#lambda](
               ZNonEmptySetCovariant(IntSumCommutativeInverse),
-              ZNonEmptySetDeriveEqual(IntHashOrd)
+              ZNonEmptySetDeriveEqual(IntHashOrd, Identity[Sum[Int]])
             ),
             IntHashOrd
           )

--- a/core/shared/src/test/scala/zio/prelude/ZSetSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ZSetSpec.scala
@@ -22,11 +22,11 @@ object ZSetSpec extends DefaultRunnableSpec {
   def genZSet[R <: Random with Sized, A, B](a: Gen[R, A], b: Gen[R, B]): Gen[R, ZSet[A, B]] =
     Gen.mapOf(a, b).map(ZSet.fromMap)
 
-  val smallInts: Gen[Random with Sized, Chunk[Int]] =
+  lazy val smallInts: Gen[Random with Sized, Chunk[Int]] =
     Gen.chunkOf(Gen.int(-10, 10))
 
-  val naturals: Gen[Random with Sized, Natural] =
-    Gen.sized(n => Gens.natural(Natural.zero, Natural.unsafeMake(n)))
+  lazy val naturals: Gen[Random with Sized, Natural] =
+    Gen.small(n => Gens.natural(Natural.zero, Natural.unsafeMake(n)))
 
   implicit def SumIdentity[A: Identity]: Identity[Sum[A]] =
     Identity[A].invmap(Equivalence(Sum.wrap, Sum.unwrap))
@@ -54,7 +54,7 @@ object ZSetSpec extends DefaultRunnableSpec {
             IntHashOrd
           )
         ),
-        // testM("foreach")(checkAllLaws(ForEach)(genFZSet(naturals), Gen.anyInt)),
+        testM("foreach")(checkAllLaws(ForEach)(genFZSet(naturals), Gen.anyInt)),
         testM("hash")(checkAllLaws(Hash)(genZSet(Gen.anyInt, Gen.anyInt))),
         testM("intersect commutative")(
           checkAllLaws(Commutative)(genZSet(Gen.anyInt, Gen.anyInt).map(_.transform(Min(_))))


### PR DESCRIPTION
Implements `ForEach` for `ZSet`. This is only defined when the `ZSet` is a multiset, as we can only perform an effect an integral number of times.

Doing this in a way that was sound also required implementing a `Natural` new type so that we know whether the `ZSet` contains only non-negative values since a `ZSet` with negative integer values is also well defined but has different semantics.

In the course of doing this I also noticed that the definition of laws and type class instance as `val` could lead to deadlocks due to early initialization issues. I changed all the laws to be `lazy val` and am hopeful that this will improve the flakiness we have seen in CI. I think we should consider doing the same with type class instances.