### PR TITLE
Make `Optional` an `IterableOnce`

### DIFF
--- a/core-tests/shared/src/test/scala-2.13+/zio/prelude/data/OptionalSpec.scala
+++ b/core-tests/shared/src/test/scala-2.13+/zio/prelude/data/OptionalSpec.scala
@@ -13,7 +13,7 @@ object OptionalSpec extends ZIOBaseSpec {
         val list: List[Int]             = List(1, 2, 3)
         val result: List[Long]          = list.flatMap(get)
 
-        assertTrue(result != List(1L, 2L, 3L))
+        assertTrue(result == List(1L, 2L, 3L))
       }
     )
 

--- a/core-tests/shared/src/test/scala-2.13+/zio/prelude/data/OptionalSpec.scala
+++ b/core-tests/shared/src/test/scala-2.13+/zio/prelude/data/OptionalSpec.scala
@@ -14,8 +14,8 @@ object OptionalSpec extends ZIOBaseSpec {
         val list: List[Int]             = List(1, 2, 3)
         val result: List[Long]          = list.flatMap(get)
 
-        assertTrue(result == List(1L, 2L, 3L))
-      } @@ exceptScala212
+        assertTrue(result != List(1L, 2L, 3L))
+      }
     )
 
 }

--- a/core-tests/shared/src/test/scala-2.13+/zio/prelude/data/OptionalSpec.scala
+++ b/core-tests/shared/src/test/scala-2.13+/zio/prelude/data/OptionalSpec.scala
@@ -2,7 +2,6 @@ package zio.prelude.data
 
 import zio.Scope
 import zio.prelude.ZIOBaseSpec
-import zio.test.TestAspect.exceptScala212
 import zio.test.{Spec, TestEnvironment, assertTrue}
 
 object OptionalSpec extends ZIOBaseSpec {
@@ -14,7 +13,7 @@ object OptionalSpec extends ZIOBaseSpec {
         val list: List[Int]             = List(1, 2, 3)
         val result: List[Long]          = list.flatMap(get)
 
-        assertTrue(result == List(1L, 2L, 3L))
+        assertTrue(result != List(1L, 2L, 3L))
       }
     )
 

--- a/core-tests/shared/src/test/scala-2.13+/zio/prelude/data/OptionalSpec.scala
+++ b/core-tests/shared/src/test/scala-2.13+/zio/prelude/data/OptionalSpec.scala
@@ -14,7 +14,7 @@ object OptionalSpec extends ZIOBaseSpec {
         val list: List[Int]             = List(1, 2, 3)
         val result: List[Long]          = list.flatMap(get)
 
-        assertTrue(result != List(1L, 2L, 3L))
+        assertTrue(result == List(1L, 2L, 3L))
       }
     )
 

--- a/core-tests/shared/src/test/scala/zio/prelude/data/OptionalSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/data/OptionalSpec.scala
@@ -11,11 +11,11 @@ object OptionalSpec extends ZIOBaseSpec {
     suite("Optional")(
       test("is an IterableOnce") {
         def get(a: Int): Optional[Long] = Optional.Present(a.toLong)
-        val list: List[Int] = List(1, 2, 3)
-        val result: List[Long] = list.flatMap(get)
+        val list: List[Int]             = List(1, 2, 3)
+        val result: List[Long]          = list.flatMap(get)
 
         assertTrue(result == List(1L, 2L, 3L))
-      },
+      }
     )
 
 }

--- a/core-tests/shared/src/test/scala/zio/prelude/data/OptionalSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/data/OptionalSpec.scala
@@ -1,0 +1,21 @@
+package zio.prelude.data
+
+import zio.Scope
+import zio.prelude.ZIOBaseSpec
+import zio.prelude.data.Optional
+import zio.test.{Spec, TestEnvironment, assertTrue}
+
+object OptionalSpec extends ZIOBaseSpec {
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("Optional")(
+      test("is an IterableOnce") {
+        def get(a: Int): Optional[Long] = Optional.Present(a.toLong)
+        val list: List[Int] = List(1, 2, 3)
+        val result: List[Long] = list.flatMap(get)
+
+        assertTrue(result == List(1L, 2L, 3L))
+      },
+    )
+
+}

--- a/core-tests/shared/src/test/scala/zio/prelude/data/OptionalSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/data/OptionalSpec.scala
@@ -3,6 +3,7 @@ package zio.prelude.data
 import zio.Scope
 import zio.prelude.ZIOBaseSpec
 import zio.prelude.data.Optional
+import zio.test.TestAspect.exceptScala212
 import zio.test.{Spec, TestEnvironment, assertTrue}
 
 object OptionalSpec extends ZIOBaseSpec {
@@ -16,6 +17,6 @@ object OptionalSpec extends ZIOBaseSpec {
 
         assertTrue(result == List(1L, 2L, 3L))
       }
-    )
+    ) @@ exceptScala212
 
 }

--- a/core-tests/shared/src/test/scala/zio/prelude/data/OptionalSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/data/OptionalSpec.scala
@@ -2,7 +2,6 @@ package zio.prelude.data
 
 import zio.Scope
 import zio.prelude.ZIOBaseSpec
-import zio.prelude.data.Optional
 import zio.test.TestAspect.exceptScala212
 import zio.test.{Spec, TestEnvironment, assertTrue}
 
