### PR TITLE
Add ZValidation#toEitherUnordered (returning NonEmptyMultiSet)

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -88,7 +88,7 @@ sealed trait ZValidation[+W, +E, +A] { self =>
     }
 
   /**
-   * Folds over the error and success values of this `ZValidation`.
+   * Folds over the ordered errors and success values of this `ZValidation`.
    */
   final def foldOrdered[B](failure: NonEmptyChunk[E] => B, success: A => B): B =
     self match {

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -167,13 +167,13 @@ sealed trait ZValidation[+W, +E, +A] { self =>
     }
 
   /**
-   * Transforms this `ZValidation` to an `Either` with errors in the order they occurred, discarding the log.
+   * Transforms this `ZValidation` to an `Either`, discarding the log.
    */
   final def toEither[E1 >: E]: Either[NonEmptyChunk[E1], A] =
     fold(Left(_), Right(_))
 
   /**
-   * Transforms this `ZValidation` to an `Either`, discarding the log.
+   * Transforms this `ZValidation` to an `Either`, discarding the order in which the errors ocurred and discarding the log.
    */
   final def toEitherUnordered[E1 >: E]: Either[NonEmptyMultiSet[E], A] =
     self match {

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -173,7 +173,7 @@ sealed trait ZValidation[+W, +E, +A] { self =>
     fold(Left(_), Right(_))
 
   /**
-   * Transforms this `ZValidation` to an `Either`, discarding the order in which the errors ocurred and discarding the log.
+   * Transforms this `ZValidation` to an `Either`, discarding the order in which the errors occurred and discarding the log.
    */
   final def toEitherUnordered[E1 >: E]: Either[NonEmptyMultiSet[E], A] =
     self match {

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -48,11 +48,11 @@ sealed trait ZValidation[+W, +E, +A] { self =>
   override final def equals(that: Any): Boolean =
     that match {
       case that: AnyRef if self.eq(that) => true
-      case that: ZValidation[_, _, _]    => self.toEitherUnordered == that.toEitherUnordered
+      case that: ZValidation[_, _, _]    => self.toEitherMultiSet == that.toEitherMultiSet
       case _                             => false
     }
 
-  override final def hashCode(): Int = toEitherUnordered.hashCode()
+  override final def hashCode(): Int = toEitherMultiSet.hashCode()
 
   /**
    * Transforms the value of this `ZValidation` with the specified validation
@@ -175,7 +175,7 @@ sealed trait ZValidation[+W, +E, +A] { self =>
   /**
    * Transforms this `ZValidation` to an `Either`, discarding the order in which the errors occurred and discarding the log.
    */
-  final def toEitherUnordered[E1 >: E]: Either[NonEmptyMultiSet[E], A] =
+  final def toEitherMultiSet[E1 >: E]: Either[NonEmptyMultiSet[E], A] =
     self match {
       case failure @ Failure(_, _) => Left(failure.errorsUnordered)
       case Success(_, value)       => Right(value)
@@ -278,7 +278,7 @@ object ZValidation extends LowPriorityValidationImplicits {
    * Derives an `Equal[ZValidation[W, E, A]]` given an `Equal[A]`.
    */
   implicit def ZValidationEqual[W, E, A: Equal]: Equal[ZValidation[W, E, A]] =
-    Equal[Either[NonEmptyMultiSet[E], A]].contramap(_.toEitherUnordered)
+    Equal[Either[NonEmptyMultiSet[E], A]].contramap(_.toEitherMultiSet)
 
   /**
    * The `DeriveEqual` instance for `ZValidation`.
@@ -335,7 +335,7 @@ object ZValidation extends LowPriorityValidationImplicits {
    * Derives a `PartialOrd[ZValidation[W, E, A]]` given an `Ord[E]` and an `Ord[A]`.
    */
   implicit def ZValidationPartialOrd[W, E: PartialOrd, A: PartialOrd]: PartialOrd[ZValidation[W, E, A]] =
-    PartialOrd[Either[NonEmptyMultiSet[E], A]].contramap(_.toEitherUnordered)
+    PartialOrd[Either[NonEmptyMultiSet[E], A]].contramap(_.toEitherMultiSet)
 
   /**
    * Attempts to evaluate the specified value, catching any error that occurs
@@ -1518,5 +1518,5 @@ trait LowPriorityValidationImplicits {
    * Derives a `Hash[ZValidation[W, E, A]]` given a `Hash[A]`.
    */
   implicit def ZValidationHash[W, E, A: Hash]: Hash[ZValidation[W, E, A]] =
-    Hash[Either[NonEmptyMultiSet[E], A]].contramap(_.toEitherUnordered)
+    Hash[Either[NonEmptyMultiSet[E], A]].contramap(_.toEitherMultiSet)
 }

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -79,7 +79,7 @@ sealed trait ZValidation[+W, +E, +A] { self =>
     }
 
   /**
-   * Folds over the ordered errors and success values of this `ZValidation`.
+   * Folds over the error and success values of this `ZValidation`.
    */
   final def fold[B](failure: NonEmptyChunk[E] => B, success: A => B): B =
     self match {
@@ -169,10 +169,8 @@ sealed trait ZValidation[+W, +E, +A] { self =>
   /**
    * Transforms this `ZValidation` to an `Either` with errors in the order they occurred, discarding the log.
    */
-  final def toEither[E1 >: E]: Either[NonEmptyChunk[E1], A] = this match {
-    case Failure(_, errors) => Left(errors)
-    case Success(_, value)  => Right(value)
-  }
+  final def toEither[E1 >: E]: Either[NonEmptyChunk[E1], A] =
+    fold(Left(_), Right(_))
 
   /**
    * Transforms this `ZValidation` to an `Either`, discarding the log.
@@ -256,8 +254,7 @@ object ZValidation extends LowPriorityValidationImplicits {
   final case class Failure[+W, +E](log: Chunk[W], errors: NonEmptyChunk[E]) extends ZValidation[W, E, Nothing] {
     lazy val errorsUnordered: NonEmptyMultiSet[E] = NonEmptyMultiSet.fromIterable(errors.head, errors.tail)
   }
-
-  final case class Success[+W, +A](log: Chunk[W], value: A) extends ZValidation[W, Nothing, A]
+  final case class Success[+W, +A](log: Chunk[W], value: A)                 extends ZValidation[W, Nothing, A]
 
   /**
    * The `Covariant` instance for `ZValidation`.

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -1515,7 +1515,7 @@ trait LowPriorityValidationImplicits {
     }
 
   /**
-   * Derives an `Hash[ZValidation[W, E, A]]` given an `Hash[A]`.
+   * Derives a `Hash[ZValidation[W, E, A]]` given a `Hash[A]`.
    */
   implicit def ZValidationHash[W, E, A: Hash]: Hash[ZValidation[W, E, A]] =
     Hash[Either[NonEmptyMultiSet[E], A]].contramap(_.toEitherUnordered)

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -46,11 +46,13 @@ sealed trait ZValidation[+W, +E, +A] { self =>
    * equal to each other.
    */
   override final def equals(that: Any): Boolean =
-    (self, that) match {
-      case (Failure(_, e), Failure(_, e1)) => e == e1
-      case (Success(_, a), Success(_, a1)) => a == a1
-      case _                               => false
+    that match {
+      case that: AnyRef if self.eq(that) => true
+      case that: ZValidation[_, _, _]    => self.toEither == that.toEither
+      case _                             => false
     }
+
+  override final def hashCode(): Int = toEither.hashCode()
 
   /**
    * Transforms the value of this `ZValidation` with the specified validation

--- a/core/shared/src/test/scala/zio/prelude/ZValidationSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ZValidationSpec.scala
@@ -1,6 +1,5 @@
 package zio.prelude
 
-import zio.ZIO
 import zio.prelude.Equal._
 import zio.prelude.HashSpec.scalaHashCodeConsistency
 import zio.prelude.ZValidation._

--- a/core/shared/src/test/scala/zio/prelude/ZValidationSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ZValidationSpec.scala
@@ -1,6 +1,8 @@
 package zio.prelude
 
+import zio.ZIO
 import zio.prelude.Equal._
+import zio.prelude.HashSpec.scalaHashCodeConsistency
 import zio.prelude.ZValidation._
 import zio.random.Random
 import zio.test._
@@ -27,6 +29,9 @@ object ZValidationSpec extends DefaultRunnableSpec {
       testM("hash")(checkAllLaws(Hash)(genValidation)),
       testM("identityBoth")(checkAllLaws(IdentityBoth)(genFValidation, Gen.anyInt)),
       testM("partialOrd")(checkAllLaws(PartialOrd)(genValidation))
+    ),
+    suite("ScalaHashCode consistency")(
+      testM("ZValidation")(scalaHashCodeConsistency(genValidation))
     )
   )
 }


### PR DESCRIPTION
Since we want `ZValidation` to behave as if the errors were accumulated in `NonEmptyMultiSet`, I've been thinking that we should be nudging our users to use methods that work with `NonEmptyMultiSet`.
Methods that work with the actual `NonEmptyChunk` should not be in the spotlight as much and people should use them only if explicitly wanted (`toEitherOrdered` or `toEitherWith`).
