### PR TITLE
Making ClassTagWrapper public to solve issue #1253

### DIFF
--- a/core/shared/src/main/scala-2/zio/prelude/Newtype.scala
+++ b/core/shared/src/main/scala-2/zio/prelude/Newtype.scala
@@ -310,11 +310,11 @@ object Newtype {
     value.asInstanceOf[F[T#Type]]
   }
 
-  private trait ClassTagWrapper[-A] {
+  trait ClassTagWrapper[-A] {
     def classTag: ClassTag[_]
   }
 
-  private object ClassTagWrapper {
+  object ClassTagWrapper {
     def apply[A](implicit ev: ClassTagWrapper[A]): ClassTagWrapper[A] = ev
 
     implicit def classTagWrapperForNewtype[A](implicit underlying: ClassTag[A]): ClassTagWrapper[Newtype[A]] =


### PR DESCRIPTION
Solves:

https://github.com/zio/zio-prelude/issues/1253

(Error message: "object ClassTagWrapper in object Newtype cannot be accessed as a member of object zio.prelude.Newtype" when attempting to use a ClassTag on a Newtype or Subtype.)