### PR TITLE
fix reversed if condition in divisibleBy

### DIFF
--- a/macros/shared/src/main/scala/zio/prelude/Assertion.scala
+++ b/macros/shared/src/main/scala/zio/prelude/Assertion.scala
@@ -148,7 +148,7 @@ object Assertion {
         if (result) Right(())
         else Left(AssertionError.Failure(s"divisibleBy($n)"))
       } else {
-        if (!result) Left(AssertionError.Failure(s"notDivisibleBy($n)"))
+        if (result) Left(AssertionError.Failure(s"notDivisibleBy($n)"))
         else Right(())
       }
     }


### PR DESCRIPTION
The if condition in the negated path of `DivisibleBy` needs to be reversed. We should not raise `AssertionError` if `result` is false.

For example, 5 should be valid for`!divisible(2)`, so the `result` is `false`, `!negated` is `false`, then we should go to `Right()` instead of `AssertionError`.