### PR TITLE
Refresh Mergify config: fix invalid team assignee

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,10 +1,10 @@
 pull_request_rules:
-  - name: assign and label scala-steward's PRs
+  - name: request review and label scala-steward's PRs
     conditions:
       - author=scala-steward
     actions:
-      assign:
-        users: ["@zio/zio-prelude"]
+      request_reviews:
+        teams: ["zio-prelude"]
       label:
         add: ["type: dependencies"]
   - name: label scala-steward's breaking PRs


### PR DESCRIPTION
This refreshes the long-dormant `.mergify.yml` so that it is correct and ready to act once Mergify is re-enabled on the repo.

### What changed

The first rule tried to `assign` Scala Stewardʼs PRs to the team `@zio/zio-prelude`:

```yaml
assign:
  users: ["@zio/zio-prelude"]
```

GitHub assignees must be **individual users** — a team handle can never be an assignee, so this action has been a silent no-op/error for years. This replaces it with the supported way to route PRs to a team:

```yaml
request_reviews:
  teams: ["zio-prelude"]
```

which restores the original intent of surfacing Scala Stewardʼs PRs to the `zio-prelude` team.

The `merge` ruleʼs conditions (`status-success=ci` and `status-success=license/cla`) still match the current CI — both checks exist on todayʼs PRs — so no other changes are needed. The classic `pull_request_rules` + `merge: squash` format is not deprecated in current Mergify.

### Important: this alone does not re-enable Mergify

Mergify last auto-merged here in 2021 (e.g. #450, #550 were merged by `mergify[bot]`); since then Scala Stewardʼs update PRs have been merged by hand. That is because **Mergify only acts on this repo while the Mergify GitHub App is installed/authorized on the `zio` org** — an org-admin action that a PR cannot perform. To fully bring it back, a `zio` org admin needs to (re)install/authorize the Mergify app (github.com/apps/mergify or dashboard.mergify.com). This PR just makes sure the config is clean and correct for when that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)