### PR TITLE
Update ZIO and enable Native multi-threading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,14 +181,12 @@ jobs:
           check-latest: true
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 7
       - name: Test on different Scala target platforms
-        run: ./sbt root${{ matrix.platform }}/test
+        run: ./sbt test{{ matrix.platform }}
 
   update-readme:
     name: Update README

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -XX:MaxMetaspaceSize=4G -Xmx4G -Xss8M # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  SBT_OPTS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G # Needed for sbt
   NODE_OPTIONS: --max_old_space_size=6144
 
 on:
@@ -29,8 +30,6 @@ jobs:
           check-latest: true
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:
@@ -57,8 +56,6 @@ jobs:
           check-latest: true
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:
@@ -85,8 +82,6 @@ jobs:
           registry-url: https://registry.npmjs.org
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:
@@ -118,8 +113,6 @@ jobs:
           check-latest: true
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:
@@ -153,8 +146,6 @@ jobs:
           check-latest: true
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:
@@ -198,8 +189,6 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           fetch-depth: '0'
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Setup Scala
         uses: actions/setup-java@v4.2.1
         with:
@@ -277,8 +266,6 @@ jobs:
           check-latest: true
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:
@@ -303,8 +290,6 @@ jobs:
         uses: actions/checkout@v4.1.7
         with:
           fetch-depth: '0'
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Setup Scala
         uses: actions/setup-java@v4.2.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
         with:
           swap-size-gb: 7
       - name: Test on different Scala target platforms
-        run: ./sbt test{{ matrix.platform }}
+        run: ./sbt test${{ matrix.platform }}
 
   update-readme:
     name: Update README

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,4 +1,4 @@
 -J-Xmx4G
 -J-Xms512M
--J-Xss8M
+-J-Xss4M
 -J-XX:+UseG1GC

--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,4 @@
+-J-Xmx4G
+-J-Xms512M
+-J-Xss8M
+-J-XX:+UseG1GC

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ addCommandAlias(
   ";coreTestsNative/test;experimentalTestsNative/test" // `test` currently executes only compilation, see `nativeSettings` in `BuildHelper`
 )
 
-val zioVersion = "2.1.7"
+val zioVersion = "2.1.8"
 
 val projectsCommon = List(
   core,

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
-import BuildHelper._
+import BuildHelper.*
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
-Global / concurrentRestrictions += Tags.limit(NativeTags.Link, 1)
+Global / concurrentRestrictions += Tags.limit(NativeTags.Link, java.lang.Runtime.getRuntime.availableProcessors())
 
 inThisBuild(
   List(
@@ -35,7 +35,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "testNative",
-  ";coreTestsNative/test;experimentalTestsNative/test" // `test` currently executes only compilation, see `nativeSettings` in `BuildHelper`
+  ";coreTestsNative/test;experimentalTestsNative/test"
 )
 
 val zioVersion = "2.1.8"

--- a/core-tests/shared/src/test/scala/zio/prelude/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/ZIOBaseSpec.scala
@@ -1,10 +1,12 @@
 package zio.prelude
 
 import zio._
+import zio.test.TestAspect._
 import zio.test._
 
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectAtLeastR[Environment with TestEnvironment]] =
-    if (TestPlatform.isJVM || TestPlatform.isNative) Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
-    else Chunk(TestAspect.timeout(60.seconds), TestAspect.sequential, TestAspect.timed)
+    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
+    else if (TestPlatform.isNative) Chunk(TestAspect.timeout(300.seconds), TestAspect.timed, size(10))
+    else Chunk(TestAspect.timeout(300.seconds), TestAspect.sequential, TestAspect.timed, size(10))
 }

--- a/core-tests/shared/src/test/scala/zio/prelude/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/ZIOBaseSpec.scala
@@ -5,6 +5,6 @@ import zio.test._
 
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectAtLeastR[Environment with TestEnvironment]] =
-    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
+    if (TestPlatform.isJVM || TestPlatform.isNative) Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
     else Chunk(TestAspect.timeout(60.seconds), TestAspect.sequential, TestAspect.timed)
 }

--- a/experimental-tests/shared/src/test/scala/zio/prelude/experimental/DistributiveProdSpec.scala
+++ b/experimental-tests/shared/src/test/scala/zio/prelude/experimental/DistributiveProdSpec.scala
@@ -4,6 +4,7 @@ package experimental
 import zio.prelude.experimental.laws._
 import zio.prelude.laws._
 import zio.test._
+import zio.test.TestAspect._
 import zio.test.laws._
 
 object DistributiveProdSpec extends ZIOBaseSpec {
@@ -15,5 +16,5 @@ object DistributiveProdSpec extends ZIOBaseSpec {
         test("ParSeq distributive multiply")(checkAllLaws(DistributiveProdLaws)(Gens.parSeq(Gen.unit, Gen.int))),
         test("fx.Cause distributive multiply")(checkAllLaws(DistributiveProdLaws)(Gens.parSeq(Gen.empty, Gen.int)))
       )
-    )
+    ) @@ exceptJVM(sequential)
 }

