### PR TITLE
Run tests on 8 as the main Java version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['8']
         scala: ['2.11.12', '2.12.15', '2.13.6', '3.1.0']
         platform: ['JVM']
     steps:
@@ -83,8 +82,6 @@ jobs:
           fetch-depth: 0
       - name: Setup Scala and Java
         uses: olafurpg/setup-scala@v13
-        with:
-          java-version: ${{ matrix.java }}
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Run tests
@@ -116,15 +113,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: ['8']
         platform: ['JS', 'Native']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v2.3.5
       - name: Setup Scala and Java
         uses: olafurpg/setup-scala@v13
-        with:
-          java-version: ${{ matrix.java }}
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Test on different Scala target platforms


### PR DESCRIPTION
Work around https://github.com/olafurpg/setup-scala/issues/45
We don't specify `java-version: ${{ matrix.java }}` for other steps (most importantly `publish`) and `olafurpg/setup-scala`/Jabba clearly defaults to 8.
