### PR TITLE
Add ZValidation.validateAll_

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/ZValidation.scala
+++ b/core/shared/src/main/scala/zio/prelude/ZValidation.scala
@@ -509,6 +509,13 @@ object ZValidation extends LowPriorityValidationImplicits {
     validateAll[Iterable, W, E, A](validations).map(_.toSet)
 
   /**
+   * Combine a set of `ZValidation` values into a single `ZValidation` that
+   * succeeds if they all succeed, or else fails with all of their errors.
+   */
+  def validateAll_[F[+_]: ForEach, W, E](validations: F[ZValidation[W, E, Any]]): ZValidation[W, E, Unit] =
+    ForEach[F].forEach_(validations)(identity)
+
+  /**
    * Constructs a `ZValidation` that fails with the specified error.
    */
   def fail[E](error: E): Validation[E, Nothing] =


### PR DESCRIPTION
It seems that some instances of ForEach (Map, Iterable,...) overrides `forEach_` method to avoid construction of the result collection. It would be nice to have access to these optimized implementations via `validateAll_` method.