### PR TITLE
Implement CommutativeIdentity

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
+++ b/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
@@ -118,6 +118,16 @@ object CommutativeEqual {
     }
 }
 
+trait CommutativeIdentity[A] extends Commutative[A] with Identity[A]
+
+object CommutativeIdentity {
+  implicit def derive[A](implicit commutative0: Commutative[A], identity0: Identity[A]): CommutativeIdentity[A] =
+    new CommutativeIdentity[A] {
+      def combine(l: => A, r: => A): A = commutative0.combine(l, r)
+      def identity: A                  = identity0.identity
+    }
+}
+
 trait CovariantDeriveEqual[F[+_]] extends Covariant[F] with DeriveEqual[F]
 
 object CovariantDeriveEqual {


### PR DESCRIPTION
Allows requiring that both a way of commutative `combine` operator and an `identity` value exist without creating ambiguities regarding the `Associative` instance.