### PR TITLE
fixes #1180: Type-class instances for zio.Config

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/Associative.scala
+++ b/core/shared/src/main/scala/zio/prelude/Associative.scala
@@ -17,7 +17,7 @@
 package zio.prelude
 
 import zio.prelude.newtypes.{And, AndF, AndThen, Both, First, Last, Max, Min, Natural, Or, OrF, Prod, Sum}
-import zio.{Cause, Chunk, Duration => ZIODuration, NonEmptyChunk}
+import zio.{Cause, Chunk, ConfigProvider, Duration => ZIODuration, NonEmptyChunk}
 
 import scala.annotation.tailrec
 
@@ -351,6 +351,12 @@ object Associative extends AssociativeLowPriority {
    */
   implicit def ChunkIdentity[A]: Identity[Chunk[A]] =
     Identity.make(Chunk.empty, _ ++ _)
+
+  /**
+   * The `Associative` instance for `ConfigProvider`.
+   */
+  implicit val ConfigProviderAssociative: Associative[ConfigProvider] =
+    Associative.make(_.orElse(_))
 
   /**
    * Derives an `Associative[F[A]]` given a `Derive[F, Associative]` and an

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1075,6 +1075,15 @@ object AssociativeBoth extends AssociativeBothLowPriority {
     }
 
   /**
+   * The `IdentityBoth` instance for `Config`.
+   */
+  implicit val ConfigIdentityBoth: IdentityBoth[Config] =
+    new IdentityBoth[Config] {
+      val any: Config[Any]                                               = Config.succeed(())
+      def both[A, B](fa: => Config[A], fb: => Config[B]): Config[(A, B)] = fa ++ fb
+    }
+
+  /**
    * The `AssociativeBoth` instance for `Const`.
    */
   implicit def ConstAssociativeBoth[A: Associative]: AssociativeBoth[({ type ConstA[+B] = Const[A, B] })#ConstA] =

--- a/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
@@ -58,6 +58,15 @@ object AssociativeEither {
     }
 
   /**
+   * The `AssociativeEither` instance for `Config`.
+   */
+  implicit val ConfigAssociativeEither: AssociativeEither[Config] =
+    new AssociativeEither[Config] {
+      def either[A, B](fa: => Config[A], fb: => Config[B]): Config[Either[A, B]] =
+        fa.map(Left(_)).orElse(fb.map(Right(_)))
+    }
+
+  /**
    * The `AssociativeEither` instance for `Either`.
    */
   implicit def EitherAssociativeEither[L]: AssociativeEither[({ type lambda[+r] = Either[L, r] })#lambda] =

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -16,11 +16,11 @@
 
 package zio.prelude
 
+import zio._
 import zio.prelude.coherent.CovariantIdentityBoth
 import zio.prelude.newtypes.Failure
 import zio.stm.ZSTM
 import zio.stream.{ZSink, ZStream}
-import zio.{Cause, Chunk, ChunkBuilder, Exit, Fiber, NonEmptyChunk, Schedule, ZIO}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -96,6 +96,16 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
           (a: Commutative[A]) => Commutative.make[B]((l, r) => f.to(a.combine(f.from(l), f.from(r)))),
           (b: Commutative[B]) => Commutative.make[A]((l, r) => f.from(b.combine(f.to(l), f.to(r))))
         )
+    }
+
+  /**
+   * The `Covariant` instance for `Config`.
+   */
+  implicit def ConfigCovariant[A]: Covariant[Config] =
+    new Covariant[Config] {
+      override def map[A, B](f: A => B): Config[A] => Config[B] = { config =>
+        config.map(f)
+      }
     }
 
   /**


### PR DESCRIPTION
This PR propose to include some type class instances for zio.Config in zio-prelude. 

Currently the set of proposed additions is in par with what's provided by [zio-config-cats](https://github.com/zio/zio-config/blob/series/4.x/cats/shared/src/main/scala/zio/config/cats/instances/package.scala)