### PR TITLE
Up out CI game

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,19 +1,36 @@
-name-template: 'v$NEXT_PATCH_VERSION'
-tag-template: 'v$NEXT_PATCH_VERSION'
-categories:
-  - title: '🚀 Features'
-    labels:
-      - 'feature'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'bug'
-  - title: '🧰 Maintenance'
-    labels:
-      - 'build'
-  - title: '🌱 Dependency Updates'
-    labels:
-      - 'dependency-update'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 template: |
-  ## Changes
+  # What's Changed
   $CHANGES
+categories:
+  - title: 'Breaking'
+    label: 'type: breaking'
+  - title: 'New'
+    label: 'type: feature'
+  - title: 'Bug Fixes'
+    label: 'type: bug'
+  - title: 'Maintenance'
+    label: 'type: maintenance'
+  - title: 'Documentation'
+    label: 'type: docs'
+  - title: 'Dependency Updates'
+    label: 'type: dependencies'
+
+version-resolver:
+  major:
+    labels:
+      - 'type: breaking'
+  minor:
+    labels:
+      - 'type: feature'
+  patch:
+    labels:
+      - 'type: bug'
+      - 'type: maintenance'
+      - 'type: docs'
+      - 'type: dependencies'
+      - 'type: security'
+
+exclude-labels:
+  - 'skip-changelog'

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,12 @@
+{
+  "automerge": true,
+  "labels": ["type: dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "sbt"
+      ],
+      "enabled": false
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 'adopt@1.8' , 'adopt@1.11' ]
-        scala: [ '2.11.12' , '2.12.13' , '2.13.5' , '3.0.0-M3' ]
+        java: ['adopt@1.8', 'adopt@1.11']
+        scala: ['2.11.12', '2.12.13', '2.13.5', '3.0.0-M3']
         platform: ['JVM', 'JS', 'Native']
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ $JAVA8 , $JAVA11 ]
-        scala: [ $SCALA_211 , $SCALA_212 , $SCALA_213 , $SCALA_3 ]
+        java: [ ${JAVA8} , ${JAVA11} ]
+        scala: [ ${SCALA_211} , ${SCALA_212} , ${SCALA_213} , ${SCALA_3} ]
         platform: ['JVM', 'JS', 'Native']
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,5 @@
 name: CI
 
-# Keep this consistent with the versions in project/BuildHelper.scala
 env:
   JAVA8: adopt@1.8
   JAVA11: adopt@1.11
@@ -40,8 +39,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ ${{ env.JAVA8 }} , ${{ env.JAVA11 }} ]
-        scala: [${{ env.SCALA_211 }} , ${{ env.SCALA_212 }} , ${{ env.SCALA_213 }} , ${{ env.SCALA_3 }} ]
+        java: [ env.JAVA8 , env.JAVA11 ]
+        scala: [ env.SCALA_211 , env.SCALA_212 , env.SCALA_213 , env.SCALA_3 ]
         platform: ['JVM', 'JS', 'Native']
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: CI
 
 env:
-  JAVA8: adopt@1.8
-  JAVA11: adopt@1.11
-  SCALA_211: 2.11.12
-  SCALA_212: 2.12.13
-  SCALA_213: 2.13.5
-  SCALA_3: 3.0.0-M3
   JDK_JAVA_OPTIONS: -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
 on:
@@ -39,8 +33,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ ${JAVA8} , ${JAVA11} ]
-        scala: [ ${SCALA_211} , ${SCALA_212} , ${SCALA_213} , ${SCALA_3} ]
+        java: [ 'adopt@1.8' , 'adopt@1.11' ]
+        scala: [ '2.11.12' , '2.12.13' , '2.13.5' , '3.0.0-M3' ]
         platform: ['JVM', 'JS', 'Native']
     steps:
       - name: Checkout current branch
@@ -54,10 +48,10 @@ jobs:
       - name: Cache scala dependencies
         uses: coursier/cache-action@v5
       - name: Run tests
-        if: ${{ matrix.scala != env.SCALA_3 }}
+        if: ${{ !startsWith(matrix.scala, '3.') }}
         run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
       - name: Run dotty tests
-        if: ${{ matrix.scala == env.SCALA_3 && matrix.platform == 'JVM' }}
+        if: ${{ startsWith(matrix.scala, '3.') && matrix.platform == 'JVM' }}
         run: sbt ++${{ matrix.scala }}! testJVM
 
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Cache scala dependencies
         uses: coursier/cache-action@v5
       - name: Run tests
-        if: ${{ !startsWith(matrix.scala, '3.') }}
+        if: ${{ !startsWith(matrix.scala, '3.0.') }}
         run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
       - name: Run dotty tests
