### PR TITLE
[RFC] A sketch of a Read type class

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Debug.scala
+++ b/core/shared/src/main/scala/zio/prelude/Debug.scala
@@ -143,15 +143,92 @@ object Debug extends DebugVersionSpecific {
 
   implicit val NothingDebug: Debug[Nothing] = n => n
   implicit val UnitDebug: Debug[Unit]       = _ => Repr.Object("scala" :: Nil, "()")
-  implicit val IntDebug: Debug[Int]         = Repr.Int(_)
-  implicit val DoubleDebug: Debug[Double]   = Repr.Double(_)
-  implicit val FloatDebug: Debug[Float]     = Repr.Float(_)
-  implicit val LongDebug: Debug[Long]       = Repr.Long(_)
-  implicit val ByteDebug: Debug[Byte]       = Repr.Byte(_)
-  implicit val CharDebug: Debug[Char]       = Repr.Char(_)
-  implicit val BooleanDebug: Debug[Boolean] = Repr.Boolean(_)
-  implicit val ShortDebug: Debug[Short]     = Repr.Short(_)
-  implicit val StringDebug: Debug[String]   = Repr.String(_)
+
+  implicit val IntRead: Read[Int] = new Read[Int] {
+    def debug(value: Int): Repr                                              = Repr.Int(value)
+    def fromDebug(debug: Repr): Either[Read.ReadException.ReprMismatch, Int] = debug match {
+      case Repr.Int(value)                                                    => Right(value)
+      case Repr.Long(value) if Int.MinValue <= value && value <= Int.MaxValue => Right(value.toInt)
+      case Repr.Short(value)                                                  => Right(value.toInt)
+      case Repr.Byte(value)                                                   => Right(value.toInt)
+      case _                                                                  => Left(Read.ReadException.ReprMismatch("Int", debug))
+    }
+  }
+
+  implicit val DoubleRead: Read[Double] = new Read[Double] {
+    def debug(value: Double): Repr                                              = Repr.Double(value)
+    def fromDebug(debug: Repr): Either[Read.ReadException.ReprMismatch, Double] = debug match {
+      case Repr.Double(value) => Right(value)
+      case Repr.Float(value)  => Right(value.toDouble)
+      case _                  => Left(Read.ReadException.ReprMismatch("Double", debug))
+    }
+  }
+
+  implicit val FloatRead: Read[Float] = new Read[Float] {
+    def debug(value: Float): Repr                                              = Repr.Float(value)
+    def fromDebug(debug: Repr): Either[Read.ReadException.ReprMismatch, Float] = debug match {
+      case Repr.Float(value) => Right(value)
+      case _                 => Left(Read.ReadException.ReprMismatch("Float", debug))
+    }
+  }
+
+  implicit val LongRead: Read[Long] = new Read[Long] {
+    def debug(value: Long): Repr                                              = Repr.Long(value)
+    def fromDebug(debug: Repr): Either[Read.ReadException.ReprMismatch, Long] = debug match {
+      case Repr.Long(value)  => Right(value)
+      case Repr.Int(value)   => Right(value.toLong)
+      case Repr.Short(value) => Right(value.toLong)
+      case Repr.Byte(value)  => Right(value.toLong)
+      case _                 => Left(Read.ReadException.ReprMismatch("Long", debug))
+    }
+  }
+
+  implicit val ByteRead: Read[Byte] = new Read[Byte] {
+    def debug(value: Byte): Repr                                              = Repr.Byte(value)
+    def fromDebug(debug: Repr): Either[Read.ReadException.ReprMismatch, Byte] = debug match {
+      case Repr.Byte(value)                                                      => Right(value)
+      case Repr.Short(value) if Byte.MinValue <= value && value <= Byte.MaxValue => Right(value.toByte)
+      case Repr.Int(value) if Byte.MinValue <= value && value <= Byte.MaxValue   => Right(value.toByte)
+      case Repr.Long(value) if Byte.MinValue <= value && value <= Byte.MaxValue  => Right(value.toByte)
+      case _                                                                     => Left(Read.ReadException.ReprMismatch("Byte", debug))
+    }
+  }
+
+  implicit val CharRead: Read[Char] = new Read[Char] {
+    def debug(value: Char): Repr                                              = Repr.Char(value)
+    def fromDebug(debug: Repr): Either[Read.ReadException.ReprMismatch, Char] = debug match {
+      case Repr.Char(value) => Right(value)
+      case _                => Left(Read.ReadException.ReprMismatch("Char", debug))
+    }
+  }
+
+  implicit val BooleanRead: Read[Boolean] = new Read[Boolean] {
+    def debug(value: Boolean): Repr                                              = Repr.Boolean(value)
+    def fromDebug(debug: Repr): Either[Read.ReadException.ReprMismatch, Boolean] = debug match {
+      case Repr.Boolean(value) => Right(value)
+      case _                   => Left(Read.ReadException.ReprMismatch("Boolean", debug))
+    }
+  }
+
+  implicit val ShortRead: Read[Short] = new Read[Short] {
+    def debug(value: Short): Repr                                              = Repr.Short(value)
+    def fromDebug(debug: Repr): Either[Read.ReadException.ReprMismatch, Short] = debug match {
+      case Repr.Short(value)                                                      => Right(value)
+      case Repr.Byte(value)                                                       => Right(value.toShort)
+      case Repr.Int(value) if Short.MinValue <= value && value <= Short.MaxValue  => Right(value.toShort)
+      case Repr.Long(value) if Short.MinValue <= value && value <= Short.MaxValue => Right(value.toShort)
+      case _                                                                      => Left(Read.ReadException.ReprMismatch("Short", debug))
+    }
+  }
+
+  implicit val StringRead: Read[String] = new Read[String] {
+    def debug(value: String): Repr                                              = Repr.String(value)
+    def fromDebug(debug: Repr): Either[Read.ReadException.ReprMismatch, String] = debug match {
+      case Repr.String(value) => Right(value)
+      case _                  => Left(Read.ReadException.ReprMismatch("String", debug))
+    }
+
+  }
 
   def keyValueDebug[A: Debug, B: Debug]: Debug[(A, B)] = n => Repr.KeyValue(n._1.debug, n._2.debug)
 

--- a/core/shared/src/main/scala/zio/prelude/Read.scala
+++ b/core/shared/src/main/scala/zio/prelude/Read.scala
@@ -4,6 +4,8 @@ import zio.prelude.coherent.ReadEqual
 import zio.test.TestResult
 import zio.test.laws.{Lawful, Laws}
 
+import scala.util.matching.Regex
+
 trait Read[A] extends Debug[A] {
   def fromDebug(debug: Debug.Repr): Either[Read.ReadException.ReprMismatch, A]
   final def read(string: String): Either[Read.ReadException, A] = Read.parse(string).flatMap(fromDebug)
@@ -42,8 +44,8 @@ object Read extends Lawful[ReadEqual] {
   }
 
   private object Pattern {
-    val String = "\"(.*)\"".r
-    val Char   = "'(.)'".r
+    val String: Regex = "\"(.*)\"".r
+    val Char: Regex   = "'(.)'".r
   }
 
   def parse(string: String): Either[ReadException.ParseError, Debug.Repr] = string match {

--- a/core/shared/src/main/scala/zio/prelude/Read.scala
+++ b/core/shared/src/main/scala/zio/prelude/Read.scala
@@ -4,6 +4,7 @@ import zio.prelude.coherent.ReadEqual
 import zio.test.TestResult
 import zio.test.laws.{Lawful, Laws}
 
+import scala.util.Try
 import scala.util.matching.Regex
 
 trait Read[A] extends Debug[A] {
@@ -52,28 +53,28 @@ object Read extends Lawful[ReadEqual] {
     case Pattern.String(value) => Right(Debug.Repr.String(StringContext.processEscapes(value)))
     case Pattern.Char(value)   => Right(Debug.Repr.Char(value.charAt(0)))
     case _                     =>
-      val boolean = string.toBooleanOption
-      if (boolean.isDefined) {
+      val boolean = Try(string.toBoolean)
+      if (boolean.isSuccess) {
         return Right(Debug.Repr.Boolean(boolean.get))
       }
-      val int     = string.toIntOption
-      if (int.isDefined) {
+      val int     = Try(string.toInt)
+      if (int.isSuccess) {
         return Right(Debug.Repr.Int(int.get))
       }
       if (string.lastOption.contains('L')) {
-        val long = string.init.toLongOption
-        if (long.isDefined) {
+        val long = Try(string.init.toLong)
+        if (long.isSuccess) {
           return Right(Debug.Repr.Long(long.get))
         }
       }
       if (string.lastOption.contains('f')) {
-        val float = string.toFloatOption
-        if (float.isDefined) {
+        val float = Try(string.toFloat)
+        if (float.isSuccess) {
           return Right(Debug.Repr.Float(float.get))
         }
       }
-      val double  = string.toDoubleOption
-      if (double.isDefined) {
+      val double  = Try(string.toDouble)
+      if (double.isSuccess) {
         return Right(Debug.Repr.Double(double.get))
       }
       Left(ReadException.ParseError(string))

--- a/core/shared/src/main/scala/zio/prelude/Read.scala
+++ b/core/shared/src/main/scala/zio/prelude/Read.scala
@@ -1,5 +1,6 @@
 package zio.prelude
 
+import zio.EitherCompat
 import zio.prelude.coherent.ReadEqual
 import zio.test.TestResult
 import zio.test.laws.{Lawful, Laws}
@@ -7,7 +8,7 @@ import zio.test.laws.{Lawful, Laws}
 import scala.util.Try
 import scala.util.matching.Regex
 
-trait Read[A] extends Debug[A] {
+trait Read[A] extends Debug[A] with EitherCompat {
   def fromDebug(debug: Debug.Repr): Either[Read.ReadException.ReprMismatch, A]
   final def read(string: String): Either[Read.ReadException, A] =
     Read.parse(string).flatMap[Read.ReadException, A](fromDebug)

--- a/core/shared/src/main/scala/zio/prelude/Read.scala
+++ b/core/shared/src/main/scala/zio/prelude/Read.scala
@@ -1,0 +1,93 @@
+package zio.prelude
+
+import zio.prelude.coherent.ReadEqual
+import zio.test.TestResult
+import zio.test.laws.{Lawful, Laws}
+
+trait Read[A] extends Debug[A] {
+  def fromDebug(debug: Debug.Repr): Either[Read.ReadException.ReprMismatch, A]
+  final def read(string: String): Either[Read.ReadException, A] = Read.parse(string).flatMap(fromDebug)
+}
+
+object Read extends Lawful[ReadEqual] {
+
+  /**
+   * The associativity law states all values that are serialized to a string can be successfully read back:
+   *
+   * {{{
+   * a.debug.render.read === Right(a)
+   * }}}
+   */
+  lazy val readLaw: Laws[ReadEqual] =
+    new Laws.Law1[ReadEqual]("readLaw") {
+      def apply[A: ReadEqual](a: A): TestResult = {
+        implicit val throwableHash: Equal[ReadException] = Equal.ThrowableHash
+        a.debug.render.read <-> Right(a)
+      }
+    }
+
+  /**
+   * The set of all laws that instances of `Read` must satisfy.
+   */
+  lazy val laws: Laws[ReadEqual] =
+    readLaw
+
+  sealed abstract class ReadException(message: String) extends RuntimeException(message)
+
+  object ReadException {
+    final case class ReprMismatch(expected: String, got: Debug.Repr)
+        extends ReadException(s"Expected a $expected, but got '$got'.")
+
+    final case class ParseError(string: String) extends ReadException(s"Can't parse '$string'.")
+  }
+
+  private object Pattern {
+    val String = "\"(.*)\"".r
+    val Char   = "'(.)'".r
+  }
+
+  def parse(string: String): Either[ReadException.ParseError, Debug.Repr] = string match {
+    case Pattern.String(value) => Right(Debug.Repr.String(StringContext.processEscapes(value)))
+    case Pattern.Char(value)   => Right(Debug.Repr.Char(value.charAt(0)))
+    case _                     =>
+      val boolean = string.toBooleanOption
+      if (boolean.isDefined) {
+        return Right(Debug.Repr.Boolean(boolean.get))
+      }
+      val int     = string.toIntOption
+      if (int.isDefined) {
+        return Right(Debug.Repr.Int(int.get))
+      }
+      if (string.lastOption.contains('L')) {
+        val long = string.init.toLongOption
+        if (long.isDefined) {
+          return Right(Debug.Repr.Long(long.get))
+        }
+      }
+      if (string.lastOption.contains('f')) {
+        val float = string.toFloatOption
+        if (float.isDefined) {
+          return Right(Debug.Repr.Float(float.get))
+        }
+      }
+      val double  = string.toDoubleOption
+      if (double.isDefined) {
+        return Right(Debug.Repr.Double(double.get))
+      }
+      Left(ReadException.ParseError(string))
+  }
+
+}
+
+trait ReadSyntax {
+
+  implicit class ReadStringOps(self: String) {
+    def toDebug: Either[Read.ReadException.ParseError, Debug.Repr]  = Read.parse(self)
+    def read[A](implicit A: Read[A]): Either[Read.ReadException, A] = A.read(self)
+  }
+
+  implicit class ReadDebugOps(self: Debug.Repr) {
+    def read[A](implicit A: Read[A]): Either[Read.ReadException, A] = A.fromDebug(self)
+  }
+
+}

--- a/core/shared/src/main/scala/zio/prelude/Read.scala
+++ b/core/shared/src/main/scala/zio/prelude/Read.scala
@@ -9,7 +9,8 @@ import scala.util.matching.Regex
 
 trait Read[A] extends Debug[A] {
   def fromDebug(debug: Debug.Repr): Either[Read.ReadException.ReprMismatch, A]
-  final def read(string: String): Either[Read.ReadException, A] = Read.parse(string).flatMap(fromDebug)
+  final def read(string: String): Either[Read.ReadException, A] =
+    Read.parse(string).flatMap[Read.ReadException, A](fromDebug)
 }
 
 object Read extends Lawful[ReadEqual] {

--- a/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
+++ b/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
@@ -16,6 +16,7 @@
 
 package zio.prelude.coherent
 
+import zio.prelude.Read.ReadException
 import zio.prelude._
 
 trait AssociativeBothDeriveEqualInvariant[F[_]] extends AssociativeBoth[F] with DeriveEqual[F] with Invariant[F]
@@ -362,4 +363,15 @@ object HashOrd {
   def default[A](implicit ord: scala.math.Ordering[A]): Hash[A] with Ord[A] =
     make(_.##, (l, r) => Ordering.fromCompare(ord.compare(l, r)), _ == _)
 
+}
+
+trait ReadEqual[A] extends Read[A] with Equal[A]
+
+object ReadEqual {
+  implicit def derive[A](implicit read0: Read[A], equal0: Equal[A]): ReadEqual[A] =
+    new ReadEqual[A] {
+      def fromDebug(debug: Debug.Repr): Either[ReadException.ReprMismatch, A] = read0.fromDebug(debug)
+      def debug(a: A): Debug.Repr                                             = read0.debug(a)
+      protected def checkEqual(l: A, r: A): Boolean                           = equal0.equal(l, r)
+    }
 }

--- a/core/shared/src/main/scala/zio/prelude/package.scala
+++ b/core/shared/src/main/scala/zio/prelude/package.scala
@@ -50,6 +50,7 @@ package object prelude
     with NonEmptyForEachSyntax
     with OrdSyntax
     with PartialOrdSyntax
+    with ReadSyntax
     with ForEachSyntax
     with ZNonEmptySetSyntax
     with ZSetSyntax

--- a/core/shared/src/test/scala/zio/prelude/ReadSpec.scala
+++ b/core/shared/src/test/scala/zio/prelude/ReadSpec.scala
@@ -1,0 +1,22 @@
+package zio.prelude
+
+import zio.test._
+import zio.test.laws.checkAllLaws
+
+object ReadSpec extends DefaultRunnableSpec {
+
+  def spec: ZSpec[Environment, Failure] =
+    suite("ReadSpec")(
+      suite("laws")(
+        testM("boolean")(checkAllLaws(Read)(Gen.boolean)),
+        testM("byte")(checkAllLaws(Read)(Gen.anyByte)),
+        testM("char")(checkAllLaws(Read)(Gen.anyChar)),
+        testM("double")(checkAllLaws(Read)(Gen.anyDouble)),
+        testM("float")(checkAllLaws(Read)(Gen.anyFloat)),
+        testM("int")(checkAllLaws(Read)(Gen.anyInt)),
+        testM("long")(checkAllLaws(Read)(Gen.anyLong)),
+        testM("short")(checkAllLaws(Read)(Gen.anyShort)),
+        testM("string")(checkAllLaws(Read)(Gen.anyString))
+      )
+    )
+}


### PR DESCRIPTION
This is my first take on how a `Read` type class could look like in ZIO Prelude.

A `Read` type class could be handy for debugging and/or development purposed. For production use cases, we should urge our users to use full-fledged parsing/decoding/deserialization solutions, of course.

The most complex piece would probably be the parser `Read.parse(string: String): Either[ReadException.ParseError, Debug.Repr]`. But given that the structure of `Debug.Repr` is pretty tight, it shouldn't be _that_ complicated.

What do you guys think?

Inspiration/Background:
 * Haskell's built-in `Read`
 * https://github.com/ChristopherDavenport/read
 * https://github.com/typelevel/cats/issues/932