### PR TITLE
Make Equivalence subtype of PartialEquivalence

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Equivalence.scala
+++ b/core/shared/src/main/scala/zio/prelude/Equivalence.scala
@@ -29,7 +29,14 @@ package zio.prelude
  * @param to   A function that converts an `A` into a `B`.
  * @param from A function that converts a `B` into an `A`.
  */
-final case class Equivalence[A, B](to: A => B, from: B => A) { self =>
+trait Equivalence[A, B] extends PartialEquivalence[A, B, Nothing, Nothing] { self =>
+
+  def to: A => B
+  def from: B => A
+
+  final def toPartial: A => Either[Nothing, B] = (a: A) => Right(to(a))
+
+  final def fromPartial: B => Either[Nothing, A] = (b: B) => Right(from(b))
 
   /**
    * Composes this equivalence with the specified equivalence.
@@ -47,17 +54,28 @@ final case class Equivalence[A, B](to: A => B, from: B => A) { self =>
   /**
    * Flips this equivalence around.
    */
-  def flip: Equivalence[B, A] = Equivalence(from, to)
+  override def flip: Equivalence[B, A] = Equivalence(from, to)
 
-  /**
-   * Converts this equivalence to a partial equivalence that cannot fail in
-   * either direction.
-   */
-  def toPartialEquivalence: PartialEquivalence[A, B, Nothing, Nothing] =
-    PartialEquivalence((a: A) => Right(to(a)), (b: B) => Right(from(b)))
 }
 
 object Equivalence {
+
+  def apply[A, B](to0: A => B, from0: B => A): Equivalence[A, B] = new Equivalence[A, B] {
+    override def to: A => B   = to0
+    override def from: B => A = from0
+  }
+
+  def fromPartial[A, B, E1, E2](
+    toPartial0: A => Either[E1, B],
+    fromPartial0: B => Either[E2, A]
+  )(ev1: E1 <:< Nothing, ev2: E2 <:< Nothing): Equivalence[A, B] =
+    Equivalence(
+      toPartial0.andThen { case Left(value) => ev1(value); case Right(value) => value },
+      fromPartial0.andThen { case Left(value) => ev2(value); case Right(value) => value }
+    )
+
+  def unapply[A, B](self: Equivalence[A, B]): Some[(A => B, B => A)] =
+    Some((self.to, self.from))
 
   /**
    * Constructs the identity equivalence, which just says that any type is

--- a/core/shared/src/main/scala/zio/prelude/PartialEquivalence.scala
+++ b/core/shared/src/main/scala/zio/prelude/PartialEquivalence.scala
@@ -19,37 +19,53 @@ package zio.prelude
 import com.github.ghik.silencer.silent
 
 @silent("Unused import")
-final case class PartialEquivalence[A, B, +E1, +E2](to: A => Either[E1, B], from: B => Either[E2, A]) { self =>
+trait PartialEquivalence[A, B, +E1, +E2] { self =>
   import PartialEquivalence._
   import zio._ // for zio.EitherCompat
+
+  def toPartial: A => Either[E1, B]
+
+  def fromPartial: B => Either[E2, A]
 
   def >>>[C, E3 >: E1, E4 >: E2](that: PartialEquivalence[B, C, E3, E4]): PartialEquivalence[A, C, E3, E4] =
     self andThen that
 
   def andThen[C, E3 >: E1, E4 >: E2](that: PartialEquivalence[B, C, E3, E4]): PartialEquivalence[A, C, E3, E4] =
-    PartialEquivalence(self.to andThen (_.flatMap(that.to)), that.from andThen (_.flatMap(self.from)))
+    PartialEquivalence(
+      self.toPartial andThen (_.flatMap(that.toPartial)),
+      that.fromPartial andThen (_.flatMap(self.fromPartial))
+    )
 
   def canonicalLeft(a: A): Option[A] = canonicalLeftOrError[Any](a).fold(_ => None, Some(_))
 
   def canonicalLeftOrError[E](a: A)(implicit ev1: E1 <:< E, ev2: E2 <:< E): Either[E, A] =
-    to(a).left.map(ev1).flatMap(b => from(b).left.map(ev2))
+    toPartial(a).left.map(ev1).flatMap(b => fromPartial(b).left.map(ev2))
 
   def canonicalRight(b: B): Option[B] = canonicalRightOrError[Any](b).fold(_ => None, Some(_))
 
   def canonicalRightOrError[E](b: B)(implicit ev1: E1 <:< E, ev2: E2 <:< E): Either[E, B] =
-    from(b).left.map(ev2).flatMap(a => to(a).left.map(ev1))
+    fromPartial(b).left.map(ev2).flatMap(a => toPartial(a).left.map(ev1))
 
   def compose[C, E3 >: E1, E4 >: E2](that: PartialEquivalence[C, A, E3, E4]): PartialEquivalence[C, B, E3, E4] =
     that andThen self
 
-  def flip: PartialEquivalence[B, A, E2, E1] = PartialEquivalence(from, to)
-
-  def toEquivalence(implicit ev1: E1 <:< Nothing, ev2: E2 <:< Nothing): Equivalence[A, B] =
-    Equivalence((a: A) => toRight(to(a).left.map(ev1)), (b: B) => toRight(from(b).left.map(ev2)))
+  def flip: PartialEquivalence[B, A, E2, E1] = PartialEquivalence(fromPartial, toPartial)
 }
 
 object PartialEquivalence {
-  def identity[A]: PartialEquivalence[A, A, Nothing, Nothing] = Equivalence.identity[A].toPartialEquivalence
 
-  private def toRight[A](either: Either[Nothing, A]): A = either.fold(Predef.identity, Predef.identity)
+  def apply[A, B, E1, E2](
+    toPartial0: A => Either[E1, B],
+    fromPartial0: B => Either[E2, A]
+  ): PartialEquivalence[A, B, E1, E2] =
+    new PartialEquivalence[A, B, E1, E2] {
+      override def toPartial: A => Either[E1, B]   = toPartial0
+      override def fromPartial: B => Either[E2, A] = fromPartial0
+    }
+
+  def unapply[A, B, E1, E2](self: PartialEquivalence[A, B, E1, E2]): Some[(A => Either[E1, B], B => Either[E2, A])] =
+    Some((self.toPartial, self.fromPartial))
+
+  def identity[A]: Equivalence[A, A] = Equivalence.identity[A]
+
 }


### PR DESCRIPTION
We're all about subtyping and variance here at ZIO Prelude, so I was thinking it could be elegant (and also practical for our users) to express `Equivalence` as a specialization of `PartialEquivalence`.
What do you think?
