### PR TITLE
Use def instead of val for Optional's isEmpty/isDefined/nonEmpty

### DIFF
--- a/core/shared/src/main/scala/zio/prelude/data/Optional.scala
+++ b/core/shared/src/main/scala/zio/prelude/data/Optional.scala
@@ -15,9 +15,9 @@ import scala.language.implicitConversions
  * conversion defined from `A`` to `Optional[A]`, and from `Option[A]`` to `Optional[A]`.
  */
 sealed trait Optional[+A] extends IterableOnceCompat[A] { self =>
-  val isEmpty: Boolean
-  val isDefined: Boolean
-  val nonEmpty: Boolean
+  def isEmpty: Boolean
+  def isDefined: Boolean
+  def nonEmpty: Boolean
 
   /**
    * Converts this optional value to standard [[scala.Option]]
@@ -164,18 +164,18 @@ object Optional {
    *   type of the value
    */
   final case class Present[+A](get: A) extends Optional[A] {
-    override val isEmpty: Boolean   = false
-    override val isDefined: Boolean = true
-    override val nonEmpty: Boolean  = true
+    override def isEmpty: Boolean   = false
+    override def isDefined: Boolean = true
+    override def nonEmpty: Boolean  = true
   }
 
   /**
    * Optional value that is absent
    */
   case object Absent extends Optional[Nothing] {
-    override val isEmpty: Boolean   = true
-    override val isDefined: Boolean = false
-    override val nonEmpty: Boolean  = false
+    override def isEmpty: Boolean   = true
+    override def isDefined: Boolean = false
+    override def nonEmpty: Boolean  = false
   }
 
   implicit def AllValuesAreNullable[A](value: A): Optional[A]     = Present(value)


### PR DESCRIPTION
## Summary
- `Optional#isEmpty`/`isDefined`/`nonEmpty` (and their `Present`/`Absent` overrides) are now `def`s instead of `val`s, so no per-instance field is allocated to hold a value that's a compile-time constant per case.

## Test plan
- [x] `coreJVM/Test/compile`
- [x] `coreTestsJVM/test` (615 tests passed)