### PR TITLE
Delete Confusing Extension Methods

### DIFF
--- a/core-tests/shared/src/test/scala/zio/prelude/PartialOrdSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/PartialOrdSpec.scala
@@ -22,9 +22,15 @@ object PartialOrdSpec extends ZIOBaseSpec {
         assert(PartialOrd.compareSoft(Map(1 -> 2), Map(1 -> 3, 2 -> 4)))(equalTo(Ordering.LessThan)) &&
         assert(PartialOrd.compareSoft(Map(1 -> 3, 2 -> 4), Map(1 -> 2)))(equalTo(Ordering.GreaterThan)) &&
         assert(PartialOrd.compareSoft(Map(1 -> 2), Map(2 -> 2)))(equalTo(PartialOrdering.Incomparable)) &&
-        assert(PartialOrd.compareSoft(Map(1 -> 2, 3 -> 3), Map(3 -> 3, 2 -> 2)))(equalTo(PartialOrdering.Incomparable)) &&
-        assert(PartialOrd.compareSoft(Map(1 -> 2, 3 -> 3), Map(3 -> 1, 2 -> 2)))(equalTo(PartialOrdering.Incomparable)) &&
-        assert(PartialOrd.compareSoft(Map("William" -> "Will"), Map("William" -> "Bill")))(equalTo(Ordering.GreaterThan))
+        assert(PartialOrd.compareSoft(Map(1 -> 2, 3 -> 3), Map(3 -> 3, 2 -> 2)))(
+          equalTo(PartialOrdering.Incomparable)
+        ) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 2, 3 -> 3), Map(3 -> 1, 2 -> 2)))(
+          equalTo(PartialOrdering.Incomparable)
+        ) &&
+        assert(PartialOrd.compareSoft(Map("William" -> "Will"), Map("William" -> "Bill")))(
+          equalTo(Ordering.GreaterThan)
+        )
       }
     )
 }

--- a/core-tests/shared/src/test/scala/zio/prelude/PartialOrdSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/PartialOrdSpec.scala
@@ -13,18 +13,18 @@ object PartialOrdSpec extends ZIOBaseSpec {
         test("set")(checkAllLaws(PartialOrdLaws)(Gen.setOf(Gen.int)))
       ),
       test("map compareSoft") {
-        assert(Map.empty[Int, Int] compareSoft Map.empty[Int, Int])(equalTo(Ordering.Equals)) &&
-        assert(Map(1 -> 2) compareSoft Map.empty[Int, Int])(equalTo(Ordering.GreaterThan)) &&
-        assert(Map.empty[Int, Int] compareSoft Map(1 -> 2))(equalTo(Ordering.LessThan)) &&
-        assert(Map(1 -> 2) compareSoft Map(1 -> 2))(equalTo(Ordering.Equals)) &&
-        assert(Map(1 -> 2) compareSoft Map(1 -> 3))(equalTo(Ordering.LessThan)) &&
-        assert(Map(1 -> 3) compareSoft Map(1 -> 2))(equalTo(Ordering.GreaterThan)) &&
-        assert(Map(1 -> 2) compareSoft Map(1 -> 3, 2 -> 4))(equalTo(Ordering.LessThan)) &&
-        assert(Map(1 -> 3, 2 -> 4) compareSoft Map(1 -> 2))(equalTo(Ordering.GreaterThan)) &&
-        assert(Map(1 -> 2) compareSoft Map(2 -> 2))(equalTo(PartialOrdering.Incomparable)) &&
-        assert(Map(1 -> 2, 3 -> 3) compareSoft Map(3 -> 3, 2 -> 2))(equalTo(PartialOrdering.Incomparable)) &&
-        assert(Map(1 -> 2, 3 -> 3) compareSoft Map(3 -> 1, 2 -> 2))(equalTo(PartialOrdering.Incomparable)) &&
-        assert(Map("William" -> "Will") compareSoft Map("William" -> "Bill"))(equalTo(Ordering.GreaterThan))
+        assert(PartialOrd.compareSoft(Map.empty[Int, Int], Map.empty[Int, Int]))(equalTo(Ordering.Equals)) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 2), Map.empty[Int, Int]))(equalTo(Ordering.GreaterThan)) &&
+        assert(PartialOrd.compareSoft(Map.empty[Int, Int], Map(1 -> 2)))(equalTo(Ordering.LessThan)) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 2), Map(1 -> 2)))(equalTo(Ordering.Equals)) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 2), Map(1 -> 3)))(equalTo(Ordering.LessThan)) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 3), Map(1 -> 2)))(equalTo(Ordering.GreaterThan)) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 2), Map(1 -> 3, 2 -> 4)))(equalTo(Ordering.LessThan)) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 3, 2 -> 4), Map(1 -> 2)))(equalTo(Ordering.GreaterThan)) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 2), Map(2 -> 2)))(equalTo(PartialOrdering.Incomparable)) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 2, 3 -> 3), Map(3 -> 3, 2 -> 2)))(equalTo(PartialOrdering.Incomparable)) &&
+        assert(PartialOrd.compareSoft(Map(1 -> 2, 3 -> 3), Map(3 -> 1, 2 -> 2)))(equalTo(PartialOrdering.Incomparable)) &&
+        assert(PartialOrd.compareSoft(Map("William" -> "Will"), Map("William" -> "Bill")))(equalTo(Ordering.GreaterThan))
       }
     )
 }

