### PR TITLE
fix Assertion.matches when using |

### DIFF
--- a/core-tests/shared/src/test/scala/zio/prelude/AssertionSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/AssertionSpec.scala
@@ -1,0 +1,19 @@
+package zio.prelude
+
+import zio.test.Assertion._
+import zio.test.{DefaultRunnableSpec, ZSpec, assert}
+
+object AssertionSpec extends DefaultRunnableSpec {
+
+  def spec: ZSpec[Environment, Failure] = suite("Assertion")(
+    test("matches must fail when the regex only match a part of the string") {
+      assert((Assertion.matches("biking").apply("toto like biking")))(isLeft(anything))
+    },
+    test("matches must fail when a regexp using | only match a part of the string") {
+      assert((Assertion.matches("swimming|biking").apply("toto like biking")))(isLeft(anything))
+    },
+    test("matches must work when the regex only match the full string") {
+      assert((Assertion.matches("t.*g").apply("toto like biking")))(isRight(isUnit))
+    }
+  )
+}

--- a/macros/shared/src/main/scala/zio/prelude/Assertion.scala
+++ b/macros/shared/src/main/scala/zio/prelude/Assertion.scala
@@ -232,8 +232,7 @@ object Assertion {
 
   private[prelude] case class Matches(regexString: String) extends Assertion[String] {
     def apply(a: String, negated: Boolean): Either[AssertionError, Unit] = {
-      val compiled = s"^$regexString$$".r
-      val result   = compiled.findFirstIn(a).isDefined
+      val result = a.matches(regexString)
       if (!negated) {
         if (result) Right(())
         else Left(AssertionError.Failure(s"matches(${regexString.r})"))


### PR DESCRIPTION
Before my fix the following test was failing:
```
    test("matches must fail when a regexp using | only match a part of the string") {
      assert((Assertion.matches("swimming|biking").apply("toto like biking")))(isLeft(anything))
    },
```
This was du to:
```
s"^$regexString$$".r
```
That would produce the regexp: `^swimming|biking$` which is equivalent to: `(^swimming)|(biking$)`.
Another solution could have been to use:
```
s"^$(?:regexString)$$".r
```