-        if: ${{ startsWith(matrix.scala, '3.') && matrix.platform == 'JVM' }}
+        if: ${{ startsWith(matrix.scala, '3.0.') && matrix.platform == 'JVM' }}
         run: sbt ++${{ matrix.scala }}! testJVM
 
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ ${{ ${{ env.JAVA8 }} }} , ${{ ${{ env.JAVA11 }} }} ]
-        scala: [${{ ${{ env.SCALA_211 }} }} , ${{ ${{ env.SCALA_212 }} }} , ${{ ${{ env.SCALA_213 }} }} , ${{ ${{ env.SCALA_3 }} }} ]
+        java: [ $JAVA8 , $JAVA11 ]
+        scala: [ $SCALA_211 , $SCALA_212 , $SCALA_213 , $SCALA_3 ]
         platform: ['JVM', 'JS', 'Native']
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ env.JAVA8 , env.JAVA11 ]
-        scala: [ env.SCALA_211 , env.SCALA_212 , env.SCALA_213 , env.SCALA_3 ]
+        java: [ ${{ ${{ env.JAVA8 }} }} , ${{ ${{ env.JAVA11 }} }} ]
+        scala: [${{ ${{ env.SCALA_211 }} }} , ${{ ${{ env.SCALA_212 }} }} , ${{ ${{ env.SCALA_213 }} }} , ${{ ${{ env.SCALA_3 }} }} ]
         platform: ['JVM', 'JS', 'Native']
     steps:
       - name: Checkout current branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,15 @@
 name: CI
 
+# Keep this consistent with the versions in project/BuildHelper.scala
+env:
+  JAVA8: adopt@1.8
+  JAVA11: adopt@1.11
+  SCALA_211: 2.11.12
+  SCALA_212: 2.12.13
+  SCALA_213: 2.13.5
+  SCALA_3: 3.0.0-M3
+  JDK_JAVA_OPTIONS: -Xms2048M -Xmx3072M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+
 on:
   pull_request:
   push:
@@ -12,8 +22,6 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v2.3.4
@@ -32,8 +40,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['adopt@1.8', 'adopt@1.11']
-        scala: ['2.11.12', '2.12.13', '2.13.4', '3.0.0-M3']
+        java: [ ${{ env.JAVA8 }} , ${{ env.JAVA11 }} ]
+        scala: [${{ env.SCALA_211 }} , ${{ env.SCALA_212 }} , ${{ env.SCALA_213 }} , ${{ env.SCALA_3 }} ]
         platform: ['JVM', 'JS', 'Native']
     steps:
       - name: Checkout current branch
@@ -47,16 +55,23 @@ jobs:
       - name: Cache scala dependencies
         uses: coursier/cache-action@v5
       - name: Run tests
-        if: ${{ matrix.scala != '3.0.0-M3' }}
+        if: ${{ matrix.scala != env.SCALA_3 }}
         run: sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
       - name: Run dotty tests
-        if: ${{ matrix.scala == '3.0.0-M3' && matrix.platform == 'JVM' }}
+        if: ${{ matrix.scala == env.SCALA_3 && matrix.platform == 'JVM' }}
         run: sbt ++${{ matrix.scala }}! testJVM
+
+  ci:
+    runs-on: ubuntu-20.04
+    needs: [lint, test]
+    steps:
+      - name: Aggregate of lint, and all tests
+        run: echo "ci passed"
 
   publish:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
-    needs: [lint, test]
+    needs: [ci]
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout current branch

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,38 +6,14 @@ pull_request_rules:
       assign:
         users: [adamgfraser]
       label:
-        add: [dependency-update]
+        add: ["type: dependencies"]
   - name: merge Scala Steward's PRs
     conditions:
       - base=master
       - author=scala-steward
-      - "body~=(labels: library-update, semver-minor)|(labels: library-update, semver-patch)|(labels: sbt-plugin-update, semver-minor)|(labels: sbt-plugin-update, semver-patch)|(labels: scalafix-rule-update, semver-minor)|(labels: scalafix-rule-update, semver-patch)|(labels: test-library-update, semver-minor)|(labels: test-library-update, semver-patch)"
+      - "body~=(labels: library-update, semver-minor)|(labels: library-update, semver-patch)|(labels: sbt-plugin-update, semver-minor)|(labels: sbt-plugin-update, semver-patch)|(labels: scalafix-rule-update)|(labels: test-library-update)"
       - "status-success=license/cla"
