### PR TITLE
Fixed #1312 - NonEmptySet#removeNonEmpty

### DIFF
--- a/core-tests/shared/src/test/scala/zio/prelude/NonEmptySetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/NonEmptySetSpec.scala
@@ -85,6 +85,15 @@ object NonEmptySetSpec extends DefaultRunnableSpec {
             val expected = as.map(f).flatten
             actual <-> expected
           }
+        },
+        testM("removeNonEmpty") {
+          check(genSet) { as =>
+            val toRemove = as.head
+            val actual   = NonEmptySet.fromSetOption(as).get.removeNonEmpty(toRemove).map(_.toSet)
+            val modified = as - toRemove
+            val expected = Option(modified).filter(_.nonEmpty)
+            actual <-> expected
+          }
         }
       ),
       suite("constructors")(

--- a/core/shared/src/main/scala/zio/prelude/NonEmptySet.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptySet.scala
@@ -101,7 +101,7 @@ final class NonEmptySet[A] private (private val set: Set[A]) { self =>
    */
   def removeNonEmpty(elem: A): Option[NonEmptySet[A]] = {
     val newSet = set - elem
-    if (newSet.nonEmpty) Some(new NonEmptySet(set)) else None
+    if (newSet.nonEmpty) Some(new NonEmptySet(newSet)) else None
   }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/NonEmptySortedSet.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptySortedSet.scala
@@ -103,7 +103,7 @@ final class NonEmptySortedSet[A] private (private val set: SortedSet[A]) { self 
    */
   def removeNonEmpty(elem: A): Option[NonEmptySortedSet[A]] = {
     val newSet = set - elem
-    if (newSet.nonEmpty) Some(new NonEmptySortedSet(set)) else None
+    if (newSet.nonEmpty) Some(new NonEmptySortedSet(newSet)) else None
   }
 
   /**


### PR DESCRIPTION
... and NonEmptySortedSet#removeNonEmpty

(cherry-picked from series/2.x commit)