### PR TITLE
Avoid ambiguity of NewtypeF

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/NewtypeModuleF.scala
+++ b/core/shared/src/main/scala/zio/prelude/NewtypeModuleF.scala
@@ -207,8 +207,8 @@ private[prelude] sealed trait NewtypeModuleF {
 private[prelude] object NewtypeModuleF {
   val instance: NewtypeModuleF =
     new NewtypeModuleF {
-      def newtypeF: NewtypeF =
-        new NewtypeF {
+      def newtypeF: this.NewtypeF =
+        new this.NewtypeF {
           type Type[+A] = A
 
           def wrapAll[F[_], A](value: F[A]): F[A] = value
@@ -216,8 +216,8 @@ private[prelude] object NewtypeModuleF {
           def unwrapAll[F[_], A](value: F[A]): F[A] = value
         }
 
-      def subtypeF: SubtypeF =
-        new SubtypeF {
+      def subtypeF: this.SubtypeF =
+        new this.SubtypeF {
           type Type[+A] = A
 
           def wrapAll[F[_], A](value: F[A]): F[A] = value


### PR DESCRIPTION
NewtypeF is both inherited and defined in the package object.

Disambiguate by selecting this.NewtypeF.

The ambiguity will error in Scala 3.3.