### PR TITLE
Optimize `forEach_`

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -709,6 +709,9 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
         nonEmptyChunk
           .reduceMapLeft(f(_).map(ChunkBuilder.make() += _))((bs, a) => bs.zipWith(f(a))(_ += _))
           .map(bs => NonEmptyChunk.nonEmpty(bs.result()))
+
+      override def forEach1_[F[+_]: AssociativeBoth: Covariant, A](fa: NonEmptyChunk[A])(f: A => F[Any]): F[Unit] =
+        fa.reduceMapLeft(f(_).unit)((acc, a) => acc.tap(_ => f(a)))
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/NonEmptyForEach.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyForEach.scala
@@ -62,6 +62,9 @@ trait NonEmptyForEach[F[+_]] extends ForEach[F] {
   def forEach1_[G[+_]: AssociativeBoth: Covariant, A](fa: F[A])(f: A => G[Any]): G[Unit] =
     forEach1(fa)(f).as(())
 
+  override def forEach_[G[+_]: IdentityBoth: Covariant, A](fa: F[A])(f: A => G[Any]): G[Unit] =
+    forEach1_(fa)(f)
+
   /**
    * Returns the largest value in the collection if one exists or `None`
    * otherwise.

--- a/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -570,6 +570,9 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
     new NonEmptyForEach[NonEmptyList] {
       def forEach1[F[+_]: AssociativeBoth: Covariant, A, B](fa: NonEmptyList[A])(f: A => F[B]): F[NonEmptyList[B]] =
         fa.forEach(f)
+
+      override def forEach1_[F[+_]: AssociativeBoth: Covariant, A](fa: NonEmptyList[A])(f: A => F[Any]): F[Unit] =
+        fa.foldLeft(f(fa.head).unit)((acc, a) => acc.tap(_ => f(a)))
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
+++ b/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
@@ -188,7 +188,7 @@ trait CovariantIdentityBoth[F[+_]] extends Covariant[F] with IdentityBoth[F] { s
     in.foldLeft(bf.newBuilder(in).succeed)((bs, a) => bs.zipWith(f(a))(_ += _)).map(_.result())
 
   def forEach_[A, B](in: Iterable[A])(f: A => F[Any]): F[Unit] =
-    forEach(in)(f).unit
+    in.foldLeft(().succeed)((acc, a) => acc.tap(_ => f(a)))
 }
 
 object CovariantIdentityBoth {


### PR DESCRIPTION
I ran ForEachBenchmark for a single time. 
Their are significant changes in result for `zioForEach_Option` case using `ListForEach`
(because `ZIO` and `ZPure` both have their own `forEachDiscard` implementation)

before
```
[info] ForEachBenchmarks.zioForEach_Option    100000  thrpt    5   870.152 ±  11.041  ops/s
```

after
```
[info] ForEachBenchmarks.zioForEach_Option    100000  thrpt    5  4893.541 ± 282.137  ops/s
```