### PR TITLE
Add Product and Serializable interfaces to These

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/These.scala
+++ b/core/shared/src/main/scala/zio/prelude/These.scala
@@ -40,7 +40,7 @@ import zio.prelude.These._
  * information regarding all errors while still potentially returning a
  * successful computation.
  */
-sealed trait These[+A, +B] { self =>
+sealed trait These[+A, +B] extends Product with Serializable { self =>
 
   /**
    * A symbolic alias for `zipParRight`.


### PR DESCRIPTION
It helps with type inference and with avoiding issues where unrelated types are pushed into the same collection(see the `Product` and `Serializable` warts here: https://www.wartremover.org/doc/warts.html)