### PR TITLE
[ZPure] Properly handle clearLogOnError when the whole computation fails

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -743,7 +743,7 @@ sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
           zPure.flag match {
             case FlagType.ClearLogOnError =>
               clearLogOnError.push(zPure.value)
-              curZPure = zPure.continue.fold(
+              curZPure = zPure.continue.bimap(
                 e => {
                   if (zPure.value) logs.peek().clear()
                   clearLogOnError.popOrElse(false)

--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -744,7 +744,11 @@ sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
             case FlagType.ClearLogOnError =>
               clearLogOnError.push(zPure.value)
               curZPure = zPure.continue.fold(
-                e => { clearLogOnError.popOrElse(false); e },
+                e => {
+                  if (zPure.value) logs.peek().clear()
+                  clearLogOnError.popOrElse(false)
+                  e
+                },
                 a => { clearLogOnError.popOrElse(false); a }
               )
           }

--- a/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
@@ -949,6 +949,16 @@ object ZPureSpec extends DefaultRunnableSpec {
               _ <- (log(3) *> ZPure.fail("baz")).either.clearLogOnError
             } yield ()
           assert(zPure.provideState("").runLog)(equalTo((Chunk(1, 2), ())))
+        },
+        test("log is not cleared after failure with keepLogOnError when the whole computation fails") {
+          def log(i: Int): ZPure[Int, String, String, Any, Nothing, Unit] = ZPure.log(i)
+          val zPure                                                       = log(1) *> ZPure.fail("baz")
+          assert(zPure.keepLogOnError.runAll("")._1)(equalTo(Chunk(1)))
+        },
+        test("log is cleared after failure with clearLogOnError when the whole computation fails") {
+          def log(i: Int): ZPure[Int, String, String, Any, Nothing, Unit] = ZPure.log(i)
+          val zPure                                                       = log(1) *> ZPure.fail("baz")
+          assert(zPure.clearLogOnError.runAll("")._1)(equalTo(Chunk()))
         }
       )
     )

--- a/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
@@ -959,6 +959,11 @@ object ZPureSpec extends DefaultRunnableSpec {
           def log(i: Int): ZPure[Int, String, String, Any, Nothing, Unit] = ZPure.log(i)
           val zPure                                                       = log(1) *> ZPure.fail("baz")
           assert(zPure.clearLogOnError.runAll("")._1)(equalTo(Chunk()))
+        },
+        test("clearLogOnError should not affect the overall result") {
+          def log(i: Int): ZPure[Int, String, String, Any, Nothing, Unit] = ZPure.log(i)
+          val zPure                                                       = log(1) *> ZPure.fail("baz")
+          assert(zPure.clearLogOnError.runAll("")._2)(isLeft(anything))
         }
       )
     )


### PR DESCRIPTION
The logic to clear the log was not applied when the whole computation failed (without any fold).
Fixed that and added tests for it.