### PR TITLE
ZValidation#toZIO via Cause

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/ParSeq.scala
+++ b/core/shared/src/main/scala/zio/prelude/ParSeq.scala
@@ -136,7 +136,7 @@ sealed trait ParSeq[+Z <: Unit, +A] { self =>
       _.zipWith(_)(_ && _)
     ).asInstanceOf[F[ParSeq[Z, B]]]
 
-  def toCause: zio.Cause[A] = this match {
+  final def toCause: zio.Cause[A] = this match {
     case ParSeq.Both(left, right) => zio.Cause.Both(left.toCause, right.toCause)
     case _: ParSeq.Empty.type     => zio.Cause.empty
     case ParSeq.Single(value)     => zio.Cause.Fail(value)

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -195,7 +195,7 @@ sealed trait ZValidation[+W, +E, +A] { self =>
    */
   final def toZIO: IO[E, A] =
     self.fold(
-      nec => ZIO.halt(nec.foldLeft[zio.Cause[E]](zio.Cause.empty)((c, e) => zio.Cause.Both(c, zio.Cause.fail(e)))),
+      nec => ZIO.halt(nec.reduceMapLeft(zio.Cause.fail)((c, e) => zio.Cause.Both(c, zio.Cause.fail(e)))),
       ZIO.succeedNow
     )
 

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -193,8 +193,11 @@ sealed trait ZValidation[+W, +E, +A] { self =>
   /**
    * Converts this `ZValidation` into a `ZIO` effect, discarding the log.
    */
-  final def toZIO: IO[NonEmptyChunk[E], A] =
-    ZIO.fromEither(self.toEither)
+  final def toZIO: IO[E, A] =
+    self.fold(
+      nec => ZIO.halt(nec.foldLeft[zio.Cause[E]](zio.Cause.empty)((c, e) => zio.Cause.Both(c, zio.Cause.fail(e)))),
+      ZIO.succeedNow
+    )
 
   /**
    * A variant of `zipPar` that keeps only the left success value, but returns
@@ -263,7 +266,7 @@ object ZValidation extends LowPriorityValidationImplicits {
    */
   implicit def ZValidationEqual[W, E, A: Equal]: Equal[ZValidation[W, E, A]] =
     Equal.make {
-      case (Failure(_, e), Failure(_, e1)) => MultiSet.fromIterable(e) === MultiSet.fromIterable(e1)
+      case (Failure(_, e), Failure(_, e1)) => MultiSet.fromIterable(e) == MultiSet.fromIterable(e1)
       case (Success(_, a), Success(_, a1)) => a === a1
       case _                               => false
     }


### PR DESCRIPTION
I've been thinking that even though that `ZValidation` has `NonEmptyChunk` internally, it might be "cleaner" to convert it to `IO[E, A]` (and not `IO[NonEmptyChunk[E], A]`).
What do you think?
