### PR TITLE
rename groupBy to groupByNonEmpty on ForEach

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/ForEach.scala
+++ b/core/shared/src/main/scala/zio/prelude/ForEach.scala
@@ -134,7 +134,7 @@ trait ForEach[F[+_]] extends Covariant[F] { self =>
   def forEach_[G[+_]: IdentityBoth: Covariant, A](fa: F[A])(f: A => G[Any]): G[Unit] =
     forEach(fa)(f).as(())
 
-  def groupBy[V, K](fa: F[V])(f: V => K): Map[K, NonEmptyChunk[V]] =
+  def groupByNonEmpty[V, K](fa: F[V])(f: V => K): Map[K, NonEmptyChunk[V]] =
     foldLeft(fa)(Map.empty[K, NonEmptyChunk[V]]) { (m, v) =>
       val k = f(v)
       m.get(k) match {
@@ -143,7 +143,7 @@ trait ForEach[F[+_]] extends Covariant[F] { self =>
       }
     }
 
-  def groupByM[G[+_]: IdentityBoth: Covariant, V, K](fa: F[V])(f: V => G[K]): G[Map[K, NonEmptyChunk[V]]] =
+  def groupByNonEmptyM[G[+_]: IdentityBoth: Covariant, V, K](fa: F[V])(f: V => G[K]): G[Map[K, NonEmptyChunk[V]]] =
     foldLeft(fa)(Map.empty[K, NonEmptyChunk[V]].succeed) { (m, v) =>
       val k = f(v)
       AssociativeBoth.mapN(m, k) { (m, k) =>

--- a/core/shared/src/test/scala/zio/prelude/ForEachSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ForEachSpec.scala
@@ -115,9 +115,9 @@ object ForEachSpec extends DefaultRunnableSpec {
             assert(actual)(equalTo(expected))
           }
         },
-        testM("groupBy") {
+        testM("groupByNonEmpty") {
           check(genList, genIntFunction) { (as, f) =>
-            val actual   = ForEach[List].groupBy(as)(f)
+            val actual   = ForEach[List].groupByNonEmpty(as)(f)
             val expected = as
               .groupBy(f)
               .toList
@@ -126,10 +126,10 @@ object ForEachSpec extends DefaultRunnableSpec {
             assert(actual)(equalTo(expected))
           }
         },
-        testM("groupByM") {
+        testM("groupByNonEmptyM") {
           check(genList, genIntFunction) { (as, f) =>
             // Dotty can't infer Function1Covariant: 'Required: zio.prelude.Covariant[[R] =>> Int => R]'
-            val actual   = ForEach[List].groupByM(as)(f.map(Option(_))(Invariant.Function1Covariant))
+            val actual   = ForEach[List].groupByNonEmptyM(as)(f.map(Option(_))(Invariant.Function1Covariant))
             val expected = Option(
               as.groupBy(f)
                 .toList


### PR DESCRIPTION
Renames `groupBy` to `groupByNonEmpty` on `ForEach` as agreed upon on the discord server.

It names exactly the difference the method has to the std-lib method and `groupBy` is hard to reach because on most data types, it is already defined.

If you want to keep the old name around and just delegate from one to the other just let me know.