@@ -16,7 +15,7 @@ object OptionalSpec extends ZIOBaseSpec {
         val result: List[Long]          = list.flatMap(get)
 
         assertTrue(result == List(1L, 2L, 3L))
-      }
-    ) @@ exceptScala212
+      } @@ exceptScala212
+    )
 
 }

--- a/core/shared/src/main/scala-2.12/zio/prelude/IterableOnceCompat.scala
+++ b/core/shared/src/main/scala-2.12/zio/prelude/IterableOnceCompat.scala
@@ -1,0 +1,18 @@
+package zio.prelude
+
+/**
+ * Needed because Scala 2.12 doesn't have `IterableOnce`
+ */
+private[prelude] trait IterableOnceCompat[+A] {
+
+  /**
+   * Copied from `IterableOnce#iterator`
+   */
+  def iterator: Iterator[A]
+
+  /**
+   * Adapted from `IterableOnce#knownSize`
+   */
+  def knownSize: Int
+
+}

--- a/core/shared/src/main/scala-2.13+/zio/prelude/IterableOnceCompat.scala
+++ b/core/shared/src/main/scala-2.13+/zio/prelude/IterableOnceCompat.scala
@@ -2,5 +2,7 @@ package zio.prelude
 
 /**
  * Needed because Scala 2.12 doesn't have `IterableOnce`
+ *
+ * TODO: Remove when support for Scala 2.12 is dropped
  */
 private[prelude] trait IterableOnceCompat[+A] extends IterableOnce[A]

--- a/core/shared/src/main/scala-2.13+/zio/prelude/IterableOnceCompat.scala
+++ b/core/shared/src/main/scala-2.13+/zio/prelude/IterableOnceCompat.scala
@@ -1,0 +1,6 @@
+package zio.prelude
+
+/**
+ * Needed because Scala 2.12 doesn't have `IterableOnce`
+ */
+private[prelude] trait IterableOnceCompat[+A] extends IterableOnce[A]

--- a/core/shared/src/main/scala/zio/prelude/data/Optional.scala
+++ b/core/shared/src/main/scala/zio/prelude/data/Optional.scala
@@ -1,7 +1,7 @@
 package zio.prelude.data
 
 import zio.Chunk
-import scala.collection.IterableOnce
+import zio.prelude.IterableOnceCompat
 
 import scala.language.implicitConversions
 
@@ -14,7 +14,7 @@ import scala.language.implicitConversions
  * The only difference between this type and [[scala.Option]] is that there is an implicit
  * conversion defined from `A`` to `Optional[A]`, and from `Option[A]`` to `Optional[A]`.
  */
-sealed trait Optional[+A] extends IterableOnce[A] { self =>
+sealed trait Optional[+A] extends IterableOnceCompat[A] { self =>
   val isEmpty: Boolean
   val isDefined: Boolean
   val nonEmpty: Boolean

--- a/core/shared/src/main/scala/zio/prelude/data/Optional.scala
+++ b/core/shared/src/main/scala/zio/prelude/data/Optional.scala
@@ -148,7 +148,7 @@ sealed trait Optional[+A] extends IterableOnceCompat[A] { self =>
     }
 
   /**
-   * Copied from [[Option.knownSize]]
+   * Copied from `Option.knownSize`
    */
   override final def knownSize: Int = if (isEmpty) 0 else 1
 

--- a/core/shared/src/main/scala/zio/prelude/data/Optional.scala
+++ b/core/shared/src/main/scala/zio/prelude/data/Optional.scala
@@ -1,7 +1,7 @@
 package zio.prelude.data
 
 import zio.Chunk
-import scala.IterableOnce
+import scala.collection.IterableOnce
 
 import scala.language.implicitConversions
 

--- a/core/shared/src/main/scala/zio/prelude/data/Optional.scala
+++ b/core/shared/src/main/scala/zio/prelude/data/Optional.scala
@@ -1,6 +1,7 @@
 package zio.prelude.data
 
 import zio.Chunk
+import scala.IterableOnce
 
 import scala.language.implicitConversions
 
@@ -13,7 +14,7 @@ import scala.language.implicitConversions
  * The only difference between this type and [[scala.Option]] is that there is an implicit
  * conversion defined from `A`` to `Optional[A]`, and from `Option[A]`` to `Optional[A]`.
  */
-sealed trait Optional[+A] { self =>
+sealed trait Optional[+A] extends IterableOnce[A] { self =>
   val isEmpty: Boolean
   val isDefined: Boolean
   val nonEmpty: Boolean
@@ -122,7 +123,7 @@ sealed trait Optional[+A] { self =>
   final def orElse[B >: A](alternative: => Optional[B]): Optional[B] =
     if (isEmpty) alternative else this
 
-  final def iterator: Iterator[A] =
+  override final def iterator: Iterator[A] =
     self match {
       case Optional.Present(get) => Iterator.single(get)
       case Optional.Absent       => Iterator.empty
@@ -145,6 +146,12 @@ sealed trait Optional[+A] { self =>
       case Optional.Present(get) => Vector(get)
       case Optional.Absent       => Vector.empty
     }
+
+  /**
+   * Copied from [[Option.knownSize]]
+   */
+  override final def knownSize: Int = if (isEmpty) 0 else 1
+
 }
 
 object Optional {


### PR DESCRIPTION
So that we can:
```
def get(a: A): Optional[B] = ...
val list: List[A] = ...
val result: List[B] = list.flatMap(get)
```
TODO:
- [x] Fix 2.12 compilation