### PR TITLE
Implement ArrayDebug

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Debug.scala
+++ b/core/shared/src/main/scala/zio/prelude/Debug.scala
@@ -133,6 +133,12 @@ object Debug {
 
   def keyValueDebug[A: Debug, B: Debug]: Debug[(A, B)] = n => Repr.KeyValue(n._1.debug, n._2.debug)
 
+  /**
+    * Derives a `Debug[Array[A]]` given a `Debug[A]`.
+    */
+  implicit def ArrayDebug[A: Debug]: Debug[Array[A]] =
+    array => Repr.VConstructor(List("scala"), "Array", array.map(_.debug).toList)
+
   implicit def ChunkDebug[A: Debug]: Debug[Chunk[A]] =
     chunk => Repr.VConstructor(List("zio"), "Chunk", chunk.map(_.debug).toList)
 

--- a/core/shared/src/main/scala/zio/prelude/Debug.scala
+++ b/core/shared/src/main/scala/zio/prelude/Debug.scala
@@ -134,8 +134,8 @@ object Debug {
   def keyValueDebug[A: Debug, B: Debug]: Debug[(A, B)] = n => Repr.KeyValue(n._1.debug, n._2.debug)
 
   /**
-    * Derives a `Debug[Array[A]]` given a `Debug[A]`.
-    */
+   * Derives a `Debug[Array[A]]` given a `Debug[A]`.
+   */
   implicit def ArrayDebug[A: Debug]: Debug[Array[A]] =
     array => Repr.VConstructor(List("scala"), "Array", array.map(_.debug).toList)
 


### PR DESCRIPTION
Implements a `Debug` instance for `Array` given a `Debug` instance for its element type. This is a little unusual since `Array` is a mutable data structure but it is frequently used internally in functional code and the default rendering is typically not very helpful. Since all we are doing is describing a way to render an `Array` to a human readable format for debugging purposes I think this makes sense but open to other opinions.