### PR TITLE
identity both for vector.

### DIFF
--- a/core-tests/shared/src/test/scala/zio/prelude/IdentityBothSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/prelude/IdentityBothSpec.scala
@@ -14,7 +14,8 @@ object IdentityBothSpec extends ZIOBaseSpec {
         test("list")(checkAllLaws(IdentityBothLaws)(GenF.list, Gen.int)),
         test("option")(checkAllLaws(IdentityBothLaws)(GenF.option, Gen.int)),
         test("optional")(checkAllLaws(IdentityBothLaws)(optionalGenF, Gen.int)),
-        test("try")(checkAllLaws(IdentityBothLaws)(GenFs.tryScala, Gen.int))
+        test("try")(checkAllLaws(IdentityBothLaws)(GenFs.tryScala, Gen.int)),
+        test("vector")(checkAllLaws(IdentityBothLaws)(GenF.vector, Gen.int))
       )
     )
 }

--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -1389,10 +1389,11 @@ object AssociativeBoth extends AssociativeBothLowPriority {
     }
 
   /**
-   * The `AssociativeBoth` instance for `Vector`.
+   * The `IdentityBoth` (and `AssociativeBoth`) instance for `Vector`.
    */
-  implicit val VectorAssociativeBoth: AssociativeBoth[Vector] =
-    new AssociativeBoth[Vector] {
+  implicit val VectorIdentityBoth: IdentityBoth[Vector] =
+    new IdentityBoth[Vector] {
+      def any: Vector[Any]                                               = Vector(())
       def both[A, B](fa: => Vector[A], fb: => Vector[B]): Vector[(A, B)] = fa.flatMap(a => fb.map(b => (a, b)))
     }
 

--- a/docs/functional-abstractions/abstraction-diagrams.md
+++ b/docs/functional-abstractions/abstraction-diagrams.md
@@ -155,8 +155,11 @@ classDiagram
   AssociativeBoth~F<_>~ <|-- CommutativeBoth~F<_>~
   AssociativeBoth~F<_>~ <|-- IdentityBoth~F<_>~
   class AssociativeBoth~F<_>~{
+    Exit[E, +*]
     Fiber[E, +*]
-    STM[R, E, +*]
+    NonEmptyChunk[+*]
+    ZSink[R, E, I, L, +*]
+    ZStream[R, E, +*]
 
     () both[A,B](=> F[A], => F[B]): F[(A,B)]
   }
@@ -175,18 +178,23 @@ classDiagram
     ZLayer[R, E, +*]
     ZManaged[R, E, +*]
     Failure[ZManaged[R, E, +*]]
-    ZSink[R, E, I, I, +*]
+    ZSink[R, E, I, L, +*]
     ZStream[R, E, +*]
   }
   class IdentityBoth~F<_>~{
+    Chunk[+*]
+    Config[+*]
     Either[L, +*]
     Failure[Either[+*, R]]
     Option[+*]
+    Optional[+*]
     Future[+*]
     Id[+*]
     List[+*]
+    STM[R, E, +*]
     Try[+*]
- 
+    Vector[+*]
+
     () any: F[Any]
   }
 ```


### PR DESCRIPTION
List and Chunk has IdentityBoth instances, but Vector does not for some reason. 

Adding missing IdentityBoth instance to Vector.

FYI, I think there may be more cases were AssociativeBoth instances can be complemented with IdentityBoth: 

One example that comes to mind is ZStream: it only has AssociativeBoth

