### PR TITLE
mention `reduceIdentity` in the comment of `fold` on `ForEach`

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/ForEach.scala
+++ b/core/shared/src/main/scala/zio/prelude/ForEach.scala
@@ -76,7 +76,7 @@ trait ForEach[F[+_]] extends Covariant[F] { self =>
 
   /**
    * Folds over the elements of this collection using an associative operation
-   * and an identity.
+   * and an identity. Alias for `reduceIdentity`.
    */
   def fold[A: Identity](fa: F[A]): A =
     foldMap(fa)(identity)
@@ -237,6 +237,7 @@ trait ForEach[F[+_]] extends Covariant[F] { self =>
 
   /**
    * Reduces the collection to a summary value using the associative operation.
+   * Alias for `fold`.
    */
   def reduceIdentity[A: Identity](fa: F[A]): A =
     foldMap(fa)(identity[A])


### PR DESCRIPTION
Hey folks.

There was some discussion some time ago about why we have both `fold` and `reduceIdentity` on `ForEach` and the consensus was that it was probably because `fold` is hard to reach. There was no definite conclusion on what to do about it.

I think it might be best to just keep both and mention `reduceIdentity` in the scaladoc comment of `fold`. At least I will always think of fold first but then forget how the reachable one is called. It might be the same for others, especially since other functions sound similar, like `foldMap`, which is a `fold` (using the monoid) and a `map`.

Even if we decide otherwise later on and remove one of those functions, I think it is not a bad idea to keep the alias in the scaladoc in the meantime.

What do you think?