-      - "status-success=lint"
-      - "status-success=test (adopt@1.8, 2.11.12, JVM)"
-      - "status-success=test (adopt@1.8, 2.11.12, JS)"
-      - "status-success=test (adopt@1.8, 2.11.12, Native)"
-      - "status-success=test (adopt@1.8, 2.12.13, JVM)"
-      - "status-success=test (adopt@1.8, 2.12.13, JS)"
-      - "status-success=test (adopt@1.8, 2.12.13, Native)"
-      - "status-success=test (adopt@1.8, 2.13.4, JVM)"
-      - "status-success=test (adopt@1.8, 2.13.4, JS)"
-      - "status-success=test (adopt@1.8, 2.13.4, Native)"
-      - "status-success=test (adopt@1.8, 3.0.0-M3, JVM)"
-      - "status-success=test (adopt@1.8, 3.0.0-M3, JS)"
-      - "status-success=test (adopt@1.8, 3.0.0-M3, Native)"
-      - "status-success=test (adopt@1.11, 2.11.12, JVM)"
-      - "status-success=test (adopt@1.11, 2.11.12, JS)"
-      - "status-success=test (adopt@1.11, 2.11.12, Native)"
-      - "status-success=test (adopt@1.11, 2.12.13, JVM)"
-      - "status-success=test (adopt@1.11, 2.12.13, JS)"
-      - "status-success=test (adopt@1.11, 2.12.13, Native)"
-      - "status-success=test (adopt@1.11, 2.13.4, JVM)"
-      - "status-success=test (adopt@1.11, 2.13.4, JS)"
-      - "status-success=test (adopt@1.11, 2.13.4, Native)"
-      - "status-success=test (adopt@1.11, 3.0.0-M3, JVM)"
-      - "status-success=test (adopt@1.11, 3.0.0-M3, JS)"
-      - "status-success=test (adopt@1.11, 3.0.0-M3, Native)"
+      - "status-success=ci"
     actions:
       merge:
         method: squash

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -1,7 +1,6 @@
 import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import explicitdeps.ExplicitDepsPlugin.autoImport._
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
-import org.snakeyaml.engine.v2.api.{Load, LoadSettings}
 import sbt.Keys._
 import sbt._
 import sbtbuildinfo.BuildInfoKeys._
@@ -9,14 +8,15 @@ import sbtbuildinfo._
 import sbtcrossproject.CrossPlugin.autoImport._
 import scalafix.sbt.ScalafixPlugin.autoImport._
 
-import java.util.{List => JList, Map => JMap}
-import scala.io.Source
-import scala.jdk.CollectionConverters._
-
 object BuildHelper {
   private val versions: Map[String, String] = {
+    import org.snakeyaml.engine.v2.api.{Load, LoadSettings}
+
+    import java.util.{List => JList, Map => JMap}
+    import scala.jdk.CollectionConverters._
+
     val doc  = new Load(LoadSettings.builder().build())
-      .loadFromReader(Source.fromFile(".github/workflows/ci.yml").bufferedReader())
+      .loadFromReader(scala.io.Source.fromFile(".github/workflows/ci.yml").bufferedReader())
     val yaml = doc.asInstanceOf[JMap[String, JMap[String, JMap[String, JMap[String, JMap[String, JList[String]]]]]]]
     val list = yaml.get("jobs").get("test").get("strategy").get("matrix").get("scala").asScala
     list.map(v => (v.split('.').take(2).mkString("."), v)).toMap

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -8,12 +8,22 @@ import dotty.tools.sbtplugin.DottyPlugin.autoImport._
 import BuildInfoKeys._
 import scalafix.sbt.ScalafixPlugin.autoImport._
 
+import scala.io.Source
+
 object BuildHelper {
-  // Keep this consistent with the version in .circleci/config.yml
-  val Scala211   = "2.11.12"
-  val Scala212   = "2.12.13"
-  val Scala213   = "2.13.4"
-  val ScalaDotty = "3.0.0-M3"
+  val versions: Map[String, String] = {
+    val source = Source.fromFile(".github/workflows/ci.yml")
+    val result = source
+      .getLines()
+      .flatMap("(.*):(.*)".r.findFirstMatchIn(_).map(m => (m.group(1).trim, m.group(2).trim)))
+      .toArray
+    source.close()
+    result.reverse.toMap
+  }
+  val Scala211: String   = versions("SCALA_211")
+  val Scala212: String   = versions("SCALA_212")
+  val Scala213: String   = versions("SCALA_213")
+  val ScalaDotty: String = versions("SCALA_3")
 
   val SilencerVersion = "1.7.3"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,3 +16,5 @@ addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                   
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.4.2")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.4.0")
+
+libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.2.1"


### PR DESCRIPTION
 * use Renovate to maintain versions in GitHub Actions
 * manually managing each CI sub-step is unsustainable, now we have a step `ci` which aggregates all the necessary steps and which other tools can reference (e.g. GitHub or Mergify)
 * single source of truths for versions
   * Scala versions are read from `.github/workflows/ci.yml`
   * in `.github/workflows/ci.yml`, versions are not duplicated
 * better policy for Release Drafter, with better labeling support (taken from Release Drafter itself)
