### PR TITLE
remove variance requirement for Covariant/Contravariant

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeBoth.scala
@@ -48,11 +48,11 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   def apply[F[_]](implicit associativeBoth: AssociativeBoth[F]): AssociativeBoth[F] =
     associativeBoth
 
-  def compose[F[+_]: AssociativeBoth, G[+_]: AssociativeBoth](implicit
+  def compose[F[_]: AssociativeBoth, G[_]: AssociativeBoth](implicit
     f: Covariant[F],
     g: Covariant[G]
-  ): AssociativeBoth[({ type lambda[+A] = F[G[A]] })#lambda] with Covariant[({ type lambda[+A] = F[G[A]] })#lambda] =
-    new AssociativeBoth[({ type lambda[+A] = F[G[A]] })#lambda] with Covariant[({ type lambda[+A] = F[G[A]] })#lambda] {
+  ): AssociativeBoth[({ type lambda[A] = F[G[A]] })#lambda] with Covariant[({ type lambda[A] = F[G[A]] })#lambda] =
+    new AssociativeBoth[({ type lambda[A] = F[G[A]] })#lambda] with Covariant[({ type lambda[A] = F[G[A]] })#lambda] {
       def map[A, B](fn: A => B)                      = f.map(g.map(fn))
       def both[A, B](fa: => F[G[A]], fb: => F[G[B]]) = fa.zipWith(fb)(_ zip _)
     }
@@ -60,7 +60,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 2 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, B](
     a0: F[A0],
     a1: F[A1]
   )(
@@ -71,7 +71,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 3 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2]
@@ -85,7 +85,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 4 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -100,7 +100,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 5 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -116,7 +116,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 6 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -133,7 +133,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 7 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -151,7 +151,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 8 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -170,7 +170,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 9 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -190,7 +190,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 10 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -211,7 +211,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 11 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -234,7 +234,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 12 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -258,7 +258,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 13 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -283,7 +283,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 14 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -309,7 +309,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 15 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -336,7 +336,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 16 `F` values using the provided function `f`.
    */
-  def mapN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, B](
+  def mapN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -365,7 +365,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    * Combines 17 `F` values using the provided function `f`.
    */
   def mapN[F[
-    +_
+    _
   ]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, B](
     a0: F[A0],
     a1: F[A1],
@@ -396,7 +396,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    * Combines 18 `F` values into a tuple in maps the result with the provided function.
    */
   def mapN[F[
-    +_
+    _
   ]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, B](
     a0: F[A0],
     a1: F[A1],
@@ -432,7 +432,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    */
   def mapN[
     F[
-      +_
+      _
     ]: AssociativeBoth: Covariant,
     A0,
     A1,
@@ -493,7 +493,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    */
   def mapN[
     F[
-      +_
+      _
     ]: AssociativeBoth: Covariant,
     A0,
     A1,
@@ -562,7 +562,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    */
   def mapN[
     F[
-      +_
+      _
     ]: AssociativeBoth: Covariant,
     A0,
     A1,
@@ -636,7 +636,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    */
   def mapN[
     F[
-      +_
+      _
     ]: AssociativeBoth: Covariant,
     A0,
     A1,
@@ -716,7 +716,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 2 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1](
     a0: F[A0],
     a1: F[A1]
   ): F[(A0, A1)] =
@@ -725,7 +725,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 3 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2]
@@ -735,7 +735,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 4 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -746,7 +746,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 5 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -758,7 +758,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 6 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -771,7 +771,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 7 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -785,7 +785,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 8 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -800,7 +800,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 9 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -816,7 +816,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 10 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -833,7 +833,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 11 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -851,7 +851,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 12 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -870,7 +870,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 13 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -890,7 +890,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 14 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -911,7 +911,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 15 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -933,7 +933,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
   /**
    * Combines 16 `F` values into a tuple.
    */
-  def tupleN[F[+_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](
+  def tupleN[F[_]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -959,7 +959,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    * Combines 17 `F` values into a tuple.
    */
   def tupleN[F[
-    +_
+    _
   ]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](
     a0: F[A0],
     a1: F[A1],
@@ -987,7 +987,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    * Combines 18 `F` values into a tuple.
    */
   def tupleN[F[
-    +_
+    _
   ]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](
     a0: F[A0],
     a1: F[A1],
@@ -1016,7 +1016,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    * Combines 19 `F` values into a tuple.
    */
   def tupleN[F[
-    +_
+    _
   ]: AssociativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](
     a0: F[A0],
     a1: F[A1],
@@ -1047,7 +1047,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    */
   def tupleN[
     F[
-      +_
+      _
     ]: AssociativeBoth: Covariant,
     A0,
     A1,
@@ -1100,7 +1100,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    */
   def tupleN[
     F[
-      +_
+      _
     ]: AssociativeBoth: Covariant,
     A0,
     A1,
@@ -1155,7 +1155,7 @@ object AssociativeBoth extends AssociativeBothLowPriority {
    */
   def tupleN[
     F[
-      +_
+      _
     ]: AssociativeBoth: Covariant,
     A0,
     A1,
@@ -1511,7 +1511,7 @@ trait AssociativeBothSyntax {
   /**
    * Provides infix syntax for associative operations for covariant types.
    */
-  implicit class AssociativeBothCovariantOps[F[+_], A](fa: => F[A]) {
+  implicit class AssociativeBothCovariantOps[F[_], A](fa: => F[A]) {
 
     /**
      * A symbolic alias for `zipLeft`.
@@ -1568,7 +1568,7 @@ trait AssociativeBothSyntax {
       both.both(fa, fb).contramap(f)
   }
 
-  implicit class AssociativeBothTuple2Ops[F[+_], T1, T2](tf: => (F[T1], F[T2])) {
+  implicit class AssociativeBothTuple2Ops[F[_], T1, T2](tf: => (F[T1], F[T2])) {
     def mapN[R](f: (T1, T2) => R)(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[R] =
       (AssociativeBoth.mapN(_: F[T1], _: F[T2])(f)).tupled(tf)
 
@@ -1576,7 +1576,7 @@ trait AssociativeBothSyntax {
       (AssociativeBoth.tupleN(_: F[T1], _: F[T2])).tupled(tf)
   }
 
-  implicit class AssociativeBothTuple3Ops[F[+_], T1, T2, T3](tf: => (F[T1], F[T2], F[T3])) {
+  implicit class AssociativeBothTuple3Ops[F[_], T1, T2, T3](tf: => (F[T1], F[T2], F[T3])) {
     def mapN[R](f: (T1, T2, T3) => R)(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[R] =
       (AssociativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3])(f)).tupled(tf)
 
@@ -1584,7 +1584,7 @@ trait AssociativeBothSyntax {
       (AssociativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3])).tupled(tf)
   }
 
-  implicit class AssociativeBothTuple4Ops[F[+_], T1, T2, T3, T4](tf: => (F[T1], F[T2], F[T3], F[T4])) {
+  implicit class AssociativeBothTuple4Ops[F[_], T1, T2, T3, T4](tf: => (F[T1], F[T2], F[T3], F[T4])) {
     def mapN[R](f: (T1, T2, T3, T4) => R)(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[R] =
       (AssociativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4])(f)).tupled(tf)
 
@@ -1592,7 +1592,7 @@ trait AssociativeBothSyntax {
       (AssociativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4])).tupled(tf)
   }
 
-  implicit class AssociativeBothTuple5Ops[F[+_], T1, T2, T3, T4, T5](tf: => (F[T1], F[T2], F[T3], F[T4], F[T5])) {
+  implicit class AssociativeBothTuple5Ops[F[_], T1, T2, T3, T4, T5](tf: => (F[T1], F[T2], F[T3], F[T4], F[T5])) {
     def mapN[R](f: (T1, T2, T3, T4, T5) => R)(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[R] =
       (AssociativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5])(f)).tupled(tf)
 
@@ -1600,7 +1600,7 @@ trait AssociativeBothSyntax {
       (AssociativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5])).tupled(tf)
   }
 
-  implicit class AssociativeBothTuple6Ops[F[+_], T1, T2, T3, T4, T5, T6](
+  implicit class AssociativeBothTuple6Ops[F[_], T1, T2, T3, T4, T5, T6](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6])
   ) {
     def mapN[R](f: (T1, T2, T3, T4, T5, T6) => R)(implicit both: AssociativeBoth[F], covariant: Covariant[F]): F[R] =
@@ -1610,7 +1610,7 @@ trait AssociativeBothSyntax {
       (AssociativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6])).tupled(tf)
   }
 
-  implicit class AssociativeBothTuple7Ops[F[+_], T1, T2, T3, T4, T5, T6, T7](
+  implicit class AssociativeBothTuple7Ops[F[_], T1, T2, T3, T4, T5, T6, T7](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7])
   ) {
     def mapN[R](
@@ -1622,7 +1622,7 @@ trait AssociativeBothSyntax {
       (AssociativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7])).tupled(tf)
   }
 
-  implicit class AssociativeBothTuple8Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8](
+  implicit class AssociativeBothTuple8Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8])
   ) {
     def mapN[R](
@@ -1638,7 +1638,7 @@ trait AssociativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class AssociativeBothTuple9Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9](
+  implicit class AssociativeBothTuple9Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9])
   ) {
     def mapN[R](
@@ -1654,7 +1654,7 @@ trait AssociativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class AssociativeBothTuple10Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
+  implicit class AssociativeBothTuple10Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10])
   ) {
     def mapN[R](
@@ -1673,7 +1673,7 @@ trait AssociativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class AssociativeBothTuple11Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
+  implicit class AssociativeBothTuple11Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10], F[T11])
   ) {
     def mapN[R](
@@ -1716,7 +1716,7 @@ trait AssociativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class AssociativeBothTuple12Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
+  implicit class AssociativeBothTuple12Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10], F[T11], F[T12])
   ) {
     def mapN[R](
@@ -1761,7 +1761,7 @@ trait AssociativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class AssociativeBothTuple13Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](
+  implicit class AssociativeBothTuple13Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10], F[T11], F[T12], F[T13])
   ) {
     def mapN[R](
@@ -1808,7 +1808,7 @@ trait AssociativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class AssociativeBothTuple14Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](
+  implicit class AssociativeBothTuple14Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10], F[T11], F[T12], F[T13], F[T14])
   ) {
     def mapN[R](
@@ -1857,7 +1857,7 @@ trait AssociativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class AssociativeBothTuple15Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](
+  implicit class AssociativeBothTuple15Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](
     tf: => (
       F[T1],
       F[T2],
@@ -1925,7 +1925,7 @@ trait AssociativeBothSyntax {
   }
 
   implicit class AssociativeBothTuple16Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2015,7 +2015,7 @@ trait AssociativeBothSyntax {
   }
 
   implicit class AssociativeBothTuple17Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2109,7 +2109,7 @@ trait AssociativeBothSyntax {
   }
 
   implicit class AssociativeBothTuple18Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2207,7 +2207,7 @@ trait AssociativeBothSyntax {
   }
 
   implicit class AssociativeBothTuple19Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2309,7 +2309,7 @@ trait AssociativeBothSyntax {
   }
 
   implicit class AssociativeBothTuple20Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2415,7 +2415,7 @@ trait AssociativeBothSyntax {
   }
 
   implicit class AssociativeBothTuple21Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2525,7 +2525,7 @@ trait AssociativeBothSyntax {
   }
 
   implicit class AssociativeBothTuple22Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,

--- a/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/AssociativeEither.scala
@@ -282,7 +282,7 @@ trait AssociativeEitherSyntax {
   /**
    * Provides infix syntax for associative operations for covariant types.
    */
-  implicit class AssociativeEitherCovariantOps[F[+_], A](fa: => F[A]) {
+  implicit class AssociativeEitherCovariantOps[F[_], A](fa: => F[A]) {
 
     /**
      * Combines an `F[A]` value with itself using `orElse` until it eventually

--- a/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeBoth.scala
@@ -187,7 +187,7 @@ object CommutativeBoth {
   /**
    * Combines 2 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, B](
     a0: F[A0],
     a1: F[A1]
   )(
@@ -198,7 +198,7 @@ object CommutativeBoth {
   /**
    * Combines 3 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2]
@@ -212,7 +212,7 @@ object CommutativeBoth {
   /**
    * Combines 4 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -227,7 +227,7 @@ object CommutativeBoth {
   /**
    * Combines 5 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -243,7 +243,7 @@ object CommutativeBoth {
   /**
    * Combines 6 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -260,7 +260,7 @@ object CommutativeBoth {
   /**
    * Combines 7 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -278,7 +278,7 @@ object CommutativeBoth {
   /**
    * Combines 8 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -297,7 +297,7 @@ object CommutativeBoth {
   /**
    * Combines 9 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -317,7 +317,7 @@ object CommutativeBoth {
   /**
    * Combines 10 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -338,7 +338,7 @@ object CommutativeBoth {
   /**
    * Combines 11 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -361,7 +361,7 @@ object CommutativeBoth {
   /**
    * Combines 12 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -385,7 +385,7 @@ object CommutativeBoth {
   /**
    * Combines 13 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -410,7 +410,7 @@ object CommutativeBoth {
   /**
    * Combines 14 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -436,7 +436,7 @@ object CommutativeBoth {
   /**
    * Combines 15 `F` values using the provided function `f` in parallel.
    */
-  def mapN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B](
+  def mapN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, B](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -464,7 +464,7 @@ object CommutativeBoth {
    * Combines 16 `F` values using the provided function `f` in parallel.
    */
   def mapN[F[
-    +_
+    _
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, B](
     a0: F[A0],
     a1: F[A1],
@@ -494,7 +494,7 @@ object CommutativeBoth {
    * Combines 17 `F` values using the provided function `f` in parallel.
    */
   def mapN[F[
-    +_
+    _
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, B](
     a0: F[A0],
     a1: F[A1],
@@ -525,7 +525,7 @@ object CommutativeBoth {
    * Combines 18 `F` values using the provided function `f` in parallel.
    */
   def mapN[F[
-    +_
+    _
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, B](
     a0: F[A0],
     a1: F[A1],
@@ -561,7 +561,7 @@ object CommutativeBoth {
    */
   def mapN[
     F[
-      +_
+      _
     ]: CommutativeBoth: Covariant,
     A0,
     A1,
@@ -622,7 +622,7 @@ object CommutativeBoth {
    */
   def mapN[
     F[
-      +_
+      _
     ]: CommutativeBoth: Covariant,
     A0,
     A1,
@@ -691,7 +691,7 @@ object CommutativeBoth {
    */
   def mapN[
     F[
-      +_
+      _
     ]: CommutativeBoth: Covariant,
     A0,
     A1,
@@ -765,7 +765,7 @@ object CommutativeBoth {
    */
   def mapN[
     F[
-      +_
+      _
     ]: CommutativeBoth: Covariant,
     A0,
     A1,
@@ -845,7 +845,7 @@ object CommutativeBoth {
   /**
    * Combines 2 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1](
     a0: F[A0],
     a1: F[A1]
   ): F[(A0, A1)] =
@@ -854,7 +854,7 @@ object CommutativeBoth {
   /**
    * Combines 3 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2]
@@ -864,7 +864,7 @@ object CommutativeBoth {
   /**
    * Combines 4 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -875,7 +875,7 @@ object CommutativeBoth {
   /**
    * Combines 5 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -887,7 +887,7 @@ object CommutativeBoth {
   /**
    * Combines 6 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -900,7 +900,7 @@ object CommutativeBoth {
   /**
    * Combines 7 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -914,7 +914,7 @@ object CommutativeBoth {
   /**
    * Combines 8 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -929,7 +929,7 @@ object CommutativeBoth {
   /**
    * Combines 9 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -945,7 +945,7 @@ object CommutativeBoth {
   /**
    * Combines 10 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -962,7 +962,7 @@ object CommutativeBoth {
   /**
    * Combines 11 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -980,7 +980,7 @@ object CommutativeBoth {
   /**
    * Combines 12 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -999,7 +999,7 @@ object CommutativeBoth {
   /**
    * Combines 13 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -1019,7 +1019,7 @@ object CommutativeBoth {
   /**
    * Combines 14 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -1040,7 +1040,7 @@ object CommutativeBoth {
   /**
    * Combines 15 `F` values into a tuple in a parallel manner.
    */
-  def tupleN[F[+_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](
+  def tupleN[F[_]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14](
     a0: F[A0],
     a1: F[A1],
     a2: F[A2],
@@ -1065,7 +1065,7 @@ object CommutativeBoth {
    * Combines 16 `F` values into a tuple in a parallel manner.
    */
   def tupleN[F[
-    +_
+    _
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15](
     a0: F[A0],
     a1: F[A1],
@@ -1092,7 +1092,7 @@ object CommutativeBoth {
    * Combines 17 `F` values into a tuple in a parallel manner.
    */
   def tupleN[F[
-    +_
+    _
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16](
     a0: F[A0],
     a1: F[A1],
@@ -1120,7 +1120,7 @@ object CommutativeBoth {
    * Combines 18 `F` values into a tuple in a parallel manner.
    */
   def tupleN[F[
-    +_
+    _
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17](
     a0: F[A0],
     a1: F[A1],
@@ -1149,7 +1149,7 @@ object CommutativeBoth {
    * Combines 19 `F` values into a tuple in a parallel manner.
    */
   def tupleN[F[
-    +_
+    _
   ]: CommutativeBoth: Covariant, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9, A10, A11, A12, A13, A14, A15, A16, A17, A18](
     a0: F[A0],
     a1: F[A1],
@@ -1180,7 +1180,7 @@ object CommutativeBoth {
    */
   def tupleN[
     F[
-      +_
+      _
     ]: CommutativeBoth: Covariant,
     A0,
     A1,
@@ -1233,7 +1233,7 @@ object CommutativeBoth {
    */
   def tupleN[
     F[
-      +_
+      _
     ]: CommutativeBoth: Covariant,
     A0,
     A1,
@@ -1288,7 +1288,7 @@ object CommutativeBoth {
    */
   def tupleN[
     F[
-      +_
+      _
     ]: CommutativeBoth: Covariant,
     A0,
     A1,
@@ -1365,7 +1365,7 @@ trait CommutativeBothSyntax {
   /**
    * Provides infix syntax for commutative operations for covariant types.
    */
-  implicit class CommutativeBothCovariantOps[F[+_], A](fa: => F[A]) {
+  implicit class CommutativeBothCovariantOps[F[_], A](fa: => F[A]) {
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an
@@ -1391,7 +1391,7 @@ trait CommutativeBothSyntax {
     )(f: C => (A, B))(implicit both: CommutativeBoth[F], contravariant: Contravariant[F]): F[C] =
       both.both(fa, fb).contramap(f)
   }
-  implicit class CommutativeBothTuple2Ops[F[+_], T1, T2](tf: => (F[T1], F[T2])) {
+  implicit class CommutativeBothTuple2Ops[F[_], T1, T2](tf: => (F[T1], F[T2])) {
     def mapParN[R](f: (T1, T2) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth.mapN(_: F[T1], _: F[T2])(f)).tupled(tf)
 
@@ -1399,7 +1399,7 @@ trait CommutativeBothSyntax {
       (CommutativeBoth.tupleN(_: F[T1], _: F[T2])).tupled(tf)
   }
 
-  implicit class CommutativeBothTuple3Ops[F[+_], T1, T2, T3](tf: => (F[T1], F[T2], F[T3])) {
+  implicit class CommutativeBothTuple3Ops[F[_], T1, T2, T3](tf: => (F[T1], F[T2], F[T3])) {
     def mapParN[R](f: (T1, T2, T3) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3])(f)).tupled(tf)
 
@@ -1407,7 +1407,7 @@ trait CommutativeBothSyntax {
       (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3])).tupled(tf)
   }
 
-  implicit class CommutativeBothTuple4Ops[F[+_], T1, T2, T3, T4](tf: => (F[T1], F[T2], F[T3], F[T4])) {
+  implicit class CommutativeBothTuple4Ops[F[_], T1, T2, T3, T4](tf: => (F[T1], F[T2], F[T3], F[T4])) {
     def mapParN[R](f: (T1, T2, T3, T4) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4])(f)).tupled(tf)
 
@@ -1415,7 +1415,7 @@ trait CommutativeBothSyntax {
       (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4])).tupled(tf)
   }
 
-  implicit class CommutativeBothTuple5Ops[F[+_], T1, T2, T3, T4, T5](tf: => (F[T1], F[T2], F[T3], F[T4], F[T5])) {
+  implicit class CommutativeBothTuple5Ops[F[_], T1, T2, T3, T4, T5](tf: => (F[T1], F[T2], F[T3], F[T4], F[T5])) {
     def mapParN[R](f: (T1, T2, T3, T4, T5) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
       (CommutativeBoth.mapN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5])(f)).tupled(tf)
 
@@ -1423,7 +1423,7 @@ trait CommutativeBothSyntax {
       (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5])).tupled(tf)
   }
 
-  implicit class CommutativeBothTuple6Ops[F[+_], T1, T2, T3, T4, T5, T6](
+  implicit class CommutativeBothTuple6Ops[F[_], T1, T2, T3, T4, T5, T6](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6])
   ) {
     def mapParN[R](f: (T1, T2, T3, T4, T5, T6) => R)(implicit both: CommutativeBoth[F], covariant: Covariant[F]): F[R] =
@@ -1433,7 +1433,7 @@ trait CommutativeBothSyntax {
       (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6])).tupled(tf)
   }
 
-  implicit class CommutativeBothTuple7Ops[F[+_], T1, T2, T3, T4, T5, T6, T7](
+  implicit class CommutativeBothTuple7Ops[F[_], T1, T2, T3, T4, T5, T6, T7](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7])
   ) {
     def mapParN[R](
@@ -1445,7 +1445,7 @@ trait CommutativeBothSyntax {
       (CommutativeBoth.tupleN(_: F[T1], _: F[T2], _: F[T3], _: F[T4], _: F[T5], _: F[T6], _: F[T7])).tupled(tf)
   }
 
-  implicit class CommutativeBothTuple8Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8](
+  implicit class CommutativeBothTuple8Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8])
   ) {
     def mapParN[R](
@@ -1461,7 +1461,7 @@ trait CommutativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class CommutativeBothTuple9Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9](
+  implicit class CommutativeBothTuple9Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9])
   ) {
     def mapParN[R](
@@ -1477,7 +1477,7 @@ trait CommutativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class CommutativeBothTuple10Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
+  implicit class CommutativeBothTuple10Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10])
   ) {
     def mapParN[R](
@@ -1498,7 +1498,7 @@ trait CommutativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class CommutativeBothTuple11Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
+  implicit class CommutativeBothTuple11Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10], F[T11])
   ) {
     def mapParN[R](
@@ -1541,7 +1541,7 @@ trait CommutativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class CommutativeBothTuple12Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
+  implicit class CommutativeBothTuple12Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10], F[T11], F[T12])
   ) {
     def mapParN[R](
@@ -1586,7 +1586,7 @@ trait CommutativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class CommutativeBothTuple13Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](
+  implicit class CommutativeBothTuple13Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10], F[T11], F[T12], F[T13])
   ) {
     def mapParN[R](
@@ -1633,7 +1633,7 @@ trait CommutativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class CommutativeBothTuple14Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](
+  implicit class CommutativeBothTuple14Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14](
     tf: => (F[T1], F[T2], F[T3], F[T4], F[T5], F[T6], F[T7], F[T8], F[T9], F[T10], F[T11], F[T12], F[T13], F[T14])
   ) {
     def mapParN[R](
@@ -1682,7 +1682,7 @@ trait CommutativeBothSyntax {
         .tupled(tf)
   }
 
-  implicit class CommutativeBothTuple15Ops[F[+_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](
+  implicit class CommutativeBothTuple15Ops[F[_], T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15](
     tf: => (
       F[T1],
       F[T2],
@@ -1752,7 +1752,7 @@ trait CommutativeBothSyntax {
   }
 
   implicit class CommutativeBothTuple16Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -1842,7 +1842,7 @@ trait CommutativeBothSyntax {
   }
 
   implicit class CommutativeBothTuple17Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -1936,7 +1936,7 @@ trait CommutativeBothSyntax {
   }
 
   implicit class CommutativeBothTuple18Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2034,7 +2034,7 @@ trait CommutativeBothSyntax {
   }
 
   implicit class CommutativeBothTuple19Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2136,7 +2136,7 @@ trait CommutativeBothSyntax {
   }
 
   implicit class CommutativeBothTuple20Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2242,7 +2242,7 @@ trait CommutativeBothSyntax {
   }
 
   implicit class CommutativeBothTuple21Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,
@@ -2352,7 +2352,7 @@ trait CommutativeBothSyntax {
   }
 
   implicit class CommutativeBothTuple22Ops[
-    F[+_],
+    F[_],
     T1,
     T2,
     T3,

--- a/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
+++ b/core/shared/src/main/scala/zio/prelude/CommutativeEither.scala
@@ -102,7 +102,7 @@ trait CommutativeEitherSyntax {
   /**
    * Provides infix syntax for commutative operations for covariant types.
    */
-  implicit class CommutativeEitherCovariantOps[F[+_], A](fa: => F[A]) {
+  implicit class CommutativeEitherCovariantOps[F[_], A](fa: => F[A]) {
 
     /**
      * Combines two values of types `F[A]` and `F[A]` to produce an
@@ -115,7 +115,7 @@ trait CommutativeEitherSyntax {
   /**
    * Provides infix syntax for commutative operations for contravariant types.
    */
-  implicit class CommutativeEitherContravariantOps[F[-_], A](fa: => F[A]) {
+  implicit class CommutativeEitherContravariantOps[F[_], A](fa: => F[A]) {
 
     /**
      * Combines two values of types `F[A]` and `F[B]` to produce an

--- a/core/shared/src/main/scala/zio/prelude/Contravariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Contravariant.scala
@@ -87,7 +87,7 @@ trait ContravariantSyntax {
   /**
    * Provides infix syntax for mapping over covariant values.
    */
-  implicit class ContravariantOps[F[-_], A](private val self: F[A]) {
+  implicit class ContravariantOps[F[_], A](private val self: F[A]) {
     def contramap[B](f: B => A)(implicit contravariant: Contravariant[F]): F[B] =
       contravariant.contramap(f)(self)
   }

--- a/core/shared/src/main/scala/zio/prelude/Contravariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Contravariant.scala
@@ -16,7 +16,7 @@
 
 package zio.prelude
 
-trait ContravariantSubset[F[-_], Subset[_]] {
+trait ContravariantSubset[F[_], Subset[_]] {
   def contramapSubset[A, B: Subset](f: B => A): F[A] => F[B]
 }
 
@@ -43,7 +43,7 @@ trait ContravariantSubset[F[-_], Subset[_]] {
  * compares strings by computing their lengths with the provided function and
  * comparing those.
  */
-trait Contravariant[F[-_]] extends ContravariantSubset[F, AnyType] with Invariant[F] { self =>
+trait Contravariant[F[_]] extends ContravariantSubset[F, AnyType] with Invariant[F] { self =>
   final def contramapSubset[A, B: AnyType](f: B => A): F[A] => F[B] =
     contramap(f)
 
@@ -58,16 +58,16 @@ trait Contravariant[F[-_]] extends ContravariantSubset[F, AnyType] with Invarian
   /**
    * Compose two contravariant functors.
    */
-  final def compose[G[-_]](implicit g: Contravariant[G]): Covariant[({ type lambda[+A] = F[G[A]] })#lambda] =
-    new Covariant[({ type lambda[+A] = F[G[A]] })#lambda] {
+  final def compose[G[-_]](implicit g: Contravariant[G]): Covariant[({ type lambda[A] = F[G[A]] })#lambda] =
+    new Covariant[({ type lambda[A] = F[G[A]] })#lambda] {
       def map[A, B](f: A => B): F[G[A]] => F[G[B]] = self.contramap(g.contramap(f))
     }
 
   /**
    * Compose contravariant and covariant functors.
    */
-  final def compose[G[+_]](implicit g: Covariant[G]): Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] =
-    new Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] {
+  final def compose[G[+_]](implicit g: Covariant[G]): Contravariant[({ type lambda[A] = F[G[A]] })#lambda] =
+    new Contravariant[({ type lambda[A] = F[G[A]] })#lambda] {
       def contramap[A, B](f: B => A): F[G[A]] => F[G[B]] = self.contramap(g.map(f))
     }
 }

--- a/core/shared/src/main/scala/zio/prelude/Covariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Covariant.scala
@@ -16,7 +16,7 @@
 
 package zio.prelude
 
-trait CovariantSubset[F[+_], Subset[_]] {
+trait CovariantSubset[F[_], Subset[_]] {
   def mapSubset[A, B: Subset](f: A => B): F[A] => F[B]
 }
 
@@ -42,7 +42,7 @@ trait CovariantSubset[F[+_], Subset[_]] {
  * `String => Int` that returns the length of a string, then we can construct
  * a `List[Int]` with the length of each string.
  */
-trait Covariant[F[+_]] extends CovariantSubset[F, AnyType] with Invariant[F] { self =>
+trait Covariant[F[_]] extends CovariantSubset[F, AnyType] with Invariant[F] { self =>
   final def mapSubset[A, B: AnyType](f: A => B): F[A] => F[B] = map(f)
 
   /**
@@ -60,16 +60,16 @@ trait Covariant[F[+_]] extends CovariantSubset[F, AnyType] with Invariant[F] { s
   /**
    * Compose two covariant functors.
    */
-  final def compose[G[+_]](implicit g: Covariant[G]): Covariant[({ type lambda[+A] = F[G[A]] })#lambda] =
-    new Covariant[({ type lambda[+A] = F[G[A]] })#lambda] {
+  final def compose[G[+_]](implicit g: Covariant[G]): Covariant[({ type lambda[A] = F[G[A]] })#lambda] =
+    new Covariant[({ type lambda[A] = F[G[A]] })#lambda] {
       def map[A, B](f: A => B): F[G[A]] => F[G[B]] = self.map(g.map(f))
     }
 
   /**
    * Compose covariant and contravariant functors.
    */
-  final def compose[G[-_]](implicit g: Contravariant[G]): Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] =
-    new Contravariant[({ type lambda[-A] = F[G[A]] })#lambda] {
+  final def compose[G[-_]](implicit g: Contravariant[G]): Contravariant[({ type lambda[A] = F[G[A]] })#lambda] =
+    new Contravariant[({ type lambda[A] = F[G[A]] })#lambda] {
       def contramap[A, B](f: B => A): F[G[A]] => F[G[B]] = self.map(g.contramap(f))
     }
 }

--- a/core/shared/src/main/scala/zio/prelude/Covariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Covariant.scala
@@ -21,7 +21,7 @@ trait CovariantSubset[F[_], Subset[_]] {
 }
 
 /**
- * `Covariant[F]` provides implicit evidence that `F[+_]` is a covariant
+ * `Covariant[F]` provides implicit evidence that `F[_]` is a covariant
  * endofunctor in the category of Scala objects.
  *
  * Covariant instances of type `F[A]` "produce" values of type `A` in some
@@ -79,7 +79,7 @@ object Covariant {
   /**
    * Summons an implicit `Covariant[F]`.
    */
-  def apply[F[+_]](implicit covariant: Covariant[F]): Covariant[F] =
+  def apply[F[_]](implicit covariant: Covariant[F]): Covariant[F] =
     covariant
 
 }
@@ -89,7 +89,7 @@ trait CovariantSyntax {
   /**
    * Provides infix syntax for mapping over covariant values.
    */
-  implicit class CovariantOps[F[+_], A](private val self: F[A]) {
+  implicit class CovariantOps[F[_], A](private val self: F[A]) {
     def as[B](b: => B)(implicit F: Covariant[F]): F[B] = map(_ => b)
 
     def map[B](f: A => B)(implicit F: Covariant[F]): F[B] =

--- a/core/shared/src/main/scala/zio/prelude/Debug.scala
+++ b/core/shared/src/main/scala/zio/prelude/Debug.scala
@@ -268,7 +268,7 @@ object Debug extends DebugVersionSpecific {
    * Derives a `Debug[Array[A]]` given a `Debug[A]`.
    */
   implicit def ArrayDebug[A: Debug]: Debug[Array[A]] =
-    array => Repr.VConstructor(List("scala"), "Array", array.map(_.debug).toList)
+    array => Repr.VConstructor(List("scala"), "Array", genericArrayOps(array).map(_.debug).toList)
 
   /**
    * The `Debug` instance for `BigDecimal`.

--- a/core/shared/src/main/scala/zio/prelude/ForEach.scala
+++ b/core/shared/src/main/scala/zio/prelude/ForEach.scala
@@ -205,7 +205,7 @@ trait ForEach[F[+_]] extends Covariant[F] { self =>
     }
 
   def groupByNonEmptyM[G[+_]: IdentityBoth: Covariant, V, K](fa: F[V])(f: V => G[K]): G[Map[K, NonEmptyChunk[V]]] =
-    foldLeft(fa)(Map.empty[K, NonEmptyChunk[V]].succeed) { (m, v) =>
+    foldLeft(fa)(Map.empty[K, NonEmptyChunk[V]].succeed[G]) { (m, v) =>
       val k = f(v)
       AssociativeBoth.mapN(m, k) { (m, k) =>
         m.get(k) match {

--- a/core/shared/src/main/scala/zio/prelude/IdentityBoth.scala
+++ b/core/shared/src/main/scala/zio/prelude/IdentityBoth.scala
@@ -67,7 +67,7 @@ object IdentityBoth {
 trait IdentityBothSyntax {
 
   implicit class IdentityBothAnyOps[A](a: => A) {
-    def succeed[F[+_]](implicit both: IdentityBoth[F], covariant: Covariant[F]): F[A] =
+    def succeed[F[_]](implicit both: IdentityBoth[F], covariant: Covariant[F]): F[A] =
       both.any.map(_ => a)
   }
 

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -131,7 +131,7 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
     new ForEach[({ type lambda[+a] = Either[E, a] })#lambda] with Bicovariant[Either] {
 
       def forEach[G[+_]: IdentityBoth: Covariant, A, B](either: Either[E, A])(f: A => G[B]): G[Either[E, B]] =
-        either.fold(Left(_).succeed, f(_).map(Right(_)))
+        either.fold(Left(_).succeed[G], f(_).map(Right(_)))
 
       override def bimap[A, B, AA, BB](f: A => AA, g: B => BB): Either[A, B] => Either[AA, BB] = {
         case Right(a) => Right(g(a))
@@ -758,7 +758,7 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
   implicit val OptionalForEach: ForEach[Optional] =
     new ForEach[Optional] {
       def forEach[G[+_]: IdentityBoth: Covariant, A, B](option: Optional[A])(f: A => G[B]): G[Optional[B]] =
-        option.fold[G[Optional[B]]](Optional.Absent.succeed)(a => f(a).map(Optional.Present(_)))
+        option.fold[G[Optional[B]]](Optional.Absent.succeed[G])(a => f(a).map(Optional.Present(_)))
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/Invariant.scala
+++ b/core/shared/src/main/scala/zio/prelude/Invariant.scala
@@ -115,7 +115,7 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
   implicit def ConstForEach[A]: ForEach[({ type ConstA[+B] = Const[A, B] })#ConstA] =
     new ForEach[({ type ConstA[+B] = Const[A, B] })#ConstA] {
       def forEach[G[+_]: IdentityBoth: Covariant, B, C](fa: Const[A, B])(f: B => G[C]): G[Const[A, C]] =
-        Const.wrap(Const.unwrap(fa)).succeed
+        Const.wrap(Const.unwrap(fa)).succeed[G]
     }
 
   /**
@@ -749,7 +749,7 @@ object Invariant extends LowPriorityInvariantImplicits with InvariantVersionSpec
   implicit val OptionForEach: ForEach[Option] =
     new ForEach[Option] {
       def forEach[G[+_]: IdentityBoth: Covariant, A, B](option: Option[A])(f: A => G[B]): G[Option[B]] =
-        option.fold[G[Option[B]]](Option.empty.succeed)(a => f(a).map(Some(_)))
+        option.fold[G[Option[B]]](Option.empty.succeed[G])(a => f(a).map(Some(_)))
     }
 
   /**

--- a/core/shared/src/main/scala/zio/prelude/ParSeq.scala
+++ b/core/shared/src/main/scala/zio/prelude/ParSeq.scala
@@ -131,7 +131,7 @@ sealed trait ParSeq[+Z <: Unit, +A] { self =>
    * events.
    */
   final def forEach[F[+_]: IdentityBoth: Covariant, B](f: A => F[B]): F[ParSeq[Z, B]] =
-    fold[F[ParSeq[Unit, B]]](ParSeq.empty.succeed, a => f(a).map(ParSeq.single))(
+    fold[F[ParSeq[Unit, B]]](ParSeq.empty.succeed[F], a => f(a).map(ParSeq.single))(
       _.zipWith(_)(_ ++ _),
       _.zipWith(_)(_ && _)
     ).asInstanceOf[F[ParSeq[Z, B]]]

--- a/core/shared/src/main/scala/zio/prelude/ZSet.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZSet.scala
@@ -130,7 +130,7 @@ final class ZSet[+A, +B] private (private val map: HashMap[A @uncheckedVariance,
       }
 
     map
-      .foldLeft[G[HashMap[C, Natural]]](HashMap.empty.succeed) { case (g, (a, b)) => loop(g, a, ev(b)) }
+      .foldLeft[G[HashMap[C, Natural]]](HashMap.empty[C, Natural].succeed[G]) { case (g, (a, b)) => loop(g, a, ev(b)) }
       .map(new ZSet(_))
   }
 


### PR DESCRIPTION
Hey there,

I'm proposing to remove some variance annotations on the `Covariant` and `Contravariant` type classes. The downside to having these variance annotations is that you can't provide typeclass instances for types that for whatever reason can't be made covariant. This can be the case for types in a library that you don't control or for Java types.
I recently ran into this problem when I tried to implement a `Covariant` instance for the `TemporalQuery` type in `java.time`. Since I cannot discern any benefit of these annotations, I propose to drop them altogether.
Note that this doesn't preclude having a `F[+_]` type parameter on some _methods_ that really do require this thing to be covariant. But it doesn't need to be on the typeclass itself. 