### PR TITLE
Fix docs website build in CI

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -284,7 +284,7 @@ lazy val docs = project
   .settings(
     scalacOptions -= "-Yno-imports",
     scalacOptions -= "-Xfatal-warnings",
-    scalaVersion                               := Scala213,
+    scalaVersion                               := "2.13.18",
     projectName                                := "ZIO Prelude",
     mainModuleName                             := (core.jvm / moduleName).value,
     projectStage                               := ProjectStage.ProductionReady,

--- a/build.sbt
+++ b/build.sbt
@@ -284,8 +284,7 @@ lazy val docs = project
   .settings(
     scalacOptions -= "-Yno-imports",
     scalacOptions -= "-Xfatal-warnings",
-    scalaVersion                               := "2.13.18",
-    crossScalaVersions                         := Seq("2.13.18"),
+    scalaVersion                               := Scala213,
     projectName                                := "ZIO Prelude",
     mainModuleName                             := (core.jvm / moduleName).value,
     projectStage                               := ProjectStage.ProductionReady,

--- a/build.sbt
+++ b/build.sbt
@@ -285,6 +285,7 @@ lazy val docs = project
     scalacOptions -= "-Yno-imports",
     scalacOptions -= "-Xfatal-warnings",
     scalaVersion                               := "2.13.18",
+    crossScalaVersions                         := Seq("2.13.18"),
     projectName                                := "ZIO Prelude",
     mainModuleName                             := (core.jvm / moduleName).value,
     projectStage                               := ProjectStage.ProductionReady,

--- a/build.sbt
+++ b/build.sbt
@@ -284,7 +284,8 @@ lazy val docs = project
   .settings(
     scalacOptions -= "-Yno-imports",
     scalacOptions -= "-Xfatal-warnings",
-    scalaVersion                               := Scala213,
+    scalaVersion                               := "2.13.18",
+    crossScalaVersions                         := Seq("2.13.18"),
     projectName                                := "ZIO Prelude",
     mainModuleName                             := (core.jvm / moduleName).value,
     projectStage                               := ProjectStage.ProductionReady,

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -12,7 +12,7 @@ import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport.*
 
 object BuildHelper {
   val Scala212: String = "2.12.21"
-  val Scala213: String = "2.13.16"
+  val Scala213: String = "2.13.18"
   val Scala3: String   = "3.3.7"
 
   private val stdOptions = Seq(

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -12,7 +12,7 @@ import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport.*
 
 object BuildHelper {
   val Scala212: String = "2.12.21"
-  val Scala213: String = "2.13.18"
+  val Scala213: String = "2.13.16"
   val Scala3: String   = "3.3.7"
 
   private val stdOptions = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,4 @@ addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                   
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.5.6")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.4.8")
-addSbtPlugin("dev.zio"                           % "zio-sbt-website"               % "0.4.0-alpha.35")
+addSbtPlugin("dev.zio"                           % "zio-sbt-website"               % "0.5.1")


### PR DESCRIPTION
## Summary
- The `publishLocal` CI job's website build step (`docs/buildWebsite`) has been failing on `series/2.x` and on unrelated PRs (e.g. #1674): the Docusaurus 2.1.0 scaffold bundled by `zio-sbt-website` 0.4.0-alpha.35 resolves a newer webpack release whose `ProgressPlugin` rejects the legacy options it's initialized with.
- Bump `zio-sbt-website` to 0.5.1, the earliest release that pins webpack to a compatible version (zio/zio-sbt#652).
- That version requires the Scala 2.13 compiler used to build the `docs` project to be 2.13.18+ (SIP-51 forward binary compatibility check), so scope a `scalaVersion` bump to just the `docs` project. I also tried bumping the shared `Scala213` constant in `BuildHelper.scala` instead (simpler, no special-casing), but reverted it: CI runs with `-Xfatal-warnings` (GitHub Actions sets `CI=true`), and Scala 2.13.18 emits a few new compiler warnings that don't exist under 2.13.16, which broke `lint`/`compile`/`testJvms`/`testPlatforms` across the whole build. `docs` is the only project that already disables `-Xfatal-warnings`, so scoping the version bump to it avoids that blast radius entirely — it doesn't touch the library's cross-build versions, published artifacts, or MiMa baseline.
- Also pin `docs`'s `crossScalaVersions` to `Seq("2.13.18")`. Without it, sbt's `+`/`++` cross-build commands (used by the `compile` and `test (2.13.*)` CI jobs) reset `scalaVersion` for every project on each cross-build pass, including `docs`'s project-scoped override, which reintroduced the SIP-51 mismatch on the 2.13.16 pass.

## Test plan
- [x] Reproduced the original failure locally with `sbt docs/clean; sbt docs/buildWebsite` on unpatched `series/2.x`
- [x] `sbt docs/clean; sbt docs/buildWebsite` succeeds after the fix
- [x] `sbt check` (fmt check, compile, scalafix --check across all modules) passes
- [x] `sbt root213/test` (615 tests) passes
- [x] `sbt +rootJVM/Test/compile` and `sbt ++2.13.16 root213/test` pass (mirrors the CI `compile`/`test` jobs' cross-build commands, which caught the `crossScalaVersions` gap)
- [x] `sbt +publishLocal` passes
- [x] All CI checks green on this PR