### PR TITLE
Add keySet/values method to NonEmptyMap and NonEmptySortedMap

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/NonEmptyMap.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyMap.scala
@@ -49,6 +49,16 @@ final class NonEmptyMap[K, V] private (private val map: Map[K, V]) { self =>
       (head, Some(newMap(tail)))
   }
 
+  def keySet: NonEmptySet[K] = {
+    val (head, tail) = peel
+    NonEmptySet.fromIterable(head._1, tail.keys)
+  }
+
+  def values: NonEmptyChunk[V] = {
+    val (head, tail) = peel
+    NonEmptyChunk.fromIterable(head._2, tail.values)
+  }
+
   /**
    * Creates a new `NonEmptyMap` with an additional element, unless the element is
    *  already present.

--- a/core/shared/src/main/scala/zio/prelude/NonEmptySortedMap.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptySortedMap.scala
@@ -52,6 +52,16 @@ final class NonEmptySortedMap[K, V] private (private val map: SortedMap[K, V])(i
       (head, Some(newMap(tail)))
   }
 
+  def keySet: NonEmptySortedSet[K] = {
+    val (head, tail) = peel
+    NonEmptySortedSet(head._1, tail.keySet)
+  }
+
+  def values: NonEmptyChunk[V] = {
+    val (head, tail) = peel
+    NonEmptyChunk.fromIterable(head._2, tail.values)
+  }
+
   /**
    * Creates a new `NonEmptySortedMap` with an additional element, unless the element is
    *  already present.


### PR DESCRIPTION
It would be better if we can leverage the non-emptiness and provide the NonEmpty version of `keySet` and `values` method in NonEmptyMap and NonEmptySortedMap