### PR TITLE
[ZPure] Implement clearLogOnError and keepLogOnError

### DIFF
--- a/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
@@ -906,6 +906,49 @@ object ZPureSpec extends DefaultRunnableSpec {
             _ <- ZPure.log("times")
           } yield b
           assert(computation.runLog)(equalTo((Chunk("plus", "times"), 6)))
+        },
+        test("log is not cleared after failure") {
+          def log(i: Int): ZPure[Int, String, String, Any, Nothing, Unit] = ZPure.log(i)
+          val zPure                                                       =
+            for {
+              _ <- (log(1) *> ZPure.fail("baz")).either
+              _ <- log(2)
+              _ <- (log(3) *> ZPure.fail("baz")).either
+              _ <- (log(4) *> (if (false) ZPure.fail("baz") else ZPure.unit)).either
+            } yield ()
+          assert(zPure.keepLogOnError.provideState("").runLog)(equalTo((Chunk(1, 2, 3, 4), ())))
+        },
+        test("log is not cleared after failure with keepLogOnError") {
+          def log(i: Int): ZPure[Int, String, String, Any, Nothing, Unit] = ZPure.log(i)
+          val zPure                                                       =
+            for {
+              _ <- (log(1) *> ZPure.fail("baz")).either
+              _ <- log(2)
+              _ <- (log(3) *> ZPure.fail("baz")).either
+              _ <- (log(4) *> (if (false) ZPure.fail("baz") else ZPure.unit)).either
+            } yield ()
+          assert(zPure.keepLogOnError.provideState("").runLog)(equalTo((Chunk(1, 2, 3, 4), ())))
+        },
+        test("log is cleared after failure with clearLogOnError") {
+          def log(i: Int): ZPure[Int, String, String, Any, Nothing, Unit] = ZPure.log(i)
+          val zPure                                                       =
+            for {
+              _ <- (log(1) *> ZPure.fail("baz")).either
+              _ <- log(2)
+              _ <- (log(3) *> ZPure.fail("baz")).either
+              _ <- (log(4) *> (if (false) ZPure.fail("baz") else ZPure.unit)).either
+            } yield ()
+          assert(zPure.clearLogOnError.provideState("").runLog)(equalTo((Chunk(2, 4), ())))
+        },
+        test("combine clearLogOnError and keepLogOnError") {
+          def log(i: Int): ZPure[Int, String, String, Any, Nothing, Unit] = ZPure.log(i)
+          val zPure                                                       =
+            for {
+              _ <- (log(1) *> ZPure.fail("baz")).either.keepLogOnError
+              _ <- log(2)
+              _ <- (log(3) *> ZPure.fail("baz")).either.clearLogOnError
+            } yield ()
+          assert(zPure.provideState("").runLog)(equalTo((Chunk(1, 2), ())))
         }
       )
     )


### PR DESCRIPTION
Add the ability to change the behavior of `ZPure`, so that it may or may not clear the log on error.
It is implemented in a way that allows different monadic regions having different flags.