--- a/core/shared/src/main/scala/zio/prelude/Divariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Divariant.scala
@@ -96,10 +96,10 @@ object Divariant {
   implicit val Function1Divariant: Divariant[Function1] =
     new Divariant[Function1] {
       override def leftContramap[A, B, C](c2a: C => A): (A => B) => C => B = { a2b => c =>
-        c |> c2a |> a2b
+        a2b(c2a(c))
       }
       override def rightMap[A, B, C](b2c: B => C): (A => B) => A => C      = { a2b => a =>
-        a |> a2b |> b2c
+        b2c(a2b(a))
       }
     }
 }

--- a/core/shared/src/main/scala/zio/prelude/Equal.scala
+++ b/core/shared/src/main/scala/zio/prelude/Equal.scala
@@ -330,7 +330,7 @@ object Equal extends EqualVersionSpecific {
   implicit def MapPartialOrd[A, B: Equal]: PartialOrd[Map[A, B]] = new PartialOrd[Map[A, B]] {
 
     protected def checkCompare(l: Map[A, B], r: Map[A, B]): PartialOrdering =
-      l.compareStrict(r)
+      PartialOrd.compareStrict(l, r)
 
     override protected def checkEqual(l: Map[A, B], r: Map[A, B]): Boolean =
       l.size == r.size &&

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -709,7 +709,9 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
         nonEmptyChunk
           .reduceMapLeft(f(_).map(ChunkBuilder.make() += _))((bs, a) => bs.zipWith(f(a))(_ += _))
           .map(bs => NonEmptyChunk.nonEmpty(bs.result()))
-      override def forEach1_[F[+_]: AssociativeBoth: Covariant, A](nonEmptyChunk: NonEmptyChunk[A])(f: A => F[Any]): F[Unit] =
+      override def forEach1_[F[+_]: AssociativeBoth: Covariant, A](nonEmptyChunk: NonEmptyChunk[A])(
+        f: A => F[Any]
+      ): F[Unit] =
         nonEmptyChunk.reduceMapLeft(f(_))((bs, a) => bs *> f(a)).unit
     }
 

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -709,6 +709,8 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
         nonEmptyChunk
           .reduceMapLeft(f(_).map(ChunkBuilder.make() += _))((bs, a) => bs.zipWith(f(a))(_ += _))
           .map(bs => NonEmptyChunk.nonEmpty(bs.result()))
+      override def forEach1_[F[+_]: AssociativeBoth: Covariant, A](nonEmptyChunk: NonEmptyChunk[A])(f: A => F[Any]): F[Unit] =
+        nonEmptyChunk.reduceMapLeft(f(_))((bs, a) => bs *> f(a)).unit
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/NonEmptyForEach.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyForEach.scala
@@ -59,6 +59,13 @@ trait NonEmptyForEach[F[+_]] extends ForEach[F] {
    * Traverses each element in the collection with the specified effectual
    * function `f` purely for its effects.
    */
+  override def forEach_[G[+_]: IdentityBoth: Covariant, A](fa: F[A])(f: A => G[Any]): G[Unit] =
+    forEach1_(fa)(f)
+
+  /**
+   * Traverses each element in the collection with the specified effectual
+   * function `f` purely for its effects.
+   */
   def forEach1_[G[+_]: AssociativeBoth: Covariant, A](fa: F[A])(f: A => G[Any]): G[Unit] =
     forEach1(fa)(f).as(())
 

--- a/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -570,7 +570,7 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
     new NonEmptyForEach[NonEmptyList] {
       def forEach1[F[+_]: AssociativeBoth: Covariant, A, B](fa: NonEmptyList[A])(f: A => F[B]): F[NonEmptyList[B]] =
         fa.forEach(f)
-      override def forEach1_[F[+_]: AssociativeBoth: Covariant, A](fa: NonEmptyList[A])(f: A => F[Any]): F[Unit] =
+      override def forEach1_[F[+_]: AssociativeBoth: Covariant, A](fa: NonEmptyList[A])(f: A => F[Any]): F[Unit]   =
         reduceMapLeft(fa)(f(_))((fas, a) => fas *> f(a)).unit
     }
 

--- a/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptyList.scala
@@ -570,6 +570,8 @@ object NonEmptyList extends LowPriorityNonEmptyListImplicits {
     new NonEmptyForEach[NonEmptyList] {
       def forEach1[F[+_]: AssociativeBoth: Covariant, A, B](fa: NonEmptyList[A])(f: A => F[B]): F[NonEmptyList[B]] =
         fa.forEach(f)
+      override def forEach1_[F[+_]: AssociativeBoth: Covariant, A](fa: NonEmptyList[A])(f: A => F[Any]): F[Unit] =
+        reduceMapLeft(fa)(f(_))((fas, a) => fas *> f(a)).unit
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/ZSet.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZSet.scala
@@ -394,7 +394,10 @@ trait LowPriorityZSetImplicits {
    */
   implicit def ZSetPartialOrd[A, B: PartialOrd](implicit ev: Identity[Sum[B]]): PartialOrd[ZSet[A, B]] =
     PartialOrd.makeFrom(
-      (l, r) => l.toMap.filterNot(_._2 === ev.identity).compareSoft(r.toMap.filterNot(_._2 === ev.identity)),
+      (
+        l,
+        r
+      ) => PartialOrd.compareSoft(l.toMap.filterNot(_._2 === ev.identity), r.toMap.filterNot(_._2 === ev.identity)),
       ZSet.ZSetEqual
     )
 

--- a/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
+++ b/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
@@ -188,7 +188,7 @@ trait CovariantIdentityBoth[F[+_]] extends Covariant[F] with IdentityBoth[F] { s
     in.foldLeft(bf.newBuilder(in).succeed)((bs, a) => bs.zipWith(f(a))(_ += _)).map(_.result())
 
   def forEach_[A, B](in: Iterable[A])(f: A => F[Any]): F[Unit] =
-    forEach(in)(f).unit
+    in.foldLeft(identityBoth.any)((bs, a) => bs *> f(a)).unit
 }
 
 object CovariantIdentityBoth {


### PR DESCRIPTION
The extension methods defined in the ZIO Prelude package object that are not associated with a functional abstraction are extremely confusing. For example the `tap` operator is available on any data and calls a function, immediately discarding the result. Someone who is working with an effect type that doesn't implement `tap` might call this method, thinking that it is going to describe running their effect and then performing some other effect on the side, discarding its result. But it won't actually evaluate the other effect at all, just construct it and discard it.