### PR TITLE
Add support for Debug derivation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -193,6 +193,44 @@ lazy val experimentalTests = crossProject(JSPlatform, JVMPlatform, NativePlatfor
   .nativeSettings(nativeSettings)
   .enablePlugins(BuildInfoPlugin)
 
+lazy val derivation = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .in(file("derivation"))
+  .dependsOn(core, core % "test->test")
+  .settings(stdSettings("zio-prelude-derivation"))
+  .settings(crossProjectSettings)
+  .settings(buildInfoSettings("zio.prelude.derivation"))
+  .settings(
+    libraryDependencies ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, _)) =>
+          Vector(
+            "com.softwaremill.magnolia1_3" %%% "magnolia" % "1.1.5"
+          )
+
+        case _ =>
+          Vector(
+            "org.scala-lang"                 % "scala-reflect" % scalaVersion.value % Provided,
+            "com.softwaremill.magnolia1_2" %%% "magnolia"      % "1.1.3"
+          )
+      }
+    }
+  )
+  .enablePlugins(BuildInfoPlugin)
+
+lazy val derivationTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
+  .in(file("derivation-tests"))
+  .dependsOn(derivation)
+  .settings(stdSettings("zio-prelude-derivation-tests"))
+  .settings(crossProjectSettings)
+  .settings(buildInfoSettings("zio.prelude.derivation.tests"))
+  .settings(testFrameworks := Seq(new TestFramework("zio.test.sbt.ZTestFramework")))
+  .settings(dottySettings)
+  .settings(libraryDependencies += "dev.zio" %%% "zio-test-sbt" % zioVersion % Test)
+  .jvmSettings(scalaReflectTestSettings)
+  .jsSettings(jsSettings)
+  .nativeSettings(nativeSettings)
+  .enablePlugins(BuildInfoPlugin)
+
 lazy val scalaParallelCollections = project
   .in(file("scala-parallel-collections"))
   .dependsOn(core.jvm, coreTests.jvm % "test->test")

