### PR TITLE
ZValidation: add toEitherException, toFuture and make toTry not discard errors

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -320,7 +320,7 @@ object ZValidation extends LowPriorityValidationImplicits {
     final case class Exception[+W, +E](failure: Failure[W, E])(implicit ev: E <:< Throwable)
         extends RuntimeException(failure.message) {
       failure.errors.tail.foreach(addSuppressed(_))
-      val _ = initCause(failure.errors.head)
+      initCause(failure.errors.head)
     }
   }
 

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -318,7 +318,7 @@ object ZValidation extends LowPriorityValidationImplicits {
 
   object Failure {
     final case class Exception[+W, +E](failure: Failure[W, E])(implicit ev: E <:< Throwable)
-        extends RuntimeException(failure.message) {
+        extends scala.Exception(failure.message) {
       failure.errors.tail.foreach(addSuppressed(_))
       initCause(failure.errors.head)
     }
@@ -336,7 +336,7 @@ object ZValidation extends LowPriorityValidationImplicits {
     }
 
   /**
-   * Derives a `Debug[ZValidation[W, E, A]]` given a `Debug[W], a `Debug[E]`,
+   * Derives a `Debug[ZValidation[W, E, A]]` given a `Debug[W]`, a `Debug[E]`,
    * and a `Debug[A]`.
    */
   implicit def ZValidationDebug[W: Debug, E: Debug, A: Debug]: Debug[ZValidation[W, E, A]] = {


### PR DESCRIPTION
Related issue https://github.com/zio/zio-prelude/issues/791

Lighter version of these PRs:
closes https://github.com/zio/zio-prelude/pull/610
closes https://github.com/zio/zio-prelude/pull/603
