### PR TITLE
Enable fatal-warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ inThisBuild(
 )
 
 addCommandAlias("fix", "; all compile:scalafix test:scalafix; all scalafmtSbt scalafmtAll")
-addCommandAlias("check", "; scalafmtSbtCheck; scalafmtCheckAll; compile:scalafix --check; test:scalafix --check")
+addCommandAlias("check", "; Test/compile; scalafmtSbtCheck; scalafmtCheckAll; compile:scalafix --check; test:scalafix --check")
 
 addCommandAlias(
   "testJVM",

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,10 @@ inThisBuild(
 )
 
 addCommandAlias("fix", "; all compile:scalafix test:scalafix; all scalafmtSbt scalafmtAll")
-addCommandAlias("check", "; Test/compile; scalafmtSbtCheck; scalafmtCheckAll; compile:scalafix --check; test:scalafix --check")
+addCommandAlias(
+  "check",
+  "; scalafmtSbtCheck; scalafmtCheckAll; Test/compile; compile:scalafix --check; test:scalafix --check"
+)
 
 addCommandAlias(
   "testJVM",

--- a/examples/shared/src/main/scala-2.x/examples/RefinedTypes.scala
+++ b/examples/shared/src/main/scala-2.x/examples/RefinedTypes.scala
@@ -31,7 +31,7 @@ object RefinedTypes extends App {
   println(sum(natural, age))
 
   val x: Natural                     = Natural(0)
-  val y: Validation[String, Natural] = Natural.make(scala.util.Random.nextInt)
+  val y: Validation[String, Natural] = Natural.make(scala.util.Random.nextInt())
 
   import Regex._
 


### PR DESCRIPTION
Scalafix, when run on its own, suppresses `fatal-warnings`, so that it can operate smoothly (and not get shot down because there is a warning in the codebase).

But in our case, we want to verify both that Scalafix is happy _and_ that the codebase doesn't contain any warnings.
