### PR TITLE
NonEmptySortedSet#toSet returns SortedSet

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/NonEmptySortedSet.scala
+++ b/core/shared/src/main/scala/zio/prelude/NonEmptySortedSet.scala
@@ -219,7 +219,7 @@ object NonEmptySortedSet {
    * Provides an implicit conversion from `NonEmptySortedSet` to the `Set`
    * for interoperability with Scala's collection library.
    */
-  implicit def toSet[A](nonEmptySet: NonEmptySortedSet[A]): Set[A] =
+  implicit def toSet[A](nonEmptySet: NonEmptySortedSet[A]): SortedSet[A] =
     nonEmptySet.toSet
 
   private val NonEmptySortedSetSeed: Int = 1247120194


### PR DESCRIPTION
Adjust return type of NonEmptySortedSet#toSet to return SortedSet.

More specific return type helps with utilising more SortedSet specific operations without explicit unwrapping.