### PR TITLE
`ZValidation#orElse` and `ZValidation#orElseLog` parameter must be lazy

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -212,14 +212,14 @@ sealed trait ZValidation[+W, +E, +A] { self =>
       case Success(w, a) => (w, Right(a))
     }
 
-  final def orElse[W1 >: W, E1, A1 >: A](that: ZValidation[W1, E1, A1]): ZValidation[W1, E1, A1] =
+  final def orElse[W1 >: W, E1, A1 >: A](that: => ZValidation[W1, E1, A1]): ZValidation[W1, E1, A1] =
     self match {
       case Failure(log, _)     => that.mapLogAll(log ++ _)
       case Success(log, value) => Success(log, value)
     }
 
   final def orElseLog[W1 >: W, E1, A1 >: A](
-    that: ZValidation[W1, E1, A1]
+    that: => ZValidation[W1, E1, A1]
   )(implicit ev: E <:< W1): ZValidation[W1, E1, A1] =
     self match {
       case Failure(log, errors) => that.mapLogAll(log ++ errors.map(ev) ++ _)


### PR DESCRIPTION
Do we want to implement tests for this change?