### PR TITLE
Add `forEachCollectSome`

### DIFF
--- a/benchmarks/src/main/scala/zio/prelude/ForEachBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/prelude/ForEachBenchmark.scala
@@ -68,6 +68,26 @@ class ForEachBenchmarks {
   def zioForEach_ZPure(bh: Blackhole): Unit =
     bh.consume(list.forEach_(ZPure.succeed[Unit, Int](_)).run)
 
+  @Benchmark
+  def catsFilterTraverseOption(bh: Blackhole): Unit =
+    bh.consume(list.traverseFilter(a => Option(a.some)))
+
+  @Benchmark
+  def catsFilterTraverseCIO(bh: Blackhole): Unit =
+    bh.consume(list.traverseFilter(CIO.some))
+
+  @Benchmark
+  def zioForEachCollectSomeOption(bh: Blackhole): Unit =
+    bh.consume(list.forEachCollectSome(a => Option(Some(a))))
+
+  @Benchmark
+  def zioForEachCollectSomeZIO(bh: Blackhole): Unit =
+    bh.consume(unsafeRun(list.forEachCollectSome(a => ZIO.some(a))))
+
+  @Benchmark
+  def zioForEachCollectSomeZPure(bh: Blackhole): Unit =
+    bh.consume(list.forEachCollectSome(a => ZPure.succeed[Unit, Option[Int]](Some(a))).run)
+
   def unsafeRun[E, A](zio: ZIO[Any, E, A]): A =
     Unsafe.unsafe(implicit unsafe => Runtime.default.unsafe.run(zio).getOrThrowFiberFailure())
 }

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1247,7 +1247,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
         val builder  = bf.newBuilder(in)
 
         ZIO
-          .whileLoop(iterator.hasNext)(f(iterator.next()))(_.fold(builder)(builder += _))
+          .whileLoop(iterator.hasNext)(f(iterator.next()))(_.foreach(builder += _))
           .as(builder.result())
       }
     }

--- a/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
+++ b/core/shared/src/main/scala/zio/prelude/coherent/coherent.scala
@@ -189,6 +189,12 @@ trait CovariantIdentityBoth[F[+_]] extends Covariant[F] with IdentityBoth[F] { s
 
   def forEach_[A, B](in: Iterable[A])(f: A => F[Any]): F[Unit] =
     in.foldLeft(identityBoth.any)((bs, a) => bs *> f(a)).unit
+
+  def forEachCollectSome[A, B, Collection[+Element] <: Iterable[Element]](in: Collection[A])(f: A => F[Option[B]])(
+    implicit bf: BuildFrom[Collection[A], B, Collection[B]]
+  ): F[Collection[B]] =
+    in.foldLeft(bf.newBuilder(in).succeed)((bs, a) => bs.zipWith(f(a))((builder, b) => b.fold(builder)(builder += _)))
+      .map(_.result())
 }
 
 object CovariantIdentityBoth {

--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -1127,7 +1127,7 @@ object ZPure {
       val builder  = bf.newBuilder(in)
 
       lazy val recurse: Option[B] => ZPure[W, S, S, R, E, Collection[B]] = { b =>
-        b.fold(builder)(builder += _)
+        b.foreach(builder += _)
         loop()
       }
 

--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -1115,6 +1115,30 @@ object ZPure {
     }
 
   /**
+   * Maps each element of a collection to a computation and combines them all
+   * into a single computation that passes the updated state from each
+   * computation to the next and collects only results of type `Some[B]`.
+   */
+  def foreachCollectSome[W, S, R, E, A, B, Collection[+Element] <: Iterable[Element]](in: Collection[A])(
+    f: A => ZPure[W, S, S, R, E, Option[B]]
+  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]]): ZPure[W, S, S, R, E, Collection[B]] =
+    ZPure.suspend {
+      val iterator = in.iterator
+      val builder  = bf.newBuilder(in)
+
+      lazy val recurse: Option[B] => ZPure[W, S, S, R, E, Collection[B]] = { b =>
+        b.fold(builder)(builder += _)
+        loop()
+      }
+
+      def loop(): ZPure[W, S, S, R, E, Collection[B]] =
+        if (iterator.hasNext) f(iterator.next()).flatMap(recurse)
+        else ZPure.succeed(builder.result())
+
+      loop()
+    }
+
+  /**
    * Constructs a computation that returns the initial state unchanged.
    */
   def get[S]: ZPure[Nothing, S, S, Any, Nothing, S] =
@@ -1269,6 +1293,13 @@ object ZPure {
         f: A => ZPure[W, S, S, R, E, Any]
       ): ZPure[W, S, S, R, E, Unit] =
         ZPure.foreachDiscard(in)(f)
+
+      override def forEachCollectSome[A, B, Collection[+Element] <: Iterable[Element]](in: Collection[A])(
+        f: A => ZPure[W, S, S, R, E, Option[B]]
+      )(implicit
+        bf: zio.BuildFrom[Collection[A], B, Collection[B]]
+      ): ZPure[W, S, S, R, E, Collection[B]] =
+        ZPure.foreachCollectSome(in)(f)
     }
 
   /**


### PR DESCRIPTION
Hi, Here comes foreach filter again 😅 
Added  infix syntax `forEachCollectSome` of `collect` after `forEach`
(and there is one more for Iterable optimized, this is why the new syntax added instead of using composition of `collect` after `forEach` on demand)