--- a/experimental-tests/shared/src/test/scala/zio/prelude/experimental/DistributiveProdSpec.scala
+++ b/experimental-tests/shared/src/test/scala/zio/prelude/experimental/DistributiveProdSpec.scala
@@ -3,8 +3,8 @@ package experimental
 
 import zio.prelude.experimental.laws._
 import zio.prelude.laws._
-import zio.test._
 import zio.test.TestAspect._
+import zio.test._
 import zio.test.laws._
 
 object DistributiveProdSpec extends ZIOBaseSpec {

--- a/experimental-tests/shared/src/test/scala/zio/prelude/experimental/ZIOBaseSpec.scala
+++ b/experimental-tests/shared/src/test/scala/zio/prelude/experimental/ZIOBaseSpec.scala
@@ -5,6 +5,6 @@ import zio.test._
 
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectAtLeastR[Environment with TestEnvironment]] =
-    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
+    if (TestPlatform.isJVM || TestPlatform.isNative) Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
     else Chunk(TestAspect.timeout(300.seconds), TestAspect.sequential, TestAspect.timed)
 }

--- a/experimental-tests/shared/src/test/scala/zio/prelude/experimental/ZIOBaseSpec.scala
+++ b/experimental-tests/shared/src/test/scala/zio/prelude/experimental/ZIOBaseSpec.scala
@@ -1,10 +1,12 @@
 package zio.prelude.experimental
 
 import zio._
+import zio.test.TestAspect._
 import zio.test._
 
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectAtLeastR[Environment with TestEnvironment]] =
-    if (TestPlatform.isJVM || TestPlatform.isNative) Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
-    else Chunk(TestAspect.timeout(300.seconds), TestAspect.sequential, TestAspect.timed)
+    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(60.seconds), TestAspect.timed)
+    else if (TestPlatform.isNative) Chunk(TestAspect.timeout(300.seconds), TestAspect.timed, size(10))
+    else Chunk(TestAspect.timeout(300.seconds), TestAspect.sequential, TestAspect.timed, size(10))
 }

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -7,7 +7,8 @@ import sbtbuildinfo.BuildInfoKeys.*
 import sbtcrossproject.CrossPlugin.autoImport.*
 import scalafix.sbt.ScalafixPlugin.autoImport.*
 
-import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
+import scala.scalanative.build.Mode
+import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport.*
 
 object BuildHelper {
   val Scala212: String = "2.12.19"
@@ -243,6 +244,12 @@ object BuildHelper {
   )
 
   def nativeSettings = Seq(
+    nativeConfig ~= { cfg =>
+      val os = System.getProperty("os.name").toLowerCase
+      // See https://github.com/zio/zio/releases/tag/v2.1.8
+      if (os.contains("mac")) cfg.withMode(Mode.releaseFast)
+      else cfg
+    },
     Test / fork := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
   )
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -243,7 +243,6 @@ object BuildHelper {
   )
 
   def nativeSettings = Seq(
-    nativeConfig ~= { _.withMultithreading(false) },
     Test / fork := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
   )
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -250,7 +250,8 @@ object BuildHelper {
       if (os.contains("mac")) cfg.withMode(Mode.releaseFast)
       else cfg
     },
-    Test / fork := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
+    Test / parallelExecution := false,
+    Test / fork              := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
   )
 
   val scalaReflectTestSettings: List[Setting[_]] = List(

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -250,6 +250,10 @@ object BuildHelper {
       if (os.contains("mac")) cfg.withMode(Mode.releaseFast)
       else cfg
     },
+    Test / nativeConfig ~= {
+      // Tests run much faster at the cost of slightly slower compilation
+      _.withMode(Mode.releaseFast)
+    },
     Test / parallelExecution := false,
     Test / fork              := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
   )

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -250,10 +250,6 @@ object BuildHelper {
       if (os.contains("mac")) cfg.withMode(Mode.releaseFast)
       else cfg
     },
-    Test / nativeConfig ~= {
-      // Tests run much faster at the cost of slightly slower compilation
-      _.withMode(Mode.releaseFast)
-    },
     Test / parallelExecution := false,
     Test / fork              := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
   )


### PR DESCRIPTION
Main changes:
- Updates ZIO to 2.1.8
- Enables multi-threading for Scala Native
- Uses the `releaseFast` mode for MacOS (see https://github.com/zio/zio/releases/tag/v2.1.8)
- Added the `.sbtopts` file with sensible config. This is needed because the default memory settings (`-Xmx1G`) is not enough to compile Scala Native

I also did some minor adjustments to CI to speed things up:
- Set `-Xmx` and `-Xms` to 6G in CI
- use `testNative` and `testJS` so that only modules that will run tests are linked