### PR TITLE
Pattern-match on types instead of tags in ZPure#runAll

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
+++ b/core/shared/src/main/scala/zio/prelude/fx/ZPure.scala
@@ -33,7 +33,7 @@ import scala.util.Try
  * context, state, failure, and logging.
  */
 
-sealed abstract class ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
+sealed trait ZPure[+W, -S1, +S2, -R, +E, +A] { self =>
   import ZPure._
 
   /**


### PR DESCRIPTION
This PR optimizes the performance of ZPure by pattern matching on implementation types over tags.

While the reasoning on why this is more performant is still not very clear to me, I've noticed similar issues in Caliban and seem to be related to how the JVM optimizes (or in better terms, fails to optimize) interface dispatches. I've also noticed that [ZIO 1.x used the same pattern matching mechanism (via tags)](https://github.com/zio/zio/blob/192d4da106a6876f44b62c41894dffed96d95bcd/core/shared/src/main/scala/zio/internal/FiberContext.scala#L308-L312), but that was changed to [type-based pattern matching in ZIO 2.x](https://github.com/zio/zio/blob/8f391f96d5163dc395f4e7fe721b1c9d19b07a0f/core/shared/src/main/scala/zio/internal/FiberRuntime.scala#L866-L868)

With the changes in this PR, we get a ~20% performance improvement when running ZPure effects.

```scala
// Before
[info] Benchmark                                 (size)   Mode  Cnt     Score   Error  Units
[info] ForEachBenchmarks.zioForEachZPure         100000  thrpt    5   960.111 ± 8.891  ops/s
[info] ForEachBenchmarks.zioForEach_ZPure        100000  thrpt    5  1378.970 ± 9.880  ops/s

// After
[info] Benchmark                                 (size)   Mode  Cnt     Score    Error  Units
[info] ForEachBenchmarks.zioForEachZPure         100000  thrpt    5  1132.690 ± 36.274  ops/s
[info] ForEachBenchmarks.zioForEach_ZPure        100000  thrpt    5  1683.133 ± 17.517  ops/s
```