### PR TITLE
Update to ZIO 2.0.0-M6-2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ addCommandAlias(
   ";lawsNative/test;experimentalLawsNative/test" // `test` currently executes only compilation, see `nativeSettings` in `BuildHelper`
 )
 
-val zioVersion = "2.0.0-M4"
+val zioVersion = "2.0.0-M6-2"
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,9 @@ addCommandAlias(
   ";lawsNative/test;experimentalLawsNative/test" // `test` currently executes only compilation, see `nativeSettings` in `BuildHelper`
 )
 
-val zioVersion = "2.0.0-M6-2"
+// TODO: revert back to a stable version ASAP
+ThisBuild / resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
+val zioVersion = "2.0.0-M6-2+21-fe2582e9-SNAPSHOT"
 
 lazy val root = project
   .in(file("."))

--- a/core-tests/shared/src/test/scala/zio/prelude/Common.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/Common.scala
@@ -6,6 +6,6 @@ import zio.test.Gen
 import scala.concurrent.duration.{Duration => ScalaDuration}
 
 object Common {
-  def finiteDurationScala: Gen[Has[Random], ScalaDuration] =
+  def finiteDurationScala: Gen[Random, ScalaDuration] =
     Gen.long(0L, Long.MaxValue / 10).map(ScalaDuration.fromNanos)
 }

--- a/core-tests/shared/src/test/scala/zio/prelude/CommutativeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/CommutativeSpec.scala
@@ -1,14 +1,14 @@
 package zio.prelude
 
+import zio.Random
 import zio.prelude.laws.CommutativeLaws
-import zio.prelude.newtypes.{And, Max, Min, Or, OrF, Prod, Sum}
+import zio.prelude.newtypes._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, Random}
 
 object CommutativeSpec extends DefaultRunnableSpec {
 
-  val anySumInt: Gen[Has[Random], Sum[Int]] = Gen.int.map(Sum(_))
+  val anySumInt: Gen[Random, Sum[Int]] = Gen.int.map(Sum(_))
 
   private implicit val DoubleEqual: Equal[Double] = Equal.DoubleEqualWithEpsilon()
   private implicit val FloatEqual: Equal[Float]   = Equal.FloatEqualWithEpsilon()

--- a/core-tests/shared/src/test/scala/zio/prelude/DebugSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/DebugSpec.scala
@@ -3,7 +3,7 @@ package zio.prelude
 import zio.prelude.Debug.{Renderer, Repr, _}
 import zio.prelude.laws._
 import zio.test.{TestResult, _}
-import zio.{Has, Random}
+import zio.Random
 
 import scala.collection.immutable.ListMap
 
@@ -17,7 +17,7 @@ object DebugSpec extends DefaultRunnableSpec {
   def primFullTest[A: Debug](a: A, exp: Option[String] = None): TestResult   = primitiveTest[A](Renderer.Full)(a, exp)
 
   final case class TestCase(string: String, number: Int, list: List[Double])
-  val genTestCase: Gen[Has[Random] with Has[Sized], TestCase] = for {
+  val genTestCase: Gen[Random with Sized, TestCase] = for {
     str    <- Gen.string
     number <- Gen.int
     list   <- Gen.listOf(Gen.double)
@@ -40,7 +40,7 @@ object DebugSpec extends DefaultRunnableSpec {
     case TestObject2 => Repr.Object(List("DebugSpec"), "TestObject2")
   }
 
-  val genTestTrait: Gen[Has[Random], TestTrait] = Gen.elements(List[TestTrait](TestObject1, TestObject2): _*)
+  val genTestTrait: Gen[Random, TestTrait] = Gen.elements(List[TestTrait](TestObject1, TestObject2): _*)
 
   def expectedTupleFull(n: Int)(v: Int): String   = s"scala.Tuple$n(${List.fill(n)(v).mkString(", ")})"
   def expectedTupleSimple(n: Int)(v: Int): String = s"(${List.fill(n)(v).mkString(", ")})"

--- a/core-tests/shared/src/test/scala/zio/prelude/DebugSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/DebugSpec.scala
@@ -1,9 +1,9 @@
 package zio.prelude
 
+import zio.Random
 import zio.prelude.Debug.{Renderer, Repr, _}
 import zio.prelude.laws._
 import zio.test.{TestResult, _}
-import zio.Random
 
 import scala.collection.immutable.ListMap
 

--- a/core-tests/shared/src/test/scala/zio/prelude/Fixtures.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/Fixtures.scala
@@ -2,14 +2,14 @@ package zio.prelude
 
 import zio.test.laws.GenF
 import zio.test.{Gen, Sized}
-import zio.{Chunk, Has, Random, ZTraceElement}
+import zio.{Chunk, Random, ZTraceElement}
 
 object Fixtures {
   type ChunkOption[+A] = Chunk[Option[A]]
 
-  val chunkOptionGenF: GenF[Has[Random] with Has[Sized], ChunkOption] =
-    new GenF[Has[Random] with Has[Sized], ChunkOption] {
-      def apply[R1 <: Has[Random] with Has[Sized], A](gen: Gen[R1, A])(implicit
+  val chunkOptionGenF: GenF[Random with Sized, ChunkOption] =
+    new GenF[Random with Sized, ChunkOption] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A])(implicit
         trace: ZTraceElement
       ): Gen[R1, Chunk[Option[A]]] =
         Gen.chunkOf(Gen.option(gen))

--- a/core-tests/shared/src/test/scala/zio/prelude/ForEachSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/ForEachSpec.scala
@@ -4,39 +4,39 @@ import zio.prelude.laws._
 import zio.prelude.newtypes._
 import zio.test._
 import zio.test.laws._
-import zio.{Chunk, Has, NonEmptyChunk, Random, Ref}
+import zio.{Chunk, NonEmptyChunk, Random, Ref}
 
 object ForEachSpec extends DefaultRunnableSpec {
   import Fixtures._
 
-  val genBoolean: Gen[Has[Random], Boolean] =
+  val genBoolean: Gen[Random, Boolean] =
     Gen.boolean
 
-  val genInt: Gen[Has[Random], Int] =
+  val genInt: Gen[Random, Int] =
     Gen.int
 
-  val genChunk: Gen[Has[Random] with Has[Sized], Chunk[Int]] =
+  val genChunk: Gen[Random with Sized, Chunk[Int]] =
     Gen.chunkOf(genInt)
 
-  val genList: Gen[Has[Random] with Has[Sized], List[Int]] =
+  val genList: Gen[Random with Sized, List[Int]] =
     Gen.listOf(genInt)
 
-  val genBooleanFunction: Gen[Has[Random], Int => Boolean] =
+  val genBooleanFunction: Gen[Random, Int => Boolean] =
     Gen.function(genBoolean)
 
-  val genIntFunction: Gen[Has[Random], Int => Int] =
+  val genIntFunction: Gen[Random, Int => Int] =
     Gen.function(genInt)
 
-  val genIntFunction2: Gen[Has[Random], (Int, Int) => Int] =
+  val genIntFunction2: Gen[Random, (Int, Int) => Int] =
     Gen.function2(genInt)
 
-  val genIntIntFunction2: Gen[Has[Random], (Int, Int) => (Int, Int)] =
+  val genIntIntFunction2: Gen[Random, (Int, Int) => (Int, Int)] =
     Gen.function2(genInt <*> genInt)
 
-  val genTheseFunction: Gen[Has[Random], These[Int, Int] => Int] =
+  val genTheseFunction: Gen[Random, These[Int, Int] => Int] =
     Gen.function(genInt)
 
-  val genEitherIntIntFunction: Gen[Has[Random], Int => Either[Int, Int]] =
+  val genEitherIntIntFunction: Gen[Random, Int => Either[Int, Int]] =
     Gen.function(Gen.either(genInt, genInt))
 
   implicit val chunkOptionForEach: ForEach[ChunkOption] =

--- a/core-tests/shared/src/test/scala/zio/prelude/HashSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/HashSpec.scala
@@ -1,14 +1,14 @@
 package zio.prelude
 
+import zio.ZIO
 import zio.prelude.Common.finiteDurationScala
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, ZIO}
 
 object HashSpec extends DefaultRunnableSpec {
 
-  final def scalaHashCodeConsistency[R, A: Hash](gen: Gen[R, A]): ZIO[R with Has[TestConfig], Nothing, TestResult] =
+  final def scalaHashCodeConsistency[R, A: Hash](gen: Gen[R, A]): ZIO[R with TestConfig, Nothing, TestResult] =
     check(gen)(a => assert(a.hash)(equalTo(a.hashCode)))
 
   def spec: ZSpec[Environment, Failure] =

--- a/core-tests/shared/src/test/scala/zio/prelude/IdempotentSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/IdempotentSpec.scala
@@ -1,10 +1,10 @@
 package zio.prelude
 
+import zio.Random
 import zio.prelude.laws._
 import zio.prelude.newtypes._
 import zio.test._
 import zio.test.laws._
-import zio.Random
 
 import scala.math.abs
 

--- a/core-tests/shared/src/test/scala/zio/prelude/IdempotentSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/IdempotentSpec.scala
@@ -4,15 +4,15 @@ import zio.prelude.laws._
 import zio.prelude.newtypes._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, Random}
+import zio.Random
 
 import scala.math.abs
 
 object IdempotentSpec extends DefaultRunnableSpec {
 
-  val anyMaxInt: Gen[Has[Random], Max[Int]] = Gen.int.map(Max(_))
+  val anyMaxInt: Gen[Random, Max[Int]] = Gen.int.map(Max(_))
 
-  val anyOrdering: Gen[Has[Random], Ordering] = Gen.int.map { n =>
+  val anyOrdering: Gen[Random, Ordering] = Gen.int.map { n =>
     abs(n) % 3 match {
       case 0 => Ordering.LessThan
       case 1 => Ordering.Equals
@@ -20,7 +20,7 @@ object IdempotentSpec extends DefaultRunnableSpec {
     }
   }
 
-  val anyPartialOrdering: Gen[Has[Random], PartialOrdering] = Gen.int.map { n =>
+  val anyPartialOrdering: Gen[Random, PartialOrdering] = Gen.int.map { n =>
     abs(n) % 4 match {
       case 0 => Ordering.LessThan
       case 1 => Ordering.Equals

--- a/core-tests/shared/src/test/scala/zio/prelude/NonEmptyForEachSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/NonEmptyForEachSpec.scala
@@ -1,9 +1,9 @@
 package zio.prelude
 
+import zio.Random
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.Random
 
 object NonEmptyForEachSpec extends DefaultRunnableSpec {
 

--- a/core-tests/shared/src/test/scala/zio/prelude/NonEmptyForEachSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/NonEmptyForEachSpec.scala
@@ -3,20 +3,20 @@ package zio.prelude
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, Random}
+import zio.Random
 
 object NonEmptyForEachSpec extends DefaultRunnableSpec {
 
-  val genInt: Gen[Has[Random], Int] =
+  val genInt: Gen[Random, Int] =
     Gen.int
 
-  val genNonEmptyList: Gen[Has[Random] with Has[Sized], NonEmptyList[Int]] =
+  val genNonEmptyList: Gen[Random with Sized, NonEmptyList[Int]] =
     Gens.nonEmptyListOf(genInt)
 
-  val genIntFunction: Gen[Has[Random], Int => Int] =
+  val genIntFunction: Gen[Random, Int => Int] =
     Gen.function(genInt)
 
-  val genIntFunction2: Gen[Has[Random], (Int, Int) => Int] =
+  val genIntFunction2: Gen[Random, (Int, Int) => Int] =
     Gen.function2(genInt)
 
   def spec: ZSpec[Environment, Failure] =

--- a/core-tests/shared/src/test/scala/zio/prelude/NonEmptyListSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/NonEmptyListSpec.scala
@@ -3,41 +3,41 @@ package zio.prelude
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, NonEmptyChunk, Random}
+import zio.{NonEmptyChunk, Random}
 
 object NonEmptyListSpec extends DefaultRunnableSpec {
 
-  lazy val genBooleanFunction: Gen[Has[Random], Int => Boolean] =
+  lazy val genBooleanFunction: Gen[Random, Int => Boolean] =
     Gen.function(Gen.boolean)
 
-  lazy val genBooleanFunction2: Gen[Has[Random], (Int, Int) => Boolean] =
+  lazy val genBooleanFunction2: Gen[Random, (Int, Int) => Boolean] =
     Gen.function2(Gen.boolean)
 
-  lazy val genCons: Gen[Has[Random] with Has[Sized], ::[Int]] =
+  lazy val genCons: Gen[Random with Sized, ::[Int]] =
     Gen.listOf1(genInt)
 
-  lazy val genConsFunction: Gen[Has[Random] with Has[Sized], Int => ::[Int]] =
+  lazy val genConsFunction: Gen[Random with Sized, Int => ::[Int]] =
     Gen.function(genCons)
 
-  lazy val genFunction: Gen[Has[Random], Int => Int] =
+  lazy val genFunction: Gen[Random, Int => Int] =
     Gen.function(genInt)
 
-  lazy val genFunction2: Gen[Has[Random] with Has[Sized], (Int, Int) => Int] =
+  lazy val genFunction2: Gen[Random with Sized, (Int, Int) => Int] =
     Gen.function2(genInt)
 
-  lazy val genInt: Gen[Has[Random], Int] =
+  lazy val genInt: Gen[Random, Int] =
     Gen.int(-10, 10)
 
-  lazy val genNonEmptyChunk: Gen[Has[Random] with Has[Sized], NonEmptyChunk[Int]] =
+  lazy val genNonEmptyChunk: Gen[Random with Sized, NonEmptyChunk[Int]] =
     Gen.chunkOf1(genInt)
 
-  lazy val genNonEmptyList: Gen[Has[Random] with Has[Sized], NonEmptyList[Int]] =
+  lazy val genNonEmptyList: Gen[Random with Sized, NonEmptyList[Int]] =
     genCons.map(NonEmptyList.fromCons)
 
-  lazy val genString: Gen[Has[Random] with Has[Sized], String] =
+  lazy val genString: Gen[Random with Sized, String] =
     Gen.alphaNumericString
 
-  lazy val genConsWithIndex: Gen[Has[Random] with Has[Sized], (::[Int], Int)] =
+  lazy val genConsWithIndex: Gen[Random with Sized, (::[Int], Int)] =
     for {
       cons  <- genCons
       index <- Gen.int(-2, cons.length + 2)

--- a/core-tests/shared/src/test/scala/zio/prelude/NonEmptySetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/NonEmptySetSpec.scala
@@ -1,9 +1,9 @@
 package zio.prelude
 
+import zio.Random
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.Random
 
 object NonEmptySetSpec extends DefaultRunnableSpec {
 

--- a/core-tests/shared/src/test/scala/zio/prelude/NonEmptySetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/NonEmptySetSpec.scala
@@ -3,20 +3,20 @@ package zio.prelude
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, Random}
+import zio.Random
 
 object NonEmptySetSpec extends DefaultRunnableSpec {
 
-  private lazy val genSet: Gen[Has[Random] with Has[Sized], Set[Int]] =
+  private lazy val genSet: Gen[Random with Sized, Set[Int]] =
     Gen.setOf1(genInt)
 
-  private lazy val genSetFunction: Gen[Has[Random] with Has[Sized], Int => Set[Int]] =
+  private lazy val genSetFunction: Gen[Random with Sized, Int => Set[Int]] =
     Gen.function(genSet)
 
-  private lazy val genInt: Gen[Has[Random], Int] =
+  private lazy val genInt: Gen[Random, Int] =
     Gen.int(-10, 10)
 
-  private lazy val genNonEmptySet: Gen[Has[Random] with Has[Sized], NonEmptySet[Int]] =
+  private lazy val genNonEmptySet: Gen[Random with Sized, NonEmptySet[Int]] =
     genSet.map(NonEmptySet.fromSetOption(_).get)
 
   def spec: ZSpec[Environment, Failure] =

--- a/core-tests/shared/src/test/scala/zio/prelude/OrdSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/OrdSpec.scala
@@ -1,10 +1,10 @@
 package zio.prelude
 
+import zio.ZIO
 import zio.prelude.Common.finiteDurationScala
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, ZIO}
 
 object OrdSpec extends DefaultRunnableSpec {
 
@@ -13,7 +13,7 @@ object OrdSpec extends DefaultRunnableSpec {
 
   def scalaOrderingConsistency[R, A: Ord](
     gen: Gen[R, A]
-  )(implicit ord: scala.math.Ordering[A]): ZIO[R with Has[TestConfig], Nothing, TestResult] =
+  )(implicit ord: scala.math.Ordering[A]): ZIO[R with TestConfig, Nothing, TestResult] =
     check(gen, gen) { (a1, a2) =>
       assert(a1 =?= a2)(equalTo(Ordering.fromCompare(ord.compare(a1, a2)))) &&
       assert(sign(Ord[A].toScala.compare(a1, a2)))(equalTo(sign(ord.compare(a1, a2))))

--- a/core-tests/shared/src/test/scala/zio/prelude/ParSeqSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/ParSeqSpec.scala
@@ -4,14 +4,14 @@ import zio.prelude.ParSeq._
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, Random}
+import zio.Random
 
 object ParSeqSpec extends DefaultRunnableSpec {
 
-  val parSeq: Gen[Has[Random] with Has[Sized], ParSeq[Unit, Int]] =
+  val parSeq: Gen[Random with Sized, ParSeq[Unit, Int]] =
     Gens.parSeq(Gen.unit, Gen.int)
 
-  val equalparSeqs: Gen[Has[Random] with Has[Sized], (ParSeq[Unit, Int], ParSeq[Unit, Int])] =
+  val equalparSeqs: Gen[Random with Sized, (ParSeq[Unit, Int], ParSeq[Unit, Int])] =
     (parSeq <*> parSeq <*> parSeq).flatMap { case (a, b, c) =>
       Gen.elements(
         (a, a),

--- a/core-tests/shared/src/test/scala/zio/prelude/ParSeqSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/ParSeqSpec.scala
@@ -1,10 +1,10 @@
 package zio.prelude
 
+import zio.Random
 import zio.prelude.ParSeq._
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.Random
 
 object ParSeqSpec extends DefaultRunnableSpec {
 

--- a/core-tests/shared/src/test/scala/zio/prelude/ZNonEmptySetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/ZNonEmptySetSpec.scala
@@ -8,11 +8,11 @@ import zio.prelude.laws._
 import zio.prelude.newtypes._
 import zio.test._
 import zio.test.laws._
-import zio.{Chunk, Has, Random, ZTraceElement}
+import zio.{Chunk, Random, ZTraceElement}
 
 object ZNonEmptySetSpec extends DefaultRunnableSpec {
 
-  def genFZNonEmptySet[R <: Has[Random] with Has[Sized], B](
+  def genFZNonEmptySet[R <: Random with Sized, B](
     b: Gen[R, B]
   ): GenF[R, ({ type lambda[+x] = ZNonEmptySet[x, B] })#lambda] =
     new GenF[R, ({ type lambda[+x] = ZNonEmptySet[x, B] })#lambda] {
@@ -20,10 +20,10 @@ object ZNonEmptySetSpec extends DefaultRunnableSpec {
         genZNonEmptySet(a, b)
     }
 
-  def genZNonEmptySet[R <: Has[Random] with Has[Sized], A, B](a: Gen[R, A], b: Gen[R, B]): Gen[R, ZNonEmptySet[A, B]] =
+  def genZNonEmptySet[R <: Random with Sized, A, B](a: Gen[R, A], b: Gen[R, B]): Gen[R, ZNonEmptySet[A, B]] =
     Gen.mapOf1(a, b).map(ZNonEmptySet.fromMapOption(_).get)
 
-  val smallInts: Gen[Has[Random] with Has[Sized], Chunk[Int]] =
+  val smallInts: Gen[Random with Sized, Chunk[Int]] =
     Gen.chunkOf(Gen.int(-10, 10))
 
   implicit def SumIdentity[A: Identity]: Identity[Sum[A]] =
@@ -39,8 +39,8 @@ object ZNonEmptySetSpec extends DefaultRunnableSpec {
           checkAllLaws[
             CovariantDeriveEqual,
             Equal,
-            Has[TestConfig],
-            Has[Random] with Has[Sized] with Has[TestConfig],
+            TestConfig,
+            Random with Sized with TestConfig,
             ({ type lambda[+x] = ZNonEmptySet[x, Int] })#lambda,
             Int
           ](CovariantLaws)(genFZNonEmptySet(Gen.int), Gen.int)(

--- a/core-tests/shared/src/test/scala/zio/prelude/ZSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/ZSetSpec.scala
@@ -5,30 +5,30 @@ import zio.prelude.Equal._
 import zio.prelude.ZSet._
 import zio.prelude.coherent.{CovariantDeriveEqual, DeriveEqualForEach}
 import zio.prelude.laws._
-import zio.prelude.newtypes.{Natural, _}
+import zio.prelude.newtypes._
 import zio.test.Assertion.{equalTo => _, _}
 import zio.test._
 import zio.test.laws._
-import zio.{Chunk, Has, Random, ZTraceElement}
+import zio.{Chunk, Random, ZTraceElement}
 
 object ZSetSpec extends DefaultRunnableSpec {
 
-  def genFZSet[R <: Has[Random] with Has[Sized], B](b: Gen[R, B]): GenF[R, ({ type lambda[+x] = ZSet[x, B] })#lambda] =
+  def genFZSet[R <: Random with Sized, B](b: Gen[R, B]): GenF[R, ({ type lambda[+x] = ZSet[x, B] })#lambda] =
     new GenF[R, ({ type lambda[+x] = ZSet[x, B] })#lambda] {
       def apply[R1 <: R, A](a: Gen[R1, A])(implicit trace: ZTraceElement): Gen[R1, ZSet[A, B]] =
         genZSet(a, b)
     }
 
-  def genZSet[R <: Has[Random] with Has[Sized], A, B](a: Gen[R, A], b: Gen[R, B]): Gen[R, ZSet[A, B]] =
+  def genZSet[R <: Random with Sized, A, B](a: Gen[R, A], b: Gen[R, B]): Gen[R, ZSet[A, B]] =
     Gen.mapOf(a, b).map(ZSet.fromMap)
 
-  lazy val smallInts: Gen[Has[Random] with Has[Sized], Chunk[Int]] =
+  lazy val smallInts: Gen[Random with Sized, Chunk[Int]] =
     Gen.chunkOf(Gen.int(-10, 10))
 
-  def natural(min: Natural, max: Natural)(implicit trace: ZTraceElement): Gen[Has[Random], Natural] =
+  def natural(min: Natural, max: Natural)(implicit trace: ZTraceElement): Gen[Random, Natural] =
     Gen.int(min, max).map(_.asInstanceOf[Natural])
 
-  def naturals: Gen[Has[Random] with Has[Sized], Natural] =
+  def naturals: Gen[Random with Sized, Natural] =
     Gen.small(n => natural(0.asInstanceOf[Natural], n.asInstanceOf[Natural]))
 
   implicit def SumIdentity[A: Identity]: Identity[Sum[A]] =
@@ -44,8 +44,8 @@ object ZSetSpec extends DefaultRunnableSpec {
           checkAllLaws[
             CovariantDeriveEqual,
             Equal,
-            Has[TestConfig],
-            Has[Random] with Has[Sized] with Has[TestConfig],
+            TestConfig,
+            Random with Sized with TestConfig,
             ({ type lambda[+x] = ZSet[x, Int] })#lambda,
             Int
           ](CovariantLaws)(genFZSet(Gen.int), Gen.int)(
@@ -62,8 +62,8 @@ object ZSetSpec extends DefaultRunnableSpec {
           checkAllLaws[
             DeriveEqualForEach,
             Equal,
-            Has[TestConfig],
-            Has[Random] with Has[Sized] with Has[TestConfig],
+            TestConfig,
+            Random with Sized with TestConfig,
             MultiSet,
             Int
           ](ForEachLaws)(genFZSet(naturals), Gen.int)(

--- a/core-tests/shared/src/test/scala/zio/prelude/ZValidationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/ZValidationSpec.scala
@@ -6,18 +6,18 @@ import zio.prelude.ZValidation._
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, Random}
+import zio.Random
 
 object ZValidationSpec extends DefaultRunnableSpec {
 
-  val genValidation: Gen[Has[Random] with Has[Sized], ZValidation[Int, Int, Int]] =
+  val genValidation: Gen[Random with Sized, ZValidation[Int, Int, Int]] =
     Gens.validation(Gen.int, Gen.int, Gen.int)
 
-  val genFValidation: GenF[Has[Random] with Has[Sized], ({ type lambda[+x] = ZValidation[Int, Int, x] })#lambda] =
+  val genFValidation: GenF[Random with Sized, ({ type lambda[+x] = ZValidation[Int, Int, x] })#lambda] =
     GenFs.validation(Gen.int, Gen.int)
 
   val genFValidationFailure
-    : GenF[Has[Random] with Has[Sized], ({ type lambda[+x] = newtypes.Failure[ZValidation[Int, x, Int]] })#lambda] =
+    : GenF[Random with Sized, ({ type lambda[+x] = newtypes.Failure[ZValidation[Int, x, Int]] })#lambda] =
     GenFs.validationFailure(Gen.int, Gen.int)
 
   def spec: ZSpec[Environment, Failure] = suite("ZValidationSpec")(

--- a/core-tests/shared/src/test/scala/zio/prelude/ZValidationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/ZValidationSpec.scala
@@ -1,12 +1,12 @@
 package zio.prelude
 
+import zio.Random
 import zio.prelude.Equal._
 import zio.prelude.HashSpec.scalaHashCodeConsistency
 import zio.prelude.ZValidation._
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.Random
 
 object ZValidationSpec extends DefaultRunnableSpec {
 

--- a/core-tests/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/fx/ZPureSpec.scala
@@ -4,35 +4,35 @@ import zio.prelude._
 import zio.prelude.laws._
 import zio.test.Assertion.{equalTo => _, _}
 import zio.test._
-import zio.{CanFail, Chunk, Has, NonEmptyChunk, Random}
+import zio.{CanFail, Chunk, NonEmptyChunk, Random}
 
 import java.util.NoSuchElementException
 import scala.util.Try
 
 object ZPureSpec extends DefaultRunnableSpec {
 
-  lazy val genInt: Gen[Has[Random], Int] =
+  lazy val genInt: Gen[Random, Int] =
     Gen.int
 
-  lazy val genString: Gen[Has[Random] with Has[Sized], String] =
+  lazy val genString: Gen[Random with Sized, String] =
     Gen.string
 
-  lazy val genIntIntToInt: Gen[Has[Random], (Int, Int) => Int] =
+  lazy val genIntIntToInt: Gen[Random, (Int, Int) => Int] =
     Gen.function2(genInt)
 
-  lazy val genIntToInt: Gen[Has[Random], Int => Int] =
+  lazy val genIntToInt: Gen[Random, Int => Int] =
     Gen.function(genInt)
 
-  lazy val genIntToIntInt: Gen[Has[Random], Int => (Int, Int)] =
+  lazy val genIntToIntInt: Gen[Random, Int => (Int, Int)] =
     Gen.function(genInt <*> genInt)
 
-  lazy val genIntToState: Gen[Has[Random], Int => State[Int, Int]] =
+  lazy val genIntToState: Gen[Random, Int => State[Int, Int]] =
     Gen.function(genState)
 
-  lazy val genState: Gen[Has[Random], State[Int, Int]] =
+  lazy val genState: Gen[Random, State[Int, Int]] =
     Gens.state(genInt, genInt)
 
-  lazy val genStateState: Gen[Has[Random], State[Int, State[Int, Int]]] =
+  lazy val genStateState: Gen[Random, State[Int, State[Int, Int]]] =
     Gens.state(genInt, genState)
 
   def spec: ZSpec[Environment, Failure] =

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1270,9 +1270,13 @@ object AssociativeBoth {
   /**
    * The `AssociativeBoth` instance for `ZSink`.
    */
-  implicit def ZSinkAssociativeBoth[R, E, I]: AssociativeBoth[({ type lambda[+a] = ZSink[R, E, I, I, a] })#lambda] =
-    new AssociativeBoth[({ type lambda[+a] = ZSink[R, E, I, I, a] })#lambda] {
-      def both[A, B](fa: => ZSink[R, E, I, I, A], fb: => ZSink[R, E, I, I, B]): ZSink[R, E, I, I, (A, B)] = fa zip fb
+  implicit def ZSinkAssociativeBoth[R, InErr, In, OutErr, L <: In]
+    : AssociativeBoth[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] =
+    new AssociativeBoth[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] {
+      def both[A, B](
+        fa: => ZSink[R, InErr, In, OutErr, L, A],
+        fb: => ZSink[R, InErr, In, OutErr, L, B]
+      ): ZSink[R, InErr, In, OutErr, L, (A, B)] = fa.zip(fb)
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1234,16 +1234,6 @@ object AssociativeBoth {
         }
     }
 
-//  /**
-//   * The `IdentityBoth` instance for `ZLayer`.
-//   */
-//  implicit def ZLayerIdentityBoth[R, E]: IdentityBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] =
-//    new IdentityBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] {
-//      val any: ZLayer[R, E, Any] = ZLayer.succeed(())
-//
-//      def both[A, B](fa: => ZLayer[R, E, A], fb: => ZLayer[R, E, B]): ZLayer[R, E, (A, B)] = fa zipPar fb
-//    }
-
   /**
    * The `AssociativeBoth` instance for `ZManaged`.
    */

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1234,15 +1234,15 @@ object AssociativeBoth {
         }
     }
 
-  /**
-   * The `IdentityBoth` instance for `ZLayer`.
-   */
-  implicit def ZLayerIdentityBoth[R, E]: IdentityBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] =
-    new IdentityBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] {
-      val any: ZLayer[R, E, Any] = ZLayer.succeed(())
-
-      def both[A, B](fa: => ZLayer[R, E, A], fb: => ZLayer[R, E, B]): ZLayer[R, E, (A, B)] = fa zipPar fb
-    }
+//  /**
+//   * The `IdentityBoth` instance for `ZLayer`.
+//   */
+//  implicit def ZLayerIdentityBoth[R, E]: IdentityBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] =
+//    new IdentityBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] {
+//      val any: ZLayer[R, E, Any] = ZLayer.succeed(())
+//
+//      def both[A, B](fa: => ZLayer[R, E, A], fb: => ZLayer[R, E, B]): ZLayer[R, E, (A, B)] = fa zipPar fb
+//    }
 
   /**
    * The `AssociativeBoth` instance for `ZManaged`.
@@ -1270,13 +1270,13 @@ object AssociativeBoth {
   /**
    * The `AssociativeBoth` instance for `ZSink`.
    */
-  implicit def ZSinkAssociativeBoth[R, InErr, In, OutErr, L <: In]
-    : AssociativeBoth[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] =
-    new AssociativeBoth[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] {
+  implicit def ZSinkAssociativeBoth[R, E, In, L <: In]
+    : AssociativeBoth[({ type lambda[+a] = ZSink[R, E, In, L, a] })#lambda] =
+    new AssociativeBoth[({ type lambda[+a] = ZSink[R, E, In, L, a] })#lambda] {
       def both[A, B](
-        fa: => ZSink[R, InErr, In, OutErr, L, A],
-        fb: => ZSink[R, InErr, In, OutErr, L, B]
-      ): ZSink[R, InErr, In, OutErr, L, (A, B)] = fa.zip(fb)
+        fa: => ZSink[R, E, In, L, A],
+        fb: => ZSink[R, E, In, L, B]
+      ): ZSink[R, E, In, L, (A, B)] = fa.zip(fb)
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/AssociativeCompose.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeCompose.scala
@@ -45,12 +45,13 @@ object AssociativeCompose {
 
   }
 
-  implicit val URIOIdentityCompose: IdentityCompose[URIO] = new IdentityCompose[URIO] {
-    def identity[A]: URIO[A, A] = URIO.service[A]
+  implicit val URIOIdentityCompose: IdentityCompose[({ type lambda[-r, +a] = URIO[r, ZEnvironment[a]] })#lambda] =
+    new IdentityCompose[({ type lambda[-r, +a] = URIO[r, ZEnvironment[a]] })#lambda] {
+      def identity[A]: URIO[A, ZEnvironment[A]] = URIO.environment
 
-    def compose[A, B, C](bc: URIO[B, C], ab: URIO[A, B]): URIO[A, C] =
-      ab.flatMap(b => bc.provideEnvironment(ZEnvironment(b)))
-  }
+      def compose[A, B, C](bc: URIO[B, ZEnvironment[C]], ab: URIO[A, ZEnvironment[B]]): URIO[A, ZEnvironment[C]] =
+        ab.flatMap(b => bc.provideEnvironment(b))
+    }
 
   implicit val URLayerIdentityCompose: IdentityCompose[URLayer] = new IdentityCompose[URLayer] {
     def identity[A]: URLayer[A, A] = ZLayer.environment
@@ -59,12 +60,17 @@ object AssociativeCompose {
       new ZLayerProvideSomeOps[A, Nothing, B](ab) >>> bc
   }
 
-  implicit val URManagedIdentityCompose: IdentityCompose[URManaged] = new IdentityCompose[URManaged] {
-    def identity[A]: URManaged[A, A] = ZManaged.service[A]
+  implicit val URManagedIdentityCompose
+    : IdentityCompose[({ type lambda[-r, +a] = URManaged[r, ZEnvironment[a]] })#lambda] =
+    new IdentityCompose[({ type lambda[-r, +a] = URManaged[r, ZEnvironment[a]] })#lambda] {
+      def identity[A]: URManaged[A, ZEnvironment[A]] = ZManaged.environment
 
-    def compose[A, B, C](bc: URManaged[B, C], ab: URManaged[A, B]): URManaged[A, C] =
-      ab.flatMap(b => bc.provideEnvironment(ZEnvironment(b)))
-  }
+      def compose[A, B, C](
+        bc: URManaged[B, ZEnvironment[C]],
+        ab: URManaged[A, ZEnvironment[B]]
+      ): URManaged[A, ZEnvironment[C]] =
+        ab.flatMap(b => bc.provideEnvironment(b))
+    }
 }
 
 trait AssociativeComposeSyntax {

--- a/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
@@ -218,7 +218,7 @@ object AssociativeEither {
   implicit def ZLayerAssociativeEither[R, E]: AssociativeEither[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] =
     new AssociativeEither[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] {
       def either[A, B](fa: => ZLayer[R, E, A], fb: => ZLayer[R, E, B]): ZLayer[R, E, Either[A, B]] =
-        fa.map(Left(_)) orElse fb.map(Right(_))
+        fa.map(e => ZEnvironment(Left(e.get[A]))) orElse fb.map(e => ZEnvironment(Right(e.get[B])))
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
@@ -213,15 +213,6 @@ object AssociativeEither {
     }
 
   /**
-   * The `AssociativeEither` instance for `ZLayer`.
-   */
-  implicit def ZLayerAssociativeEither[R, E]: AssociativeEither[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] =
-    new AssociativeEither[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] {
-      def either[A, B](fa: => ZLayer[R, E, A], fb: => ZLayer[R, E, B]): ZLayer[R, E, Either[A, B]] =
-        fa.map(e => ZEnvironment(Left(e.get[A]))) orElse fb.map(e => ZEnvironment(Right(e.get[B])))
-    }
-
-  /**
    * The `AssociativeEither` instance for `ZManaged`.
    */
   implicit def ZManagedAssociativeEither[R, E]: AssociativeEither[({ type lambda[+a] = ZManaged[R, E, a] })#lambda] =

--- a/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -177,9 +177,13 @@ object CommutativeBoth {
   /**
    * The `CommutativeBoth` instance for `ZSink`.
    */
-  implicit def ZSinkCommutativeBoth[R, E, I, L]: CommutativeBoth[({ type lambda[+a] = ZSink[R, E, I, L, a] })#lambda] =
-    new CommutativeBoth[({ type lambda[+a] = ZSink[R, E, I, L, a] })#lambda] {
-      def both[A, B](fa: => ZSink[R, E, I, L, A], fb: => ZSink[R, E, I, L, B]): ZSink[R, E, I, L, (A, B)] = fa zipPar fb
+  implicit def ZSinkCommutativeBoth[R, InErr, In, OutErr, L <: In]
+    : CommutativeBoth[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] =
+    new CommutativeBoth[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] {
+      def both[A, B](
+        fa: => ZSink[R, InErr, In, OutErr, L, A],
+        fb: => ZSink[R, InErr, In, OutErr, L, B]
+      ): ZSink[R, InErr, In, OutErr, L, (A, B)] = fa.zipPar(fb)
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -143,13 +143,13 @@ object CommutativeBoth {
         }
     }
 
-  /**
-   * The `CommutativeBoth` instance for `ZLayer`.
-   */
-  implicit def ZLayerCommutativeBoth[R, E]: CommutativeBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] =
-    new CommutativeBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] {
-      def both[A, B](fa: => ZLayer[R, E, A], fb: => ZLayer[R, E, B]): ZLayer[R, E, (A, B)] = fa zipPar fb
-    }
+//  /**
+//   * The `CommutativeBoth` instance for `ZLayer`.
+//   */
+//  implicit def ZLayerCommutativeBoth[R, E]: CommutativeBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] =
+//    new CommutativeBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] {
+//      def both[A, B](fa: => ZLayer[R, E, A], fb: => ZLayer[R, E, B]): ZLayer[R, E, (A, B)] = fa zipPar fb
+//    }
 
   /**
    * The `CommutativeBoth` instance for `ZManaged`.
@@ -177,13 +177,13 @@ object CommutativeBoth {
   /**
    * The `CommutativeBoth` instance for `ZSink`.
    */
-  implicit def ZSinkCommutativeBoth[R, InErr, In, OutErr, L <: In]
-    : CommutativeBoth[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] =
-    new CommutativeBoth[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] {
+  implicit def ZSinkCommutativeBoth[R, E, In, L <: In]
+    : CommutativeBoth[({ type lambda[+a] = ZSink[R, E, In, L, a] })#lambda] =
+    new CommutativeBoth[({ type lambda[+a] = ZSink[R, E, In, L, a] })#lambda] {
       def both[A, B](
-        fa: => ZSink[R, InErr, In, OutErr, L, A],
-        fb: => ZSink[R, InErr, In, OutErr, L, B]
-      ): ZSink[R, InErr, In, OutErr, L, (A, B)] = fa.zipPar(fb)
+        fa: => ZSink[R, E, In, L, A],
+        fb: => ZSink[R, E, In, L, B]
+      ): ZSink[R, E, In, L, (A, B)] = fa.zipPar(fb)
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -143,14 +143,6 @@ object CommutativeBoth {
         }
     }
 
-//  /**
-//   * The `CommutativeBoth` instance for `ZLayer`.
-//   */
-//  implicit def ZLayerCommutativeBoth[R, E]: CommutativeBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] =
-//    new CommutativeBoth[({ type lambda[+a] = ZLayer[R, E, a] })#lambda] {
-//      def both[A, B](fa: => ZLayer[R, E, A], fb: => ZLayer[R, E, B]): ZLayer[R, E, (A, B)] = fa zipPar fb
-//    }
-
   /**
    * The `CommutativeBoth` instance for `ZManaged`.
    */

--- a/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
@@ -52,10 +52,13 @@ object CommutativeEither {
   /**
    * The `CommutativeEither` instance for `ZSink`.
    */
-  implicit def ZSinkCommutativeEither[R, E, I, L]
-    : CommutativeEither[({ type lambda[+a] = ZSink[R, E, I, L, a] })#lambda] =
-    new CommutativeEither[({ type lambda[+a] = ZSink[R, E, I, L, a] })#lambda] {
-      def either[A, B](fa: => ZSink[R, E, I, L, A], fb: => ZSink[R, E, I, L, B]): ZSink[R, E, I, L, Either[A, B]] =
+  implicit def ZSinkCommutativeEither[R, InErr, In, OutErr, L]
+    : CommutativeEither[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] =
+    new CommutativeEither[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] {
+      def either[A, B](
+        fa: => ZSink[R, InErr, In, OutErr, L, A],
+        fb: => ZSink[R, InErr, In, OutErr, L, B]
+      ): ZSink[R, InErr, In, OutErr, L, Either[A, B]] =
         fa.raceBoth(fb)
     }
 

--- a/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
@@ -52,13 +52,13 @@ object CommutativeEither {
   /**
    * The `CommutativeEither` instance for `ZSink`.
    */
-  implicit def ZSinkCommutativeEither[R, InErr, In, OutErr, L]
-    : CommutativeEither[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] =
-    new CommutativeEither[({ type lambda[+a] = ZSink[R, InErr, In, OutErr, L, a] })#lambda] {
+  implicit def ZSinkCommutativeEither[R, E, In, L]
+    : CommutativeEither[({ type lambda[+a] = ZSink[R, E, In, L, a] })#lambda] =
+    new CommutativeEither[({ type lambda[+a] = ZSink[R, E, In, L, a] })#lambda] {
       def either[A, B](
-        fa: => ZSink[R, InErr, In, OutErr, L, A],
-        fb: => ZSink[R, InErr, In, OutErr, L, B]
-      ): ZSink[R, InErr, In, OutErr, L, Either[A, B]] =
+        fa: => ZSink[R, E, In, L, A],
+        fb: => ZSink[R, E, In, L, B]
+      ): ZSink[R, E, In, L, Either[A, B]] =
         fa.raceBoth(fb)
     }
 

--- a/core/shared/src/main/scala/zio/prelude/Equal.scala
+++ b/core/shared/src/main/scala/zio/prelude/Equal.scala
@@ -300,10 +300,10 @@ object Equal {
     HashOrd.make(_.##, (l, r) => Ordering.fromCompare(java.lang.Float.compare(l, r)))
 
   /**
-   * `Hash` and `Ord` and (and thus also `Equal`) instance for `FiberId` values.
+   * `Hash` and (and thus also `Equal`) instance for `FiberId` values.
    */
-  implicit lazy val FiberIdHashOrd: Hash[FiberId] with Ord[FiberId] =
-    HashOrd.derive[(Long, Long)].contramap[FiberId](fid => (fid.startTimeMillis, fid.seqNumber))
+  implicit lazy val FiberIdHashOrd: Hash[FiberId] =
+    Hash.default
 
   /**
    * `Hash` and `Ord` (and thus also `Equal`) instance for `Int` values.

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -19,7 +19,7 @@ package zio.prelude
 import zio.prelude.newtypes.{Failure, FailureIn, FailureOut}
 import zio.stm.ZSTM
 import zio.stream.{ZSink, ZStream}
-import zio.{Cause, Chunk, ChunkBuilder, Exit, Fiber, NonEmptyChunk, Schedule, ZIO, ZLayer, ZManaged, ZQueue, ZRef}
+import zio.{Cause, Chunk, ChunkBuilder, Exit, Fiber, NonEmptyChunk, Schedule, ZIO, ZManaged, ZQueue, ZRef}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -1305,17 +1305,17 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
   implicit def ZIOFailureCovariant[R, A]: Covariant[({ type lambda[+e] = Failure[ZIO[R, e, A]] })#lambda] =
     Zivariant.ZioZivariant.deriveFailureCovariant
 
-  /**
-   * The `Covariant` (and thus `Invariant`) for `ZLayer`
-   */
-  implicit def ZLayerCovariant[R, E]: Covariant[({ type lambda[+rout] = ZLayer[R, E, rout] })#lambda] =
-    Zivariant.ZLayerZivariant.deriveCovariant
-
-  /**
-   * The `Covariant` (and thus `Invariant`) for a failed `ZLayer`
-   */
-  implicit def ZLayerFailureCovariant[R, Out]: Covariant[({ type lambda[+e] = Failure[ZLayer[R, e, Out]] })#lambda] =
-    Zivariant.ZLayerZivariant.deriveFailureCovariant
+//  /**
+//   * The `Covariant` (and thus `Invariant`) for `ZLayer`
+//   */
+//  implicit def ZLayerCovariant[R, E]: Covariant[({ type lambda[+rout] = ZLayer[R, E, rout] })#lambda] =
+//    Zivariant.ZLayerZivariant.deriveCovariant
+//
+//  /**
+//   * The `Covariant` (and thus `Invariant`) for a failed `ZLayer`
+//   */
+//  implicit def ZLayerFailureCovariant[R, Out]: Covariant[({ type lambda[+e] = Failure[ZLayer[R, e, Out]] })#lambda] =
+//    Zivariant.ZLayerZivariant.deriveFailureCovariant
 
   /**
    * The `Covariant` (and thus `Invariant`) for `ZManaged`
@@ -1715,23 +1715,23 @@ trait LowPriorityInvariantImplicits {
         schedule => schedule.contramap(f)
     }
 
-  /**
-   * The `Contravariant` (and thus `Invariant`) instance for `ZIO`.
-   */
-  implicit def ZIOContravariant[E, A]: Contravariant[({ type lambda[-x] = ZIO[x, E, A] })#lambda] =
-    Zivariant.ZioZivariant.deriveContravariant
-
-  /**
-   * The `Contravariant` (and thus `Invariant`) instance for `ZLayer`.
-   */
-  implicit def ZLayerContravariant[E, ROut]: Contravariant[({ type lambda[-x] = ZLayer[x, E, ROut] })#lambda] =
-    Zivariant.ZLayerZivariant.deriveContravariant
-
-  /**
-   * The `Contravariant` (and thus `Invariant`) instance for `ZManaged`.
-   */
-  implicit def ZManagedContravariant[E, A]: Contravariant[({ type lambda[-x] = ZManaged[x, E, A] })#lambda] =
-    Zivariant.ZManagedZivariant.deriveContravariant
+//  /**
+//   * The `Contravariant` (and thus `Invariant`) instance for `ZIO`.
+//   */
+//  implicit def ZIOContravariant[E, A]: Contravariant[({ type lambda[-x] = ZIO[x, E, A] })#lambda] =
+//    Zivariant.ZioZivariant.deriveContravariant
+//
+//  /**
+//   * The `Contravariant` (and thus `Invariant`) instance for `ZLayer`.
+//   */
+//  implicit def ZLayerContravariant[E, ROut]: Contravariant[({ type lambda[-x] = ZLayer[x, E, ROut] })#lambda] =
+//    Zivariant.ZLayerZivariant.deriveContravariant
+//
+//  /**
+//   * The `Contravariant` (and thus `Invariant`) instance for `ZManaged`.
+//   */
+//  implicit def ZManagedContravariant[E, A]: Contravariant[({ type lambda[-x] = ZManaged[x, E, A] })#lambda] =
+//    Zivariant.ZManagedZivariant.deriveContravariant
 
   /**
    * The `Contravariant` (and thus `Invariant`) instance for `ZQueue`.
@@ -1768,24 +1768,23 @@ trait LowPriorityInvariantImplicits {
   /**
    * The `Contravariant` (and thus `Invariant`) instance for `ZSink`.
    */
-  implicit def ZSinkContravariant[R, InErr, OutErr, L, Z]
-    : Contravariant[({ type lambda[-x] = ZSink[R, InErr, x, OutErr, L, Z] })#lambda] =
-    new Contravariant[({ type lambda[-x] = ZSink[R, InErr, x, OutErr, L, Z] })#lambda] {
-      def contramap[A, C](f: C => A): ZSink[R, InErr, A, OutErr, L, Z] => ZSink[R, InErr, C, OutErr, L, Z] =
+  implicit def ZSinkContravariant[R, E, L, Z]: Contravariant[({ type lambda[-x] = ZSink[R, E, x, L, Z] })#lambda] =
+    new Contravariant[({ type lambda[-x] = ZSink[R, E, x, L, Z] })#lambda] {
+      def contramap[A, C](f: C => A): ZSink[R, E, A, L, Z] => ZSink[R, E, C, L, Z] =
         sink => sink.contramap(f)
     }
 
-  /**
-   * The `Contravariant` (and thus `Invariant`) instance for `ZStream`.
-   */
-  implicit def ZStreamContravariant[E, A]: Contravariant[({ type lambda[-x] = ZStream[x, E, A] })#lambda] =
-    Zivariant.ZStreamZivariant.deriveContravariant
-
-  /**
-   * The `Contravariant` (and thus `Invariant`) instance for `ZSTM`.
-   */
-  implicit def ZSTMZivariantContravariant[E, A]: Contravariant[({ type lambda[-x] = ZSTM[x, E, A] })#lambda] =
-    Zivariant.ZSTMZivariant.deriveContravariant
+//  /**
+//   * The `Contravariant` (and thus `Invariant`) instance for `ZStream`.
+//   */
+//  implicit def ZStreamContravariant[E, A]: Contravariant[({ type lambda[-x] = ZStream[x, E, A] })#lambda] =
+//    Zivariant.ZStreamZivariant.deriveContravariant
+//
+//  /**
+//   * The `Contravariant` (and thus `Invariant`) instance for `ZSTM`.
+//   */
+//  implicit def ZSTMZivariantContravariant[E, A]: Contravariant[({ type lambda[-x] = ZSTM[x, E, A] })#lambda] =
+//    Zivariant.ZSTMZivariant.deriveContravariant
 }
 
 trait InvariantSyntax {

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -1768,9 +1768,10 @@ trait LowPriorityInvariantImplicits {
   /**
    * The `Contravariant` (and thus `Invariant`) instance for `ZSink`.
    */
-  implicit def ZSinkContravariant[R, E, L, Z]: Contravariant[({ type lambda[-x] = ZSink[R, E, x, L, Z] })#lambda] =
-    new Contravariant[({ type lambda[-x] = ZSink[R, E, x, L, Z] })#lambda] {
-      def contramap[A, C](f: C => A): ZSink[R, E, A, L, Z] => ZSink[R, E, C, L, Z] =
+  implicit def ZSinkContravariant[R, InErr, OutErr, L, Z]
+    : Contravariant[({ type lambda[-x] = ZSink[R, InErr, x, OutErr, L, Z] })#lambda] =
+    new Contravariant[({ type lambda[-x] = ZSink[R, InErr, x, OutErr, L, Z] })#lambda] {
+      def contramap[A, C](f: C => A): ZSink[R, InErr, A, OutErr, L, Z] => ZSink[R, InErr, C, OutErr, L, Z] =
         sink => sink.contramap(f)
     }
 

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -1305,18 +1305,6 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
   implicit def ZIOFailureCovariant[R, A]: Covariant[({ type lambda[+e] = Failure[ZIO[R, e, A]] })#lambda] =
     Zivariant.ZioZivariant.deriveFailureCovariant
 
-//  /**
-//   * The `Covariant` (and thus `Invariant`) for `ZLayer`
-//   */
-//  implicit def ZLayerCovariant[R, E]: Covariant[({ type lambda[+rout] = ZLayer[R, E, rout] })#lambda] =
-//    Zivariant.ZLayerZivariant.deriveCovariant
-//
-//  /**
-//   * The `Covariant` (and thus `Invariant`) for a failed `ZLayer`
-//   */
-//  implicit def ZLayerFailureCovariant[R, Out]: Covariant[({ type lambda[+e] = Failure[ZLayer[R, e, Out]] })#lambda] =
-//    Zivariant.ZLayerZivariant.deriveFailureCovariant
-
   /**
    * The `Covariant` (and thus `Invariant`) for `ZManaged`
    */
@@ -1715,24 +1703,6 @@ trait LowPriorityInvariantImplicits {
         schedule => schedule.contramap(f)
     }
 
-//  /**
-//   * The `Contravariant` (and thus `Invariant`) instance for `ZIO`.
-//   */
-//  implicit def ZIOContravariant[E, A]: Contravariant[({ type lambda[-x] = ZIO[x, E, A] })#lambda] =
-//    Zivariant.ZioZivariant.deriveContravariant
-//
-//  /**
-//   * The `Contravariant` (and thus `Invariant`) instance for `ZLayer`.
-//   */
-//  implicit def ZLayerContravariant[E, ROut]: Contravariant[({ type lambda[-x] = ZLayer[x, E, ROut] })#lambda] =
-//    Zivariant.ZLayerZivariant.deriveContravariant
-//
-//  /**
-//   * The `Contravariant` (and thus `Invariant`) instance for `ZManaged`.
-//   */
-//  implicit def ZManagedContravariant[E, A]: Contravariant[({ type lambda[-x] = ZManaged[x, E, A] })#lambda] =
-//    Zivariant.ZManagedZivariant.deriveContravariant
-
   /**
    * The `Contravariant` (and thus `Invariant`) instance for `ZQueue`.
    */
@@ -1774,17 +1744,6 @@ trait LowPriorityInvariantImplicits {
         sink => sink.contramap(f)
     }
 
-//  /**
-//   * The `Contravariant` (and thus `Invariant`) instance for `ZStream`.
-//   */
-//  implicit def ZStreamContravariant[E, A]: Contravariant[({ type lambda[-x] = ZStream[x, E, A] })#lambda] =
-//    Zivariant.ZStreamZivariant.deriveContravariant
-//
-//  /**
-//   * The `Contravariant` (and thus `Invariant`) instance for `ZSTM`.
-//   */
-//  implicit def ZSTMZivariantContravariant[E, A]: Contravariant[({ type lambda[-x] = ZSTM[x, E, A] })#lambda] =
-//    Zivariant.ZSTMZivariant.deriveContravariant
 }
 
 trait InvariantSyntax {

--- a/core/shared/src/main/scala/zio/prelude/ParSeq.scala
+++ b/core/shared/src/main/scala/zio/prelude/ParSeq.scala
@@ -139,7 +139,7 @@ sealed trait ParSeq[+Z <: Unit, +A] { self =>
   final def toCause: zio.Cause[A] = this match {
     case ParSeq.Both(left, right) => zio.Cause.Both(left.toCause, right.toCause)
     case _: ParSeq.Empty.type     => zio.Cause.empty
-    case ParSeq.Single(value)     => zio.Cause.Fail(value)
+    case ParSeq.Single(value)     => zio.Cause.fail(value)
     case ParSeq.Then(left, right) => zio.Cause.Then(left.toCause, right.toCause)
   }
 

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -264,7 +264,7 @@ sealed trait ZValidation[+W, +E, +A] { self =>
    */
   final def toZIO: IO[E, A] =
     self.fold(
-      nec => ZIO.failCause(nec.reduceMapLeft(zio.Cause.fail)((c, e) => zio.Cause.Both(c, zio.Cause.fail(e)))),
+      nec => ZIO.failCause(nec.reduceMapLeft(e => zio.Cause.fail(e))((c, e) => zio.Cause.Both(c, zio.Cause.fail(e)))),
       ZIO.succeedNow
     )
 

--- a/core/shared/src/main/scala/zio/prelude/Zivariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Zivariant.scala
@@ -149,16 +149,6 @@ object Zivariant {
       rea => rea.mapBoth(e, a).provideSomeEnvironment(r)
   }
 
-//  implicit val ZLayerZivariant: Zivariant[ZLayer] =
-//    new Zivariant[ZLayer] {
-//      override def zimap[E, A, R, EE, AA, RR](
-//        r: ZEnvironment[EE] => ZEnvironment[E],
-//        e: A => AA,
-//        a: R => RR
-//      ): ZLayer[E, A, R] => ZLayer[EE, AA, RR] =
-//        rea => ZLayer.fromFunctionEnvironment(r) >>> rea.map(a).mapError(e)
-//    }
-
   implicit val ZManagedZivariant: Zivariant[ZManaged] =
     new Zivariant[ZManaged] {
       override def zimap[E, A, R, EE, AA, RR](

--- a/core/shared/src/main/scala/zio/prelude/Zivariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Zivariant.scala
@@ -40,19 +40,6 @@ trait Zivariant[Z[-_, +_, +_]] { self =>
         fa => Failure.wrap(self.mapLeft(f)(Failure.unwrap(fa)))
     }
 
-//  def deriveContravariant[E, A]: Contravariant[({ type lambda[-R] = Z[R, E, A] })#lambda] =
-//    new Contravariant[({ type lambda[-R] = Z[R, E, A] })#lambda] {
-//      def contramap[R, R1](f: R1 => R): Z[R, E, A] => Z[R1, E, A] = self.contramap(f)
-//    }
-//
-//  def deriveDivariant[E]: Divariant[({ type lambda[-R, +A] = Z[R, E, A] })#lambda] =
-//    new Divariant[({ type lambda[-R, +A] = Z[R, E, A] })#lambda] {
-//
-//      def leftContramap[R, A, RR](f: RR => R): Z[R, E, A] => Z[RR, E, A] = self.contramap(f)
-//
-//      def rightMap[R, A, AA](f: A => AA): Z[R, E, A] => Z[R, E, AA] = self.map(f)
-//    }
-
   def zimap[R, E, A, R1, E1, A1](
     r: ZEnvironment[R1] => ZEnvironment[R],
     e: E => E1,

--- a/core/shared/src/main/scala/zio/prelude/Zivariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Zivariant.scala
@@ -19,7 +19,7 @@ package zio.prelude
 import zio.prelude.newtypes.Failure
 import zio.stm.ZSTM
 import zio.stream.ZStream
-import zio.{ZIO, ZLayer, ZManaged}
+import zio.{ZEnvironment, ZIO, ZManaged}
 
 import scala.Predef.{identity => id}
 
@@ -40,46 +40,50 @@ trait Zivariant[Z[-_, +_, +_]] { self =>
         fa => Failure.wrap(self.mapLeft(f)(Failure.unwrap(fa)))
     }
 
-  def deriveContravariant[E, A]: Contravariant[({ type lambda[-R] = Z[R, E, A] })#lambda] =
-    new Contravariant[({ type lambda[-R] = Z[R, E, A] })#lambda] {
-      def contramap[R, R1](f: R1 => R): Z[R, E, A] => Z[R1, E, A] = self.contramap(f)
-    }
+//  def deriveContravariant[E, A]: Contravariant[({ type lambda[-R] = Z[R, E, A] })#lambda] =
+//    new Contravariant[({ type lambda[-R] = Z[R, E, A] })#lambda] {
+//      def contramap[R, R1](f: R1 => R): Z[R, E, A] => Z[R1, E, A] = self.contramap(f)
+//    }
+//
+//  def deriveDivariant[E]: Divariant[({ type lambda[-R, +A] = Z[R, E, A] })#lambda] =
+//    new Divariant[({ type lambda[-R, +A] = Z[R, E, A] })#lambda] {
+//
+//      def leftContramap[R, A, RR](f: RR => R): Z[R, E, A] => Z[RR, E, A] = self.contramap(f)
+//
+//      def rightMap[R, A, AA](f: A => AA): Z[R, E, A] => Z[R, E, AA] = self.map(f)
+//    }
 
-  def deriveDivariant[E]: Divariant[({ type lambda[-R, +A] = Z[R, E, A] })#lambda] =
-    new Divariant[({ type lambda[-R, +A] = Z[R, E, A] })#lambda] {
-
-      def leftContramap[R, A, RR](f: RR => R): Z[R, E, A] => Z[RR, E, A] = self.contramap(f)
-
-      def rightMap[R, A, AA](f: A => AA): Z[R, E, A] => Z[R, E, AA] = self.map(f)
-    }
-
-  def zimap[R, E, A, R1, E1, A1](r: R1 => R, e: E => E1, a: A => A1): Z[R, E, A] => Z[R1, E1, A1]
+  def zimap[R, E, A, R1, E1, A1](
+    r: ZEnvironment[R1] => ZEnvironment[R],
+    e: E => E1,
+    a: A => A1
+  ): Z[R, E, A] => Z[R1, E1, A1]
 
   // derived methods
-  def contramap[R, E, A, R1](r: R1 => R): Z[R, E, A] => Z[R1, E, A] =
+  def contramap[R, E, A, R1](r: ZEnvironment[R1] => ZEnvironment[R]): Z[R, E, A] => Z[R1, E, A] =
     zimap(r, id[E], id[A])
 
   def mapLeft[R, E, A, E1](e: E => E1): Z[R, E, A] => Z[R, E1, A] =
-    zimap(id[R], e, id[A])
+    zimap(id[ZEnvironment[R]], e, id[A])
 
   def map[R, E, A, A1](a: A => A1): Z[R, E, A] => Z[R, E, A1] =
-    zimap(id[R], id[E], a)
+    zimap(id[ZEnvironment[R]], id[E], a)
 
   def bimap[R, E, A, E1, A1](e: E => E1, a: A => A1): Z[R, E, A] => Z[R, E1, A1] =
-    zimap(id[R], e, a)
+    zimap(id[ZEnvironment[R]], e, a)
 
-  def dimap[R, E, A, RR, AA](r: RR => R, a: A => AA): Z[R, E, A] => Z[RR, E, AA] =
+  def dimap[R, E, A, RR, AA](r: ZEnvironment[RR] => ZEnvironment[R], a: A => AA): Z[R, E, A] => Z[RR, E, AA] =
     zimap(r, id[E], a)
 
   // zimap id id id == id
   def zimapIdentity[R, E, A](rea: Z[R, E, A])(implicit eq: Equal[Z[R, E, A]]): Boolean =
-    EqualOps(zimap(id[R], id[E], id[A])(rea)) === rea // because of Dotty
+    EqualOps(zimap(id[ZEnvironment[R]], id[E], id[A])(rea)) === rea // because of Dotty
 
   // zimap (r2 andThen r1) (e1 andThen e2) (a1 andThen a2) == zimap (r1 e1 a1) andThen zimap (r2 e2 a2)
   def zimapComposition[R, E, A, R1, R2, E1, E2, A1, A2](
     rea: Z[R, E, A],
-    r2: R2 => R1,
-    r1: R1 => R,
+    r2: ZEnvironment[R2] => ZEnvironment[R1],
+    r1: ZEnvironment[R1] => ZEnvironment[R],
     e1: E => E1,
     e2: E1 => E2,
     a1: A => A1,
@@ -93,7 +97,7 @@ trait Zivariant[Z[-_, +_, +_]] { self =>
   // zimap r e a == contramap(r) andThen map(a) andThen mapLeft(e)
   def zimapCoherentWithMapAndContramap[R, E, A, R1, E1, A1](
     rea: Z[R, E, A],
-    r: R1 => R,
+    r: ZEnvironment[R1] => ZEnvironment[R],
     e: E => E1,
     a: A => A1
   )(implicit eq: Equal[Z[R1, E1, A1]]): Boolean = {
@@ -106,13 +110,14 @@ trait Zivariant[Z[-_, +_, +_]] { self =>
 
 object Zivariant {
 
-  implicit val FunctionEitherZivariant: Zivariant[({ type lambda[-R, +E, +A] = R => Either[E, A] })#lambda] =
-    new Zivariant[({ type lambda[-R, +E, +A] = R => Either[E, A] })#lambda] {
+  implicit val FunctionEitherZivariant
+    : Zivariant[({ type lambda[-R, +E, +A] = ZEnvironment[R] => Either[E, A] })#lambda] =
+    new Zivariant[({ type lambda[-R, +E, +A] = ZEnvironment[R] => Either[E, A] })#lambda] {
       override def zimap[R, E, A, R1, E1, A1](
-        r: R1 => R,
+        r: ZEnvironment[R1] => ZEnvironment[R],
         e: E => E1,
         a: A => A1
-      ): (R => Either[E, A]) => R1 => Either[E1, A1] =
+      ): (ZEnvironment[R] => Either[E, A]) => ZEnvironment[R1] => Either[E1, A1] =
         rea =>
           r1 =>
             (r andThen rea)(r1) match {
@@ -121,9 +126,13 @@ object Zivariant {
             }
     }
 
-  implicit val FunctionTupleZivariant: Zivariant[({ type lambda[-R, +E, +A] = R => (E, A) })#lambda] =
-    new Zivariant[({ type lambda[-R, +E, +A] = R => (E, A) })#lambda] {
-      override def zimap[R, E, A, R1, E1, A1](r: R1 => R, e: E => E1, a: A => A1): (R => (E, A)) => R1 => (E1, A1) =
+  implicit val FunctionTupleZivariant: Zivariant[({ type lambda[-R, +E, +A] = ZEnvironment[R] => (E, A) })#lambda] =
+    new Zivariant[({ type lambda[-R, +E, +A] = ZEnvironment[R] => (E, A) })#lambda] {
+      override def zimap[R, E, A, R1, E1, A1](
+        r: ZEnvironment[R1] => ZEnvironment[R],
+        e: E => E1,
+        a: A => A1
+      ): (ZEnvironment[R] => (E, A)) => ZEnvironment[R1] => (E1, A1) =
         rea =>
           r1 => {
             val (ee, aa) = (r andThen rea)(r1)
@@ -132,44 +141,52 @@ object Zivariant {
     }
 
   implicit val ZioZivariant: Zivariant[ZIO] = new Zivariant[ZIO] {
-    override def zimap[R, E, A, R1, E1, A1](r: R1 => R, e: E => E1, a: A => A1): ZIO[R, E, A] => ZIO[R1, E1, A1] =
-      rea => rea.mapBoth(e, a).provideSome(r)
+    override def zimap[R, E, A, R1, E1, A1](
+      r: ZEnvironment[R1] => ZEnvironment[R],
+      e: E => E1,
+      a: A => A1
+    ): ZIO[R, E, A] => ZIO[R1, E1, A1] =
+      rea => rea.mapBoth(e, a).provideSomeEnvironment(r)
   }
 
-  implicit val ZLayerZivariant: Zivariant[ZLayer] =
-    new Zivariant[ZLayer] {
-      override def zimap[E, A, R, EE, AA, RR](
-        r: EE => E,
-        e: A => AA,
-        a: R => RR
-      ): ZLayer[E, A, R] => ZLayer[EE, AA, RR] =
-        rea => ZLayer.fromFunctionMany(r) >>> rea.map(a).mapError(e)
-    }
+//  implicit val ZLayerZivariant: Zivariant[ZLayer] =
+//    new Zivariant[ZLayer] {
+//      override def zimap[E, A, R, EE, AA, RR](
+//        r: ZEnvironment[EE] => ZEnvironment[E],
+//        e: A => AA,
+//        a: R => RR
+//      ): ZLayer[E, A, R] => ZLayer[EE, AA, RR] =
+//        rea => ZLayer.fromFunctionEnvironment(r) >>> rea.map(a).mapError(e)
+//    }
 
   implicit val ZManagedZivariant: Zivariant[ZManaged] =
     new Zivariant[ZManaged] {
       override def zimap[E, A, R, EE, AA, RR](
-        r: EE => E,
+        r: ZEnvironment[EE] => ZEnvironment[E],
         e: A => AA,
         a: R => RR
       ): ZManaged[E, A, R] => ZManaged[EE, AA, RR] =
-        rea => rea.mapBoth(e, a).provideSome(r)
+        rea => rea.mapBoth(e, a).provideSomeEnvironment(r)
     }
 
   implicit val ZStreamZivariant: Zivariant[ZStream] =
     new Zivariant[ZStream] {
       override def zimap[E, A, R, EE, AA, RR](
-        r: EE => E,
+        r: ZEnvironment[EE] => ZEnvironment[E],
         e: A => AA,
         a: R => RR
       ): ZStream[E, A, R] => ZStream[EE, AA, RR] =
-        rea => rea.mapBoth(e, a).provideSome(r)
+        rea => rea.mapBoth(e, a).provideSomeEnvironment(r)
     }
 
   implicit val ZSTMZivariant: Zivariant[ZSTM] =
     new Zivariant[ZSTM] {
-      override def zimap[E, A, R, EE, AA, RR](r: EE => E, e: A => AA, a: R => RR): ZSTM[E, A, R] => ZSTM[EE, AA, RR] =
-        rea => rea.mapBoth(e, a).provideSome(r)
+      override def zimap[E, A, R, EE, AA, RR](
+        r: ZEnvironment[EE] => ZEnvironment[E],
+        e: A => AA,
+        a: R => RR
+      ): ZSTM[E, A, R] => ZSTM[EE, AA, RR] =
+        rea => rea.mapBoth(e, a).provideSomeEnvironment(r)
     }
 }
 
@@ -177,10 +194,12 @@ trait ZivariantSyntax {
 
   implicit class ZivariantOps[Z[-_, +_, +_], R, E, A](f: => Z[R, E, A]) {
 
-    def zimap[R1, E1, A1](r: R1 => R, e: E => E1, a: A => A1)(implicit zivariant: Zivariant[Z]): Z[R1, E1, A1] =
+    def zimap[R1, E1, A1](r: ZEnvironment[R1] => ZEnvironment[R], e: E => E1, a: A => A1)(implicit
+      zivariant: Zivariant[Z]
+    ): Z[R1, E1, A1] =
       zivariant.zimap(r, e, a)(f)
 
-    def contramap[R1](r: R1 => R)(implicit zivariant: Zivariant[Z]): Z[R1, E, A] =
+    def contramap[R1](r: ZEnvironment[R1] => ZEnvironment[R])(implicit zivariant: Zivariant[Z]): Z[R1, E, A] =
       zivariant.contramap(r)(f)
 
     def mapLeft[E1](e: E => E1)(implicit zivariant: Zivariant[Z]): Z[R, E1, A] =
@@ -192,7 +211,9 @@ trait ZivariantSyntax {
     def bimap[E1, A1](e: E => E1, a: A => A1)(implicit zivariant: Zivariant[Z]): Z[R, E1, A1] =
       zivariant.bimap(e, a)(f)
 
-    def dimap[RR, AA](r: RR => R, a: A => AA)(implicit zivariant: Zivariant[Z]): Z[RR, E, AA] =
+    def dimap[RR, AA](r: ZEnvironment[RR] => ZEnvironment[R], a: A => AA)(implicit
+      zivariant: Zivariant[Z]
+    ): Z[RR, E, AA] =
       zivariant.dimap(r, a)(f)
   }
 }

--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -853,7 +853,7 @@ sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
    * Transforms ZPure to ZIO that either succeeds with `A` or fails with error(s) `E`.
    * The original state is supposed to be `()`.
    */
-  def toZIO(implicit ev: Unit <:< S1): zio.ZIO[R, E, A] = zio.ZIO.accessZIO[R] { r =>
+  def toZIO(implicit ev: Unit <:< S1): zio.ZIO[R, E, A] = zio.ZIO.serviceWithZIO[R] { r =>
     provide(r).runAll(())._2 match {
       case Left(cause)   => zio.ZIO.failCause(cause.toCause)
       case Right((_, a)) => zio.ZIO.succeedNow(a)
@@ -864,7 +864,7 @@ sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
    * Transforms ZPure to ZIO that either succeeds with `A` or fails with error(s) `E`.
    */
   def toZIOWith(s1: S1): zio.ZIO[R, E, A] =
-    zio.ZIO.accessZIO[R] { r =>
+    zio.ZIO.serviceWithZIO[R] { r =>
       val result = provide(r).runAll(s1)
       result._2 match {
         case Left(cause)   => zio.ZIO.failCause(cause.toCause)
@@ -876,7 +876,7 @@ sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
    * Transforms ZPure to ZIO that either succeeds with `S2` and `A` or fails with error(s) `E`.
    */
   def toZIOWithState(s1: S1): zio.ZIO[R, E, (S2, A)] =
-    zio.ZIO.accessZIO[R] { r =>
+    zio.ZIO.serviceWithZIO[R] { r =>
       val result = provide(r).runAll(s1)
       result._2 match {
         case Left(cause)   => zio.ZIO.failCause(cause.toCause)
@@ -888,7 +888,7 @@ sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
    * Transforms ZPure to ZIO that either succeeds with `Chunk[W]`, `S2` and `A` or fails with error(s) `E`.
    */
   def toZIOWithAll(s1: S1): zio.ZIO[R, E, (Chunk[W], S2, A)] =
-    zio.ZIO.accessZIO[R] { r =>
+    zio.ZIO.serviceWithZIO[R] { r =>
       val (log, result) = provide(r).runAll(s1)
       result match {
         case Left(cause)    => zio.ZIO.failCause(cause.toCause)

--- a/docs/functionalabstractions/parameterizedtypes/associativeboth.md
+++ b/docs/functionalabstractions/parameterizedtypes/associativeboth.md
@@ -34,7 +34,7 @@ import zio._
 
 import java.io.IOException
 
-val helloZIO: ZIO[Has[Console], IOException, Unit] =
+val helloZIO: ZIO[Console, IOException, Unit] =
   Console.printLine("Hello") <*> Console.printLine("ZIO")
 ```
 
@@ -43,7 +43,7 @@ This will print `Hello` to the console on the first line and then `ZIO` on the s
 If the first workflow fails then the second workflow will never be run.
 
 ```scala mdoc
-val failZIO: ZIO[Has[Console], IOException, Unit] =
+val failZIO: ZIO[Console, IOException, Unit] =
   ZIO.fail(new IOException("Fail")) <*> Console.printLine("ZIO")
 ```
 
@@ -169,7 +169,7 @@ The `zipLeft` and `zipRight` operators and their symbolic aliases `<*` and `*>` 
 For example, we could avoid creating unnecessary nested tuples when we combine `ZIO` workflows like this:
 
 ```scala mdoc
-val helloFromAssociativeBoth: ZIO[Has[Console], IOException, Unit] =
+val helloFromAssociativeBoth: ZIO[Console, IOException, Unit] =
   Console.printLine("Hello") *>
     Console.printLine("From") *>
     Console.printLine("AssociativeBoth")

--- a/docs/functionalabstractions/parameterizedtypes/associativeflatten.md
+++ b/docs/functionalabstractions/parameterizedtypes/associativeflatten.md
@@ -42,7 +42,7 @@ import zio._
 
 import java.io.IOException
 
-val greet: ZIO[Has[Random], Nothing, ZIO[Has[Console], IOException, Unit]] =
+val greet: ZIO[Random, Nothing, ZIO[Has[Console], IOException, Unit]] =
   Random.nextIntBounded(100).map { n =>
     Console.printLine(s"The number is $n")
   }

--- a/docs/functionalabstractions/parameterizedtypes/associativeflatten.md
+++ b/docs/functionalabstractions/parameterizedtypes/associativeflatten.md
@@ -42,7 +42,7 @@ import zio._
 
 import java.io.IOException
 
-val greet: ZIO[Random, Nothing, ZIO[Has[Console], IOException, Unit]] =
+val greet: ZIO[Random, Nothing, ZIO[Console, IOException, Unit]] =
   Random.nextIntBounded(100).map { n =>
     Console.printLine(s"The number is $n")
   }
@@ -67,7 +67,7 @@ This is exactly what the `flatten` operator does for us. It takes a `ZIO` workfl
 Let's see how we can use the `flatten` operator to fix our code from above.
 
 ```scala mdoc:nest
-val greet: ZIO[Has[Random] with Has[Console], IOException, Unit] =
+val greet: ZIO[Random with Console, IOException, Unit] =
   Random.nextIntBounded(100).map { n =>
     Console.printLine(s"The number is $n")
   }.flatten
@@ -78,7 +78,7 @@ Now we have eliminated the nested workflows. This workflow will do exactly what 
 Of course if we are working with `ZIO` we quickly learn to use the `flatMap` operator, which just combines `map` and `flatten`.
 
 ```scala mdoc:nest
-val greet: ZIO[Has[Random] with Has[Console], IOException, Unit] =
+val greet: ZIO[Random with Console, IOException, Unit] =
   Random.nextIntBounded(100).flatMap { n =>
     Console.printLine(s"The number is $n")
   }

--- a/docs/functionalabstractions/parameterizedtypes/commutativeboth.md
+++ b/docs/functionalabstractions/parameterizedtypes/commutativeboth.md
@@ -36,10 +36,10 @@ import zio._
 
 import java.io.IOException
 
-val helloZIO: ZIO[Has[Console], IOException, Unit] =
+val helloZIO: ZIO[Console, IOException, Unit] =
   Console.printLine("Hello") <*> Console.printLine("ZIO")
 
-val zioHello: ZIO[Has[Console], IOException, Unit] =
+val zioHello: ZIO[Console, IOException, Unit] =
   Console.printLine("ZIO") <*> Console.printLine("Hello")
 ```
 
@@ -50,10 +50,10 @@ The first will print `Hello` to the console on one line followed by `ZIO` on the
 We can also see this in the context of failures.
 
 ```scala mdoc
-val failZIO: ZIO[Has[Console], IOException, Unit] =
+val failZIO: ZIO[Console, IOException, Unit] =
   ZIO.fail(new IOException("Fail")) <*> Console.printLine("ZIO")
 
-val zioFail: ZIO[Has[Console], IOException, (Unit, Unit)] =
+val zioFail: ZIO[Console, IOException, (Unit, Unit)] =
   Console.printLine("ZIO") <*> ZIO.fail(new IOException("Fail"))
 ```
 
@@ -64,7 +64,7 @@ What would a commutative version of this operator be? It would have to run both 
 The `zipPar` operator on `ZIO` does just this.
 
 ```scala mdoc
-val helloZIOPar: ZIO[Has[Console], IOException, Unit] =
+val helloZIOPar: ZIO[Console, IOException, Unit] =
   Console.printLine("Hello") <&> Console.printLine("ZIO")
 ```
 

--- a/docs/functionalabstractions/parameterizedtypes/commutativeeither.md
+++ b/docs/functionalabstractions/parameterizedtypes/commutativeeither.md
@@ -36,10 +36,10 @@ import zio._
 
 import java.io.IOException
 
-val helloZIO: ZIO[Has[Console], IOException, Either[Unit, Unit]] =
+val helloZIO: ZIO[Console, IOException, Either[Unit, Unit]] =
   Console.printLine("Hello").orElseEither(Console.printLine("ZIO"))
 
-val zioHello: ZIO[Has[Console], IOException, Either[Unit, Unit]] =
+val zioHello: ZIO[Console, IOException, Either[Unit, Unit]] =
   Console.printLine("ZIO").orElseEither(Console.printLine("Hello"))
 ```
 
@@ -58,10 +58,10 @@ import zio._
 
 import java.io.IOException
 
-val helloZIO: ZIO[Has[Console], IOException, Either[Unit, Unit]] =
+val helloZIO: ZIO[Console, IOException, Either[Unit, Unit]] =
   Console.printLine("Hello").raceEither(Console.printLine("ZIO"))
 
-val zioHello: ZIO[Has[Console], IOException, Either[Unit, Unit]] =
+val zioHello: ZIO[Console, IOException, Either[Unit, Unit]] =
   Console.printLine("ZIO").raceEither(Console.printLine("Hello"))
 ```
 

--- a/docs/functionalabstractions/parameterizedtypes/identityboth.md
+++ b/docs/functionalabstractions/parameterizedtypes/identityboth.md
@@ -37,10 +37,10 @@ import zio._
 
 import java.io.IOException
 
-val helloUnit: ZIO[Has[Console], IOException, Unit] =
+val helloUnit: ZIO[Console, IOException, Unit] =
   Console.printLine("Hello") <*> ZIO.unit
 
-val unitHello: ZIO[Has[Console], IOException, Unit] =
+val unitHello: ZIO[Console, IOException, Unit] =
   ZIO.unit <*> Console.printLine("Hello")
 ```
 

--- a/docs/functionalabstractions/parameterizedtypes/identityflatten.md
+++ b/docs/functionalabstractions/parameterizedtypes/identityflatten.md
@@ -38,7 +38,7 @@ import zio._
 
 import java.io.IOException
 
-val helloIdentity: ZIO[Has[Console], IOException, Unit] =
+val helloIdentity: ZIO[Console, IOException, Unit] =
   ZIO.unit.map { _ =>
     Console.printLine("Hello from an identity!")
   }.flatten

--- a/experimental/shared/src/main/scala/zio/prelude/experimental/BothCompose.scala
+++ b/experimental/shared/src/main/scala/zio/prelude/experimental/BothCompose.scala
@@ -17,8 +17,6 @@
 package zio.prelude
 package experimental
 
-import zio._
-
 trait BothCompose[=>:[-_, +_]] extends AssociativeCompose[=>:] {
 
   type :*:[+_, +_]
@@ -76,50 +74,51 @@ object BothCompose {
 
   }
 
-  implicit val URIOApplicationCompose: BothCompose[URIO] = new BothCompose[URIO] {
-
-    type :*:[+f, +s] = Tuple2[f, s]
-
-    def fromFirst[A]: URIO[(A, Any), A] = URIO.access[(A, Any)](_._1)
-
-    def fromSecond[B]: URIO[(Any, B), B] = URIO.access[(Any, B)](_._2)
-
-    def toBoth[A, B, C](a2b: URIO[A, B])(a2c: URIO[A, C]): URIO[A, (B, C)] =
-      a2b.zip(a2c)
-
-    def compose[A, B, C](bc: URIO[B, C], ab: URIO[A, B]): URIO[A, C] =
-      AssociativeCompose.URIOIdentityCompose.compose(bc, ab)
-  }
-
-  implicit val URLayerApplicationCompose: BothCompose[URLayer] = new BothCompose[URLayer] {
-
-    type :*:[+f, +s] = Tuple2[f, s]
-
-    def fromFirst[A]: URLayer[(A, Any), A] = ZLayer.first
-
-    def fromSecond[B]: URLayer[(Any, B), B] = ZLayer.second
-
-    def toBoth[A, B, C](a2b: URLayer[A, B])(a2c: URLayer[A, C]): URLayer[A, (B, C)] =
-      a2b <&> a2c
-
-    def compose[A, B, C](bc: URLayer[B, C], ab: URLayer[A, B]): URLayer[A, C] =
-      AssociativeCompose.URLayerIdentityCompose.compose(bc, ab)
-  }
-
-  implicit val URManagedApplicationCompose: BothCompose[URManaged] = new BothCompose[URManaged] {
-
-    type :*:[+f, +s] = Tuple2[f, s]
-
-    def fromFirst[A]: URManaged[(A, Any), A] = ZManaged.access(_._1)
-
-    def fromSecond[B]: URManaged[(Any, B), B] = ZManaged.access(_._2)
-
-    def toBoth[A, B, C](a2b: URManaged[A, B])(a2c: URManaged[A, C]): URManaged[A, (B, C)] =
-      a2b.zip(a2c)
-
-    def compose[A, B, C](bc: URManaged[B, C], ab: URManaged[A, B]): URManaged[A, C] =
-      AssociativeCompose.URManagedIdentityCompose.compose(bc, ab)
-  }
+//  implicit val URIOApplicationCompose: BothCompose[({ type lambda[-r, +a] = URIO[r, ZEnvironment[a]] })#lambda] =
+//    new BothCompose[({ type lambda[-r, +a] = URIO[r, ZEnvironment[a]] })#lambda] {
+//
+//      type :*:[+f, +s] = Tuple2[f, s]
+//
+//      def fromFirst[A]: URIO[(A, Any), A] = URIO.environmentWith[(A, Any)](x => x)
+//
+//      def fromSecond[B]: URIO[(Any, B), B] = URIO.access[(Any, B)](_._2)
+//
+//      def toBoth[A, B, C](a2b: URIO[A, ZEnvironment[B]])(a2c: URIO[A, ZEnvironment[C]]): URIO[A, ZEnvironment[(B, C)]] =
+//        a2b.zip(a2c)
+//
+//      def compose[A, B, C](bc: URIO[B, ZEnvironment[C]], ab: URIO[A, ZEnvironment[B]]): URIO[A, ZEnvironment[C]] =
+//        AssociativeCompose.URIOIdentityCompose.compose(bc, ab)
+//    }
+//
+//  implicit val URLayerApplicationCompose: BothCompose[URLayer] = new BothCompose[URLayer] {
+//
+//    type :*:[+f, +s] = Tuple2[f, s]
+//
+//    def fromFirst[A]: URLayer[(A, Any), A] = ZLayer.first
+//
+//    def fromSecond[B]: URLayer[(Any, B), B] = ZLayer.second
+//
+//    def toBoth[A, B, C](a2b: URLayer[A, B])(a2c: URLayer[A, C]): URLayer[A, (B, C)] =
+//      a2b <&> a2c
+//
+//    def compose[A, B, C](bc: URLayer[B, C], ab: URLayer[A, B]): URLayer[A, C] =
+//      AssociativeCompose.URLayerIdentityCompose.compose(bc, ab)
+//  }
+//
+//  implicit val URManagedApplicationCompose: BothCompose[URManaged] = new BothCompose[URManaged] {
+//
+//    type :*:[+f, +s] = Tuple2[f, s]
+//
+//    def fromFirst[A]: URManaged[(A, Any), A] = ZManaged.access(_._1)
+//
+//    def fromSecond[B]: URManaged[(Any, B), B] = ZManaged.access(_._2)
+//
+//    def toBoth[A, B, C](a2b: URManaged[A, B])(a2c: URManaged[A, C]): URManaged[A, (B, C)] =
+//      a2b.zip(a2c)
+//
+//    def compose[A, B, C](bc: URManaged[B, C], ab: URManaged[A, B]): URManaged[A, C] =
+//      AssociativeCompose.URManagedIdentityCompose.compose(bc, ab)
+//  }
 
 }
 

--- a/experimental/shared/src/main/scala/zio/prelude/experimental/BothCompose.scala
+++ b/experimental/shared/src/main/scala/zio/prelude/experimental/BothCompose.scala
@@ -74,52 +74,6 @@ object BothCompose {
 
   }
 
-//  implicit val URIOApplicationCompose: BothCompose[({ type lambda[-r, +a] = URIO[r, ZEnvironment[a]] })#lambda] =
-//    new BothCompose[({ type lambda[-r, +a] = URIO[r, ZEnvironment[a]] })#lambda] {
-//
-//      type :*:[+f, +s] = Tuple2[f, s]
-//
-//      def fromFirst[A]: URIO[(A, Any), A] = URIO.environmentWith[(A, Any)](x => x)
-//
-//      def fromSecond[B]: URIO[(Any, B), B] = URIO.access[(Any, B)](_._2)
-//
-//      def toBoth[A, B, C](a2b: URIO[A, ZEnvironment[B]])(a2c: URIO[A, ZEnvironment[C]]): URIO[A, ZEnvironment[(B, C)]] =
-//        a2b.zip(a2c)
-//
-//      def compose[A, B, C](bc: URIO[B, ZEnvironment[C]], ab: URIO[A, ZEnvironment[B]]): URIO[A, ZEnvironment[C]] =
-//        AssociativeCompose.URIOIdentityCompose.compose(bc, ab)
-//    }
-//
-//  implicit val URLayerApplicationCompose: BothCompose[URLayer] = new BothCompose[URLayer] {
-//
-//    type :*:[+f, +s] = Tuple2[f, s]
-//
-//    def fromFirst[A]: URLayer[(A, Any), A] = ZLayer.first
-//
-//    def fromSecond[B]: URLayer[(Any, B), B] = ZLayer.second
-//
-//    def toBoth[A, B, C](a2b: URLayer[A, B])(a2c: URLayer[A, C]): URLayer[A, (B, C)] =
-//      a2b <&> a2c
-//
-//    def compose[A, B, C](bc: URLayer[B, C], ab: URLayer[A, B]): URLayer[A, C] =
-//      AssociativeCompose.URLayerIdentityCompose.compose(bc, ab)
-//  }
-//
-//  implicit val URManagedApplicationCompose: BothCompose[URManaged] = new BothCompose[URManaged] {
-//
-//    type :*:[+f, +s] = Tuple2[f, s]
-//
-//    def fromFirst[A]: URManaged[(A, Any), A] = ZManaged.access(_._1)
-//
-//    def fromSecond[B]: URManaged[(Any, B), B] = ZManaged.access(_._2)
-//
-//    def toBoth[A, B, C](a2b: URManaged[A, B])(a2c: URManaged[A, C]): URManaged[A, (B, C)] =
-//      a2b.zip(a2c)
-//
-//    def compose[A, B, C](bc: URManaged[B, C], ab: URManaged[A, B]): URManaged[A, C] =
-//      AssociativeCompose.URManagedIdentityCompose.compose(bc, ab)
-//  }
-
 }
 
 trait BothComposeSyntax {

--- a/experimental/shared/src/main/scala/zio/prelude/experimental/EitherCompose.scala
+++ b/experimental/shared/src/main/scala/zio/prelude/experimental/EitherCompose.scala
@@ -17,8 +17,6 @@
 package zio.prelude
 package experimental
 
-import zio._
-
 trait EitherCompose[=>:[-_, +_]] extends AssociativeCompose[=>:] {
 
   type :+:[+_, +_]
@@ -63,65 +61,65 @@ object EitherCompose {
     }
   }
 
-  implicit val URIOEitherCompose: EitherCompose[URIO] = new EitherCompose[URIO] {
-
-    type :+:[+l, +r] = Either[l, r]
-
-    def toLeft[A]: URIO[A, Either[A, Nothing]] = URIO.access(Left(_))
-
-    def toRight[B]: URIO[B, Either[Nothing, B]] = URIO.access(Right(_))
-
-    def fromEither[A, B, C](a2c: => URIO[A, C])(b2c: => URIO[B, C]): URIO[Either[A, B], C] = for {
-      either <- ZIO.environment[Either[A, B]]
-      a1     <- either.fold(a2c.provide(_), b2c.provide(_))
-    } yield a1
-
-    def compose[A, B, C](bc: URIO[B, C], ab: URIO[A, B]): URIO[A, C] =
-      AssociativeCompose.URIOIdentityCompose.compose(bc, ab)
-  }
-
-  implicit val URLayerEitherCompose: EitherCompose[URLayer] = new EitherCompose[URLayer] {
-
-    type :+:[+l, +r] = Either[l, r]
-
-    def toLeft[A]: URLayer[A, Either[A, Nothing]] = ZLayer.environment[A].map(Left(_))
-
-    def toRight[B]: URLayer[B, Either[Nothing, B]] = ZLayer.environment[B].map(Right(_))
-
-    def fromEither[A, B, C](a2c: => URLayer[A, C])(b2c: => URLayer[B, C]): URLayer[Either[A, B], C] = {
-      val right: ZLayer[Either[A, B], A, B]                   =
-        ZLayer.fromFunctionManyZIO[Either[A, B], A, B] {
-          case Left(a)  => ZIO.fail(a)
-          case Right(b) => ZIO.succeed(b)
-        }
-      val unright: URLayer[(Either[A, B], Cause[A]), A]       =
-        ZLayer.fromFunctionManyZIO[(Either[A, B], Cause[A]), Nothing, A] { case (_, cause) =>
-          cause.failureOrCause.fold(ZIO.succeed(_), ZIO.failCause(_))
-        }
-      val handleFailure: URLayer[(Either[A, B], Cause[A]), C] = unright >>> a2c
-      right.fold(handleFailure, b2c)
-    }
-
-    def compose[A, B, C](bc: URLayer[B, C], ab: URLayer[A, B]): URLayer[A, C] =
-      AssociativeCompose.URLayerIdentityCompose.compose(bc, ab)
-  }
-
-  implicit val URManagedEitherCompose: EitherCompose[URManaged] = new EitherCompose[URManaged] {
-
-    type :+:[+l, +r] = Either[l, r]
-
-    def toLeft[A]: URManaged[A, Either[A, Nothing]] = ZManaged.access(Left(_))
-
-    def toRight[B]: URManaged[B, Either[Nothing, B]] = ZManaged.access(Right(_))
-
-    def fromEither[A, B, C](a2c: => URManaged[A, C])(b2c: => URManaged[B, C]): URManaged[Either[A, B], C] = for {
-      either <- ZManaged.environment[Either[A, B]]
-      a1     <- either.fold(a2c.provide(_), b2c.provide(_))
-    } yield a1
-
-    def compose[A, B, C](bc: URManaged[B, C], ab: URManaged[A, B]): URManaged[A, C] =
-      AssociativeCompose.URManagedIdentityCompose.compose(bc, ab)
-  }
+//  implicit val URIOEitherCompose: EitherCompose[URIO] = new EitherCompose[URIO] {
+//
+//    type :+:[+l, +r] = Either[l, r]
+//
+//    def toLeft[A]: URIO[A, Either[A, Nothing]] = URIO.access(Left(_))
+//
+//    def toRight[B]: URIO[B, Either[Nothing, B]] = URIO.access(Right(_))
+//
+//    def fromEither[A, B, C](a2c: => URIO[A, C])(b2c: => URIO[B, C]): URIO[Either[A, B], C] = for {
+//      either <- ZIO.environment[Either[A, B]]
+//      a1     <- either.fold(a2c.provide(_), b2c.provide(_))
+//    } yield a1
+//
+//    def compose[A, B, C](bc: URIO[B, C], ab: URIO[A, B]): URIO[A, C] =
+//      AssociativeCompose.URIOIdentityCompose.compose(bc, ab)
+//  }
+//
+//  implicit val URLayerEitherCompose: EitherCompose[URLayer] = new EitherCompose[URLayer] {
+//
+//    type :+:[+l, +r] = Either[l, r]
+//
+//    def toLeft[A]: URLayer[A, Either[A, Nothing]] = ZLayer.environment[A].map(Left(_))
+//
+//    def toRight[B]: URLayer[B, Either[Nothing, B]] = ZLayer.environment[B].map(Right(_))
+//
+//    def fromEither[A, B, C](a2c: => URLayer[A, C])(b2c: => URLayer[B, C]): URLayer[Either[A, B], C] = {
+//      val right: ZLayer[Either[A, B], A, B]                   =
+//        ZLayer.fromFunctionManyZIO[Either[A, B], A, B] {
+//          case Left(a)  => ZIO.fail(a)
+//          case Right(b) => ZIO.succeed(b)
+//        }
+//      val unright: URLayer[(Either[A, B], Cause[A]), A]       =
+//        ZLayer.fromFunctionManyZIO[(Either[A, B], Cause[A]), Nothing, A] { case (_, cause) =>
+//          cause.failureOrCause.fold(ZIO.succeed(_), ZIO.failCause(_))
+//        }
+//      val handleFailure: URLayer[(Either[A, B], Cause[A]), C] = unright >>> a2c
+//      right.fold(handleFailure, b2c)
+//    }
+//
+//    def compose[A, B, C](bc: URLayer[B, C], ab: URLayer[A, B]): URLayer[A, C] =
+//      AssociativeCompose.URLayerIdentityCompose.compose(bc, ab)
+//  }
+//
+//  implicit val URManagedEitherCompose: EitherCompose[URManaged] = new EitherCompose[URManaged] {
+//
+//    type :+:[+l, +r] = Either[l, r]
+//
+//    def toLeft[A]: URManaged[A, Either[A, Nothing]] = ZManaged.access(Left(_))
+//
+//    def toRight[B]: URManaged[B, Either[Nothing, B]] = ZManaged.access(Right(_))
+//
+//    def fromEither[A, B, C](a2c: => URManaged[A, C])(b2c: => URManaged[B, C]): URManaged[Either[A, B], C] = for {
+//      either <- ZManaged.environment[Either[A, B]]
+//      a1     <- either.fold(a2c.provide(_), b2c.provide(_))
+//    } yield a1
+//
+//    def compose[A, B, C](bc: URManaged[B, C], ab: URManaged[A, B]): URManaged[A, C] =
+//      AssociativeCompose.URManagedIdentityCompose.compose(bc, ab)
+//  }
 }
 
 trait EitherComposeSyntax {

--- a/experimental/shared/src/main/scala/zio/prelude/experimental/EitherCompose.scala
+++ b/experimental/shared/src/main/scala/zio/prelude/experimental/EitherCompose.scala
@@ -61,65 +61,6 @@ object EitherCompose {
     }
   }
 
-//  implicit val URIOEitherCompose: EitherCompose[URIO] = new EitherCompose[URIO] {
-//
-//    type :+:[+l, +r] = Either[l, r]
-//
-//    def toLeft[A]: URIO[A, Either[A, Nothing]] = URIO.access(Left(_))
-//
-//    def toRight[B]: URIO[B, Either[Nothing, B]] = URIO.access(Right(_))
-//
-//    def fromEither[A, B, C](a2c: => URIO[A, C])(b2c: => URIO[B, C]): URIO[Either[A, B], C] = for {
-//      either <- ZIO.environment[Either[A, B]]
-//      a1     <- either.fold(a2c.provide(_), b2c.provide(_))
-//    } yield a1
-//
-//    def compose[A, B, C](bc: URIO[B, C], ab: URIO[A, B]): URIO[A, C] =
-//      AssociativeCompose.URIOIdentityCompose.compose(bc, ab)
-//  }
-//
-//  implicit val URLayerEitherCompose: EitherCompose[URLayer] = new EitherCompose[URLayer] {
-//
-//    type :+:[+l, +r] = Either[l, r]
-//
-//    def toLeft[A]: URLayer[A, Either[A, Nothing]] = ZLayer.environment[A].map(Left(_))
-//
-//    def toRight[B]: URLayer[B, Either[Nothing, B]] = ZLayer.environment[B].map(Right(_))
-//
-//    def fromEither[A, B, C](a2c: => URLayer[A, C])(b2c: => URLayer[B, C]): URLayer[Either[A, B], C] = {
-//      val right: ZLayer[Either[A, B], A, B]                   =
-//        ZLayer.fromFunctionManyZIO[Either[A, B], A, B] {
-//          case Left(a)  => ZIO.fail(a)
-//          case Right(b) => ZIO.succeed(b)
-//        }
-//      val unright: URLayer[(Either[A, B], Cause[A]), A]       =
-//        ZLayer.fromFunctionManyZIO[(Either[A, B], Cause[A]), Nothing, A] { case (_, cause) =>
-//          cause.failureOrCause.fold(ZIO.succeed(_), ZIO.failCause(_))
-//        }
-//      val handleFailure: URLayer[(Either[A, B], Cause[A]), C] = unright >>> a2c
-//      right.fold(handleFailure, b2c)
-//    }
-//
-//    def compose[A, B, C](bc: URLayer[B, C], ab: URLayer[A, B]): URLayer[A, C] =
-//      AssociativeCompose.URLayerIdentityCompose.compose(bc, ab)
-//  }
-//
-//  implicit val URManagedEitherCompose: EitherCompose[URManaged] = new EitherCompose[URManaged] {
-//
-//    type :+:[+l, +r] = Either[l, r]
-//
-//    def toLeft[A]: URManaged[A, Either[A, Nothing]] = ZManaged.access(Left(_))
-//
-//    def toRight[B]: URManaged[B, Either[Nothing, B]] = ZManaged.access(Right(_))
-//
-//    def fromEither[A, B, C](a2c: => URManaged[A, C])(b2c: => URManaged[B, C]): URManaged[Either[A, B], C] = for {
-//      either <- ZManaged.environment[Either[A, B]]
-//      a1     <- either.fold(a2c.provide(_), b2c.provide(_))
-//    } yield a1
-//
-//    def compose[A, B, C](bc: URManaged[B, C], ab: URManaged[A, B]): URManaged[A, C] =
-//      AssociativeCompose.URManagedIdentityCompose.compose(bc, ab)
-//  }
 }
 
 trait EitherComposeSyntax {

--- a/laws/shared/src/main/scala/zio/prelude/laws/GenFs.scala
+++ b/laws/shared/src/main/scala/zio/prelude/laws/GenFs.scala
@@ -21,7 +21,7 @@ import zio.prelude.newtypes.Failure
 import zio.test.Gen.oneOf
 import zio.test._
 import zio.test.laws._
-import zio.{Cause, Exit, Has, NonEmptyChunk, Random, ZTraceElement}
+import zio.{Cause, Exit, NonEmptyChunk, Random, ZTraceElement}
 
 import scala.concurrent.Future
 import scala.util.Try
@@ -34,15 +34,15 @@ object GenFs {
   /**
    * A generator of failed `Cause` values.
    */
-  val cause: GenF[Has[Random] with Has[Sized], Cause] =
-    new GenF[Has[Random] with Has[Sized], Cause] {
-      def apply[R1 <: Has[Random] with Has[Sized], A](gen: Gen[R1, A])(implicit
+  val cause: GenF[Random with Sized, Cause] =
+    new GenF[Random with Sized, Cause] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A])(implicit
         trace: ZTraceElement
       ): Gen[R1, Cause[A]] =
         Gen.causes(gen, Gen.throwable)
     }
 
-  def either[R <: Has[Random] with Has[Sized], E](e: Gen[R, E]): GenF[R, ({ type lambda[+a] = Either[E, a] })#lambda] =
+  def either[R <: Random with Sized, E](e: Gen[R, E]): GenF[R, ({ type lambda[+a] = Either[E, a] })#lambda] =
     new GenF[R, ({ type lambda[+a] = Either[E, a] })#lambda] {
       def apply[R1 <: R, A](a: Gen[R1, A])(implicit trace: ZTraceElement): Gen[R1, Either[E, A]] =
         Gen.either(e, a)
@@ -51,7 +51,7 @@ object GenFs {
   /**
    * A generator of `Exit` values.
    */
-  def exit[R <: Has[Random] with Has[Sized], E](
+  def exit[R <: Random with Sized, E](
     e: Gen[R, Cause[E]]
   ): GenF[R, ({ type lambda[+a] = Exit[E, a] })#lambda] =
     new GenF[R, ({ type lambda[+a] = Exit[E, a] })#lambda] {
@@ -65,15 +65,15 @@ object GenFs {
   /**
    * A generator of `Future` values.
    */
-  val future: GenF[Has[Random] with Has[Sized], Future] =
-    new GenF[Has[Random] with Has[Sized], Future] {
-      def apply[R1 <: Has[Random] with Has[Sized], A](gen: Gen[R1, A])(implicit
+  val future: GenF[Random with Sized, Future] =
+    new GenF[Random with Sized, Future] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A])(implicit
         trace: ZTraceElement
       ): Gen[R1, Future[A]] =
         oneOf(Gen.throwable.map(Future.failed), gen.map(Future.successful))
     }
 
-  def map[R <: Has[Random] with Has[Sized], K](k: Gen[R, K]): GenF[R, ({ type lambda[+v] = Map[K, v] })#lambda] =
+  def map[R <: Random with Sized, K](k: Gen[R, K]): GenF[R, ({ type lambda[+v] = Map[K, v] })#lambda] =
     new GenF[R, ({ type lambda[+v] = Map[K, v] })#lambda] {
       def apply[R1 <: R, V](v: Gen[R1, V])(implicit trace: ZTraceElement): Gen[R1, Map[K, V]] =
         Gen.mapOf(k, v)
@@ -82,25 +82,25 @@ object GenFs {
   /**
    * A generator of `NonEmptyChunk` values.
    */
-  def nonEmptyChunk: GenF[Has[Random] with Has[Sized], NonEmptyChunk] =
-    new GenF[Has[Random] with Has[Sized], NonEmptyChunk] {
-      def apply[R1 <: Has[Random] with Has[Sized], A](gen: Gen[R1, A])(implicit
+  def nonEmptyChunk: GenF[Random with Sized, NonEmptyChunk] =
+    new GenF[Random with Sized, NonEmptyChunk] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A])(implicit
         trace: ZTraceElement
       ): Gen[R1, NonEmptyChunk[A]] =
         Gen.chunkOf1(gen)
     }
 
-  def nonEmptyList: GenF[Has[Random] with Has[Sized], NonEmptyList] =
-    new GenF[Has[Random] with Has[Sized], NonEmptyList] {
-      def apply[R1 <: Has[Random] with Has[Sized], A](gen: Gen[R1, A])(implicit
+  def nonEmptyList: GenF[Random with Sized, NonEmptyList] =
+    new GenF[Random with Sized, NonEmptyList] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A])(implicit
         trace: ZTraceElement
       ): Gen[R1, NonEmptyList[A]] =
         Gens.nonEmptyListOf(gen)
     }
 
-  def nonEmptySet: GenF[Has[Random] with Has[Sized], NonEmptySet] =
-    new GenF[Has[Random] with Has[Sized], NonEmptySet] {
-      def apply[R1 <: Has[Random] with Has[Sized], A](gen: Gen[R1, A])(implicit
+  def nonEmptySet: GenF[Random with Sized, NonEmptySet] =
+    new GenF[Random with Sized, NonEmptySet] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A])(implicit
         trace: ZTraceElement
       ): Gen[R1, NonEmptySet[A]] =
         Gens.nonEmptySetOf(gen)
@@ -109,7 +109,7 @@ object GenFs {
   /**
    * A generator of `ParSeq` values.
    */
-  def parSeq[R <: Has[Random] with Has[Sized], Z <: Unit](
+  def parSeq[R <: Random with Sized, Z <: Unit](
     z: Gen[R, Z]
   ): GenF[R, ({ type lambda[+x] = ParSeq[Z, x] })#lambda] =
     new GenF[R, ({ type lambda[+x] = ParSeq[Z, x] })#lambda] {
@@ -120,19 +120,19 @@ object GenFs {
   /**
    * A generator of `Try` values.
    */
-  val tryScala: GenF[Has[Random] with Has[Sized], Try] =
-    new GenF[Has[Random] with Has[Sized], Try] {
-      def apply[R1 <: Has[Random] with Has[Sized], A](gen: Gen[R1, A])(implicit trace: ZTraceElement): Gen[R1, Try[A]] =
+  val tryScala: GenF[Random with Sized, Try] =
+    new GenF[Random with Sized, Try] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A])(implicit trace: ZTraceElement): Gen[R1, Try[A]] =
         oneOf(Gen.throwable.map(scala.util.Failure(_)), gen.map(scala.util.Success(_)))
     }
 
-  def tuple2[R <: Has[Random] with Has[Sized], A](a: Gen[R, A]): GenF[R, ({ type lambda[+x] = (A, x) })#lambda] =
+  def tuple2[R <: Random with Sized, A](a: Gen[R, A]): GenF[R, ({ type lambda[+x] = (A, x) })#lambda] =
     new GenF[R, ({ type lambda[+x] = (A, x) })#lambda] {
       def apply[R1 <: R, B](b: Gen[R1, B])(implicit trace: ZTraceElement): Gen[R1, (A, B)] =
         a.zip(b)
     }
 
-  def tuple3[R <: Has[Random] with Has[Sized], A, B](
+  def tuple3[R <: Random with Sized, A, B](
     a: Gen[R, A],
     b: Gen[R, B]
   ): GenF[R, ({ type lambda[+c] = (A, B, c) })#lambda] =
@@ -141,7 +141,7 @@ object GenFs {
         a.zip(b).zip(c)
     }
 
-  def validation[R <: Has[Random] with Has[Sized], W, E](
+  def validation[R <: Random with Sized, W, E](
     w: Gen[R, W],
     e: Gen[R, E]
   ): GenF[R, ({ type lambda[+x] = ZValidation[W, E, x] })#lambda] =
@@ -150,7 +150,7 @@ object GenFs {
         Gens.validation(w, e, a)
     }
 
-  def validationFailure[R <: Has[Random] with Has[Sized], W, A](
+  def validationFailure[R <: Random with Sized, W, A](
     w: Gen[R, W],
     a: Gen[R, A]
   ): GenF[R, ({ type lambda[+x] = Failure[ZValidation[W, x, A]] })#lambda] =

--- a/laws/shared/src/main/scala/zio/prelude/laws/Gens.scala
+++ b/laws/shared/src/main/scala/zio/prelude/laws/Gens.scala
@@ -16,11 +16,11 @@
 
 package zio.prelude.laws
 
+import zio.Random
 import zio.prelude._
 import zio.prelude.fx.Cause
 import zio.prelude.newtypes.Natural
 import zio.test._
-import zio.{Has, Random}
 
 /**
  * Provides generators for data types from _ZIO Prelude_.
@@ -30,17 +30,17 @@ object Gens {
   /**
    * A generator of natural numbers. Shrinks toward '0'.
    */
-  val anyNatural: Gen[Has[Random], Natural] =
+  val anyNatural: Gen[Random, Natural] =
     natural(Natural.zero, Natural.unsafeMake(Int.MaxValue))
 
   /**
    * A generator of natural numbers inside the specified range: [start, end].
    * The shrinker will shrink toward the lower end of the range ("smallest").
    */
-  def natural(min: Natural, max: Natural): Gen[Has[Random], Natural] =
+  def natural(min: Natural, max: Natural): Gen[Random, Natural] =
     Gen.int(min, max).map(Natural.unsafeMake)
 
-  def parSeq[R <: Has[Random] with Has[Sized], Z <: Unit, A](z: Gen[R, Z], a: Gen[R, A]): Gen[R, ParSeq[Z, A]] = {
+  def parSeq[R <: Random with Sized, Z <: Unit, A](z: Gen[R, Z], a: Gen[R, A]): Gen[R, ParSeq[Z, A]] = {
     val failure = a.map(Cause.single)
     val empty   = z.map(_ => Cause.empty.asInstanceOf[ParSeq[Nothing, Nothing]])
 
@@ -71,19 +71,19 @@ object Gens {
   /**
    * A generator of `NonEmptyList` values.
    */
-  def nonEmptyListOf[R <: Has[Random] with Has[Sized], A](a: Gen[R, A]): Gen[R, NonEmptyList[A]] =
+  def nonEmptyListOf[R <: Random with Sized, A](a: Gen[R, A]): Gen[R, NonEmptyList[A]] =
     Gen.listOf1(a).map(NonEmptyList.fromCons)
 
   /**
    * A generator of `NonEmptyMultiSet` values.
    */
-  def nonEmptyMultiSetOf[R <: Has[Random] with Has[Sized], A](a: Gen[R, A]): Gen[R, NonEmptyMultiSet[A]] =
+  def nonEmptyMultiSetOf[R <: Random with Sized, A](a: Gen[R, A]): Gen[R, NonEmptyMultiSet[A]] =
     Gen.mapOf1(a, Gen.size.map(Natural.unsafeMake)).map(NonEmptyMultiSet.fromMapOption(_).get)
 
   /**
    * A generator of `NonEmptySet` values.
    */
-  def nonEmptySetOf[R <: Has[Random] with Has[Sized], A](a: Gen[R, A]): Gen[R, NonEmptySet[A]] =
+  def nonEmptySetOf[R <: Random with Sized, A](a: Gen[R, A]): Gen[R, NonEmptySet[A]] =
     Gen.setOf1(a).map(NonEmptySet.fromSetOption(_).get)
 
   /**
@@ -95,7 +95,7 @@ object Gens {
   /**
    * A generator of `Validation` values.
    */
-  def validation[R <: Has[Random] with Has[Sized], W, E, A](
+  def validation[R <: Random with Sized, W, E, A](
     w: Gen[R, W],
     e: Gen[R, E],
     a: Gen[R, A]

--- a/scala-parallel-collections/src/test/scala/zio/prelude/scalaparallelcollections/AssociativeFlattenJvmSpec.scala
+++ b/scala-parallel-collections/src/test/scala/zio/prelude/scalaparallelcollections/AssociativeFlattenJvmSpec.scala
@@ -5,7 +5,7 @@ import com.github.ghik.silencer.silent
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, Random, ZTraceElement}
+import zio.{Random, ZTraceElement}
 
 import scala.collection.parallel.{immutable => par}
 
@@ -23,7 +23,7 @@ object AssociativeFlattenJvmSpec extends DefaultRunnableSpec {
   }
   import ParallelCollectionCompatibility._
 
-  def genParMap[R <: Has[Random] with Has[Sized], K](
+  def genParMap[R <: Random with Sized, K](
     k: Gen[R, K]
   ): GenF[R, ({ type lambda[+v] = par.ParMap[K, v] })#lambda] =
     new GenF[R, ({ type lambda[+v] = par.ParMap[K, v] })#lambda] {

--- a/scala-parallel-collections/src/test/scala/zio/prelude/scalaparallelcollections/ForEachJvmSpec.scala
+++ b/scala-parallel-collections/src/test/scala/zio/prelude/scalaparallelcollections/ForEachJvmSpec.scala
@@ -5,7 +5,7 @@ import com.github.ghik.silencer.silent
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, Random, ZTraceElement}
+import zio.{Random, ZTraceElement}
 
 import scala.collection.parallel.{immutable => par}
 
@@ -23,7 +23,7 @@ object ForEachJvmSpec extends DefaultRunnableSpec {
   }
   import ParallelCollectionCompatibility._
 
-  def genParMap[R <: Has[Random] with Has[Sized], K](
+  def genParMap[R <: Random with Sized, K](
     k: Gen[R, K]
   ): GenF[R, ({ type lambda[+v] = par.ParMap[K, v] })#lambda] =
     new GenF[R, ({ type lambda[+v] = par.ParMap[K, v] })#lambda] {
@@ -31,9 +31,9 @@ object ForEachJvmSpec extends DefaultRunnableSpec {
         Gen.mapOf(k, v).map(_.par)
     }
 
-  val genParSeq: GenF[Has[Random] with Has[Sized], par.ParSeq] =
-    new GenF[Has[Random] with Has[Sized], par.ParSeq] {
-      def apply[R1 <: Has[Random] with Has[Sized], A](gen: Gen[R1, A])(implicit
+  val genParSeq: GenF[Random with Sized, par.ParSeq] =
+    new GenF[Random with Sized, par.ParSeq] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A])(implicit
         trace: ZTraceElement
       ): Gen[R1, par.ParSeq[A]] =
         Gen.listOf(gen).map(_.par)

--- a/scala-parallel-collections/src/test/scala/zio/prelude/scalaparallelcollections/IdentityFlattenJvmSpec.scala
+++ b/scala-parallel-collections/src/test/scala/zio/prelude/scalaparallelcollections/IdentityFlattenJvmSpec.scala
@@ -5,7 +5,7 @@ import com.github.ghik.silencer.silent
 import zio.prelude.laws._
 import zio.test._
 import zio.test.laws._
-import zio.{Has, Random, ZTraceElement}
+import zio.{Random, ZTraceElement}
 
 import scala.collection.parallel.{immutable => par}
 
@@ -23,9 +23,9 @@ object IdentityFlattenJvmSpec extends DefaultRunnableSpec {
   }
   import ParallelCollectionCompatibility._
 
-  val genParSeq: GenF[Has[Random] with Has[Sized], par.ParSeq] =
-    new GenF[Has[Random] with Has[Sized], par.ParSeq] {
-      def apply[R1 <: Has[Random] with Has[Sized], A](gen: Gen[R1, A])(implicit
+  val genParSeq: GenF[Random with Sized, par.ParSeq] =
+    new GenF[Random with Sized, par.ParSeq] {
+      def apply[R1 <: Random with Sized, A](gen: Gen[R1, A])(implicit
         trace: ZTraceElement
       ): Gen[R1, par.ParSeq[A]] =
         Gen.listOf(gen).map(_.par)


### PR DESCRIPTION
This is still WIP, because I'm struggling a bit with this update.
Something, can be easily fixed on the ZIO side, like https://github.com/zio/zio/pull/6112
But some things are more serious, like the new encoding of environment (`ZEnvironment`). It makes it (almost, hopefully) impossible to define many instances, because it often requires a `Tag` or `IsNotIntersection` which are not available (AFAIK).
If you had some time @adamgfraser @kitlangton , I'd greatly appreciate if you could give this a whirl too, since I suppose you're more experienced with this new `ZEnvironment` business. :pray: 