--- a/core/shared/src/main/scala/zio/prelude/Debug.scala
+++ b/core/shared/src/main/scala/zio/prelude/Debug.scala
@@ -416,6 +416,12 @@ object Debug extends DebugVersionSpecific {
     nonEmptyChunk => Repr.VConstructor(List("zio"), "NonEmptyChunk", nonEmptyChunk.map(_.debug).toList)
 
   /**
+   * Derives a `Debug[Set[A]]` given a `Debug[A]`.
+   */
+  implicit def SetDebug[A: Debug]: Debug[Set[A]] =
+    set => Repr.VConstructor(List("scala", "collection", "immutable"), "Set", set.map(_.debug).toList)
+
+  /**
    * The `Debug`instance for `Nothing`. Note that since there are no values of
    * type `Nothing` this `Debug` instance can never be called.
    */

--- a/core/shared/src/main/scala/zio/prelude/NonEmptyMap.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyMap.scala
@@ -17,6 +17,7 @@ package zio.prelude
  */
 
 import zio.NonEmptyChunk
+import zio.prelude.Debug.keyValueDebug
 
 import scala.language.implicitConversions
 
@@ -214,6 +215,11 @@ object NonEmptyMap {
     new NonEmptyMap(asLists)
   }
 
+  /**
+   * Derives a `Debug[NonEmptyMap[K, V]]` given a `Debug[K]` and a `Debug[V]`.
+   */
+  implicit def NonEmptyMapDebug[K: Debug, V: Debug]: Debug[NonEmptyMap[K, V]] =
+    map => Debug.Repr.VConstructor(List("zio", "prelude"), "NonEmptyMap", map.toMap.map(_.debug(keyValueDebug)).toList)
 }
 
 trait NonEmptyMapSyntax {

--- a/core/shared/src/main/scala/zio/prelude/NonEmptySortedMap.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptySortedMap.scala
@@ -17,6 +17,7 @@ package zio.prelude
  */
 
 import zio.NonEmptyChunk
+import zio.prelude.Debug.keyValueDebug
 
 import scala.collection.immutable.SortedMap
 import scala.language.implicitConversions
@@ -183,6 +184,12 @@ object NonEmptySortedMap {
 
   private val NonEmptyMapSeed: Int = 1147820194
 
+  /**
+   * Derives a `Debug[NonEmptySortedMap[K, V]]` given a `Debug[K]` and a `Debug[V]`.
+   */
+  implicit def NonEmptySortedMapDebug[K: Debug, V: Debug]: Debug[NonEmptySortedMap[K, V]] =
+    map =>
+      Debug.Repr.VConstructor(List("zio", "prelude"), "NonEmptySortedMap", map.toMap.map(_.debug(keyValueDebug)).toList)
 }
 
 trait NonEmptySortedMapSyntax {

--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -349,6 +349,16 @@ object ZValidation extends LowPriorityValidationImplicits {
     }
 
   /**
+   * Derives a `Debug[Validation[E, A]]` given a `Debug[E]` and a `Debug[A]`.
+   */
+  implicit def ValidationDebug[E: Debug, A: Debug]: Debug[Validation[E, A]] = {
+    case ZValidation.Failure(_, errors) =>
+      Debug.Repr.VConstructor(List("zio", "prelude"), "ZValidation.Failure", List(errors.debug))
+    case ZValidation.Success(_, value)  =>
+      Debug.Repr.VConstructor(List("zio", "prelude"), "ZValidation.Success", List(value.debug))
+  }
+
+  /**
    * Derives a `Debug[ZValidation[W, E, A]]` given a `Debug[W], a `Debug[E]`,
    * and a `Debug[A]`.
    */

--- a/derivation-tests/shared/src/test/scala/zio/prelude/derivation/tests/DeriveDebugSpec.scala
+++ b/derivation-tests/shared/src/test/scala/zio/prelude/derivation/tests/DeriveDebugSpec.scala
@@ -1,0 +1,59 @@
+package zio.prelude.derivation.tests
+
+import zio._
+import zio.prelude._
+import zio.prelude.derivation.DeriveDebug
+import zio.test._
+
+object DeriveDebugSpec extends ZIOSpecDefault {
+  sealed trait Entity
+  object Entity {
+    case class Person(name: String, address: Address) extends Entity
+    object Person {
+      implicit val debug: Debug[Person] = DeriveDebug.gen[Person]
+    }
+
+    case class Organization(name: String, contacts: List[Person]) extends Entity
+
+    // need to keep it as not implicit, or the derivation would reference itself for the subtype's instances
+    // and runs into StackOverflow in the runtime
+    val debug: Debug[Entity] = DeriveDebug.gen[Entity]
+  }
+
+  case class Address(lines: List[String], country: Country)
+  object Address {
+    implicit val debug: Debug[Address] = DeriveDebug.gen[Address]
+  }
+
+  case class Country(name: String, code: String, salesTax: Boolean)
+  object Country {
+    implicit val debug: Debug[Country] = DeriveDebug.gen[Country]
+  }
+
+  case object ExampleObject {
+    implicit val debug: Debug[ExampleObject.type] = DeriveDebug.gen[ExampleObject.type]
+  }
+
+  case class ValueClass(value: String) extends AnyVal
+  object ValueClass {
+    implicit val debug: Debug[ValueClass] = DeriveDebug.gen[ValueClass]
+  }
+
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("DeriveDebugSpec")(
+    test("should be able to derive Debug instance for case classes and sealed traits") {
+      implicit val implicitDebug: Debug[Entity] = Entity.debug
+
+      val caseClassSample            = Address(List("foo"), Country("bar", "baz", salesTax = true))
+      val sealedTraitExample: Entity = Entity.Organization("some-org", List(Entity.Person("qux", caseClassSample)))
+
+      assertTrue(sealedTraitExample.render.nonEmpty)
+    },
+    test("should be able to derive Debug instance for case object") {
+      assertTrue(ExampleObject.render.nonEmpty)
+    },
+    test("should be able to derive Debug instance for value class") {
+      assertTrue(ValueClass("sample-value-class").render.nonEmpty)
+    }
+  )
+
+}

--- a/derivation/shared/src/main/scala/zio/prelude/derivation/DeriveDebug.scala
+++ b/derivation/shared/src/main/scala/zio/prelude/derivation/DeriveDebug.scala
@@ -1,0 +1,38 @@
+package zio.prelude.derivation
+
+import magnolia1._
+import zio.prelude.Debug
+import zio.prelude.Debug.Repr
+
+import scala.collection.immutable.ListMap
+import scala.language.experimental.macros
+object DeriveDebug {
+
+  type Typeclass[T] = Debug[T]
+
+  def join[T](ctx: CaseClass[Debug, T]): Debug[T] =
+    if (ctx.isValueClass) { (a: T) =>
+      Repr.VConstructor(
+        ctx.typeName.owner.split('.').toList,
+        ctx.typeName.short,
+        ctx.parameters.map(p => p.typeclass.debug(p.dereference(a))).toList
+      )
+    } else if (ctx.isObject) { (_: T) =>
+      Repr.Object(ctx.typeName.owner.split('.').toList, ctx.typeName.short)
+    } else { (a: T) =>
+      Repr.Constructor(
+        ctx.typeName.owner.split('.').toList,
+        ctx.typeName.short,
+        ListMap.from(ctx.parameters.map(p => p.label -> p.typeclass.debug(p.dereference(a))))
+      )
+    }
+
+  def split[T](ctx: SealedTrait[Debug, T]): Debug[T] =
+    new Debug[T] { self =>
+      def debug(a: T): Repr = ctx.split(a) { sub =>
+        sub.typeclass.debug(sub.cast(a))
+      }
+    }
+
+  def gen[T]: Debug[T] = macro Magnolia.gen[T]
+}


### PR DESCRIPTION
`Debug` is a nice feature, but without the auto derivation, it's not very practical to use it in a project.

This PR adds the support for auto derivation through magnolia. But due to the limitation of magnolia, it requires the type parameter in Debug to be invariant. Which is a drawback of